### PR TITLE
feat(core): support streams in 'berty client'

### DIFF
--- a/core/client/jsonclient/client.go
+++ b/core/client/jsonclient/client.go
@@ -19,7 +19,7 @@ func registerUnary(name string, endpoint unaryCallback) {
 	unaryMap[name] = endpoint
 }
 
-func Call(ctx context.Context, c *client.Client, endpoint string, jsonInput []byte) (interface{}, error) {
+func CallUnary(ctx context.Context, c *client.Client, endpoint string, jsonInput []byte) (interface{}, error) {
 	if jsonInput == nil {
 		jsonInput = []byte("{}")
 	}

--- a/core/client/jsonclient/streams.go
+++ b/core/client/jsonclient/streams.go
@@ -1,0 +1,65 @@
+package jsonclient
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/berty/berty/core/client"
+)
+
+type GenericServerStreamClient interface {
+	Recv() (interface{}, error)
+	// grpc.ClientStream
+}
+
+type genericStreamEntry struct {
+	data interface{}
+	err  error
+}
+
+type genericServerStreamProxy struct {
+	queue chan genericStreamEntry
+}
+
+func (p *genericServerStreamProxy) Recv() (interface{}, error) {
+	entry := <-p.queue
+	return entry.data, entry.err
+}
+
+func newGenericServerStreamProxy() *genericServerStreamProxy {
+	return &genericServerStreamProxy{
+		queue: make(chan genericStreamEntry, 100),
+	}
+}
+
+type serverStreamCallback func(*client.Client, context.Context, []byte) (GenericServerStreamClient, error)
+
+var serverStreamMap map[string]serverStreamCallback
+
+func registerServerStream(name string, endpoint serverStreamCallback) {
+	if serverStreamMap == nil {
+		serverStreamMap = make(map[string]serverStreamCallback)
+	}
+	serverStreamMap[name] = endpoint
+}
+
+func CallServerStream(ctx context.Context, c *client.Client, endpoint string, jsonInput []byte) (GenericServerStreamClient, error) {
+	if jsonInput == nil {
+		jsonInput = []byte("{}")
+	}
+	for name, handler := range serverStreamMap {
+		if strings.ToLower(name) == strings.ToLower(endpoint) {
+			return handler(c, ctx, jsonInput)
+		}
+	}
+	return nil, fmt.Errorf("unknown endpoint: %q", endpoint)
+}
+
+func ServerStreams() []string {
+	names := []string{}
+	for name := range serverStreamMap {
+		names = append(names, name)
+	}
+	return names
+}

--- a/core/client/jsonclient/{{.File.Package}}.{{.Service.Name|lower}}.gen.go.tmpl
+++ b/core/client/jsonclient/{{.File.Package}}.{{.Service.Name|lower}}.gen.go.tmpl
@@ -25,8 +25,9 @@ import (
      {{- range $method := .Method }}
      {{- if and (not .ClientStreaming) (not .ServerStreaming)}}
      registerUnary("{{$file.Package}}.{{$method.Name}}", {{$file.Package|splitList "."|last|title}}{{$method.Name}})
-     {{- else}}
-     // FIXME: support "{{$file.Package}}.{{$method.Name}}" streaming
+     {{- end}}
+     {{- if and (not .ClientStreaming) (.ServerStreaming)}}
+     registerServerStream("{{$file.Package}}.{{$method.Name}}", {{$file.Package|splitList "."|last|title}}{{$method.Name}})
      {{- end}}
      {{- end}}
   }
@@ -45,6 +46,39 @@ import (
                   return nil, err
             }
             return client.{{$file.Package|splitList "."|last|title}}().{{$method.Name}}(ctx, &typedInput)
+      }
+    {{- end}}
+    {{if and (not .ClientStreaming) (.ServerStreaming)}}
+      func {{$file.Package|splitList "."|last|title}}{{$method.Name}}(client *client.Client, ctx context.Context, jsonInput []byte) (GenericServerStreamClient, error) {
+            zap.L().Debug("client call",
+                  zap.String("service", "{{$svc.Name}}"),
+                  zap.String("method", "{{$method.Name}}"),
+                  zap.String("input", string(jsonInput)),
+            )
+            {{ $in := $method.InputType | getMessageType $file }}
+            var typedInput {{$in.GoType "."}}
+            if err := json.Unmarshal(jsonInput, &typedInput); err != nil {
+                  return nil, err
+            }
+            stream, err := client.{{$file.Package|splitList "."|last|title}}().{{$method.Name}}(ctx, &typedInput)
+            if err != nil {
+                  return nil, err
+            }
+
+            // start a stream proxy
+            streamProxy := newGenericServerStreamProxy()
+            go func() {
+                    for {
+                            data, err := stream.Recv()
+                            streamProxy.queue <- genericStreamEntry{data: data, err: err}
+                            if err != nil {
+                                    break
+                            }
+                    }
+                    // FIXME: wait for queue to be empty, then close chan
+            }()
+
+            return streamProxy, nil
       }
     {{- end}}
   {{- end}}

