### PR TITLE
feat(relay): Add real relay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # ag
 .agignore
+.env
 
 # OSX
 .DS_Store

--- a/rancher/.env.example
+++ b/rancher/.env.example
@@ -1,0 +1,8 @@
+# source me !
+
+# Set the url that Rancher is on
+export RANCHER_URL=http://server_ip:8080/
+# Set the access key, i.e. username
+export RANCHER_ACCESS_KEY=<username_of_environment_api_key>
+# Set the secret key, i.e. password
+export RANCHER_SECRET_KEY=<password_of_environment_api_key>

--- a/rancher/docker-compose.yml
+++ b/rancher/docker-compose.yml
@@ -1,0 +1,8 @@
+version: '2'
+services:
+  berty:
+    image: ${IMAGE}
+    ports:
+      - "4002:4002"
+    command: "daemon --log-level-p2p=info --log-level=info --mdns=false --hop=true --bind-p2p='/ip4/0.0.0.0/tcp/4002'"
+

--- a/rancher/rancher-compose.yml
+++ b/rancher/rancher-compose.yml
@@ -1,0 +1,4 @@
+version: '2'
+services:
+  berty:
+    scale: 1


### PR DESCRIPTION
## NODE RELAY

### Update the node relay
First you have to update the docker image
```
docker build -t {image} .
docker push {image}
```

Then upgrade with:
```
rancher-compose up (-d to not block and log) --force-upgrade --pull
```

### Connect to a berty node relay :
```
berty daemon --log-level-p2p=debug --log-level=debug --bootstrap="/ip4/<ip_server>/tcp/<p2p_port>/ipfs/<p2p_id>"
```
the default port is 4002, you can change the default port inside the docker compose

You can find the node id (p2p_id) in the log of the started node, something like:
```
berty-berty-1 | 2018-08-24T14:54:43.714643401Z 2018-08-24T14:54:43.714Z	INFO	p2p/p2p.go:134	Host	{"ID": "QmUxEsVNNvJKZQrV4RaozUFT7JZebZqAmLc5CLEGsAC5Np", "Addrs": ["/p2p-circuit/ipfs/QmUxEsVNNvJKZQrV4RaozUFT7JZebZqAmLc5CLEGsAC5Np", "/ip4/127.0.0.1/tcp/4002", "/ip4/10.42.183.81/tcp/4002"]}

Where `ID` is the p2p_id
```

since ID is currently not static, you need to update the bootstrap addr every time the remote node restart.