--- a/core/cmd/berty/client.go
+++ b/core/cmd/berty/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -18,6 +19,8 @@ type clientOptions struct {
 	endpoint    string
 	nodeAddress string
 	args        []string
+	unarize     bool
+	noIndent    bool
 }
 
 func newClientCommand() *cobra.Command {
@@ -29,7 +32,8 @@ func newClientCommand() *cobra.Command {
 	for _, endpoint := range jsonclient.Unaries() {
 		endpointCopy := endpoint
 		cmd.AddCommand(&cobra.Command{
-			Use: fmt.Sprintf("%s [input in json]", endpoint),
+			Use:   fmt.Sprintf("%s [input in json]", endpoint),
+			Short: "unary",
 			RunE: func(cmd *cobra.Command, args []string) error {
 				opts.endpoint = endpointCopy
 				opts.args = args
@@ -38,11 +42,80 @@ func newClientCommand() *cobra.Command {
 		})
 	}
 
+	for _, endpoint := range jsonclient.ServerStreams() {
+		endpointCopy := endpoint
+		cmd.AddCommand(&cobra.Command{
+			Use:   fmt.Sprintf("%s [input in json]", endpoint),
+			Short: "stream",
+			RunE: func(cmd *cobra.Command, args []string) error {
+				opts.endpoint = endpointCopy
+				opts.args = args
+				return clientServerStream(opts)
+			},
+		})
+	}
+
 	// fixme handle streaming
 
-	flags := cmd.Flags()
-	flags.StringVarP(&opts.nodeAddress, "node-address", "", "127.0.0.1:1337", "node gRPC address")
+	cmd.PersistentFlags().StringVarP(&opts.nodeAddress, "node-address", "", "127.0.0.1:1337", "node gRPC address")
+	cmd.PersistentFlags().BoolVar(&opts.unarize, "unarize", false, "return only one json at the end of the stream (streams only)")
+	cmd.PersistentFlags().BoolVar(&opts.noIndent, "no-indent", false, "do not indent json")
 	return cmd
+}
+
+func clientServerStream(opts *clientOptions) error {
+	ctx := context.Background()
+
+	zap.L().Debug("dialing node", zap.String("addr", opts.nodeAddress), zap.String("protocol", "gRPC"))
+	conn, err := grpc.Dial(opts.nodeAddress, grpc.WithInsecure())
+	if err != nil {
+		return errors.Wrap(err, "failed to dial node")
+	}
+
+	input := []byte("{}")
+	if len(opts.args) > 0 {
+		input = []byte(opts.args[0])
+	}
+
+	client := client.New(conn)
+	stream, err := jsonclient.CallServerStream(ctx, client, opts.endpoint, input)
+	if err != nil {
+		return errors.Wrap(err, "failed calling endpoint")
+	}
+
+	if opts.unarize {
+		entries := make([]interface{}, 0)
+		for {
+			entry, err := stream.Recv()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				return err
+			}
+			entries = append(entries, entry)
+		}
+		jsonPrint(entries, opts)
+	} else {
+		fmt.Println("[")
+		index := 0
+		for {
+			entry, err := stream.Recv()
+			if err == io.EOF {
+				break
+			}
+			if err != nil {
+				return err
+			}
+			if index > 0 {
+				fmt.Print(",")
+			}
+			index++
+			jsonPrint(entry, opts)
+		}
+		fmt.Println("]")
+	}
+	return nil
 }
 
 func clientUnary(opts *clientOptions) error {
@@ -60,12 +133,21 @@ func clientUnary(opts *clientOptions) error {
 	}
 
 	client := client.New(conn)
-	ret, err := jsonclient.Call(ctx, client, opts.endpoint, input)
+	ret, err := jsonclient.CallUnary(ctx, client, opts.endpoint, input)
 	if err != nil {
 		return errors.Wrap(err, "failed calling endpoint")
 	}
 
-	out, _ := json.MarshalIndent(ret, "", "  ")
-	fmt.Println(string(out))
+	jsonPrint(ret, opts)
 	return nil
+}
+
+func jsonPrint(data interface{}, opts *clientOptions) {
+	var out []byte
+	if opts.noIndent {
+		out, _ = json.Marshal(data)
+	} else {
+		out, _ = json.MarshalIndent(data, "", "  ")
+	}
+	fmt.Println(string(out))
 }


### PR DESCRIPTION
Examples:

```console
$ berty client berty.node.ContactList
[
{
  "id": "928e43ea-cbb4-49d7-a9fe-8c8aef56abe7",
  "created_at": "2018-07-30T11:54:16.488685835Z",
  "updated_at": "2018-07-30T11:54:16.487241227Z",
  "status": 42,
  "devices": [
    {
      "id": "928e43ea-cbb4-49d7-a9fe-8c8aef56abe7",
      "created_at": "2018-07-30T11:54:16.488001787Z",
      "updated_at": "2018-07-30T11:54:16.488991954Z",
      "name": "bart",
      "contact_id": "928e43ea-cbb4-49d7-a9fe-8c8aef56abe7"
    }
  ],
  "display_name": "bart"
}
,{
  "id": "test",
  "created_at": "2018-07-31T17:10:41.478131952Z",
  "updated_at": "2018-07-31T17:10:41.477692715Z",
  "status": 3,
  "display_name": "test"
}
]
```

here, the JSON is ugly because it prints each stream entries as they arrive (useful for or perpetual streams)

---

you can use `--unarize` to wait for the stream to complete and return a nice json:

```console
$ berty client berty.node.ContactList   --unarize
[
  {
    "id": "928e43ea-cbb4-49d7-a9fe-8c8aef56abe7",
    "created_at": "2018-07-30T11:54:16.488685835Z",
    "updated_at": "2018-07-30T11:54:16.487241227Z",
    "status": 42,
    "devices": [
      {
        "id": "928e43ea-cbb4-49d7-a9fe-8c8aef56abe7",
        "created_at": "2018-07-30T11:54:16.488001787Z",
        "updated_at": "2018-07-30T11:54:16.488991954Z",
        "name": "bart",
        "contact_id": "928e43ea-cbb4-49d7-a9fe-8c8aef56abe7"
      }
    ],
    "display_name": "bart"
  },
  {
    "id": "test",
    "created_at": "2018-07-31T17:10:41.478131952Z",
    "updated_at": "2018-07-31T17:10:41.477692715Z",
    "status": 3,
    "display_name": "test"
  }
]
```

---

I also added a `--no-indent` option which works for both `--unarize` and normal modes

```console
$ berty client berty.node.ContactList   --unarize --no-indent
[{"id":"928e43ea-cbb4-49d7-a9fe-8c8aef56abe7","created_at":"2018-07-30T11:54:16.488685835Z","updated_at":"2018-07-30T11:54:16.487241227Z","status":42,"devices":[{"id":"928e43ea-cbb4-49d7-a9fe-8c8aef56abe7","created_at":"2018-07-30T11:54:16.488001787Z","updated_at":"2018-07-30T11:54:16.488991954Z","name":"bart","contact_id":"928e43ea-cbb4-49d7-a9fe-8c8aef56abe7"}],"display_name":"bart"},{"id":"test","created_at":"2018-07-31T17:10:41.478131952Z","updated_at":"2018-07-31T17:10:41.477692715Z","status":3,"display_name":"test"}]
```

Fixes #64