### PR TITLE
feat(core): refactor logger (#184)

### DIFF
--- a/core/pkg/filteredzap/logger.go
+++ b/core/pkg/filteredzap/logger.go
@@ -1,0 +1,37 @@
+package filteredzap
+
+// based on https://github.com/tchap/zapext/blob/a5d992351555de581c6d36e2829287a6d1c2f16a/middleware/core_filtering.go
+
+import (
+	"go.uber.org/zap/zapcore"
+)
+
+// FilterFunc is the filter function that is called to check
+// whether the given entry together with the associated fields
+// is to be written to a core or not.
+type FilterFunc func(zapcore.Entry, []zapcore.Field) bool
+
+type filteringCore struct {
+	zapcore.Core
+	filter FilterFunc
+}
+
+// NewFilteringCore returns a core middleware that uses the given filter function
+// to decide whether to actually call Write on the next core in the chain.
+func NewFilteringCore(next zapcore.Core, filter FilterFunc) zapcore.Core {
+	return &filteringCore{next, filter}
+}
+
+func (core *filteringCore) Check(entry zapcore.Entry, checked *zapcore.CheckedEntry) *zapcore.CheckedEntry {
+	if core.Enabled(entry.Level) {
+		return checked.AddCore(entry, core)
+	}
+	return checked
+}
+
+func (core *filteringCore) Write(entry zapcore.Entry, fields []zapcore.Field) error {
+	if !core.filter(entry, fields) {
+		return nil
+	}
+	return core.Core.Write(entry, fields)
+}

--- a/core/sql/gorm.go
+++ b/core/sql/gorm.go
@@ -3,6 +3,7 @@ package sql
 import (
 	"github.com/go-gormigrate/gormigrate"
 	"github.com/jinzhu/gorm"
+	"go.uber.org/zap"
 
 	"berty.tech/core/api/p2p"
 	"berty.tech/core/entity"
@@ -12,7 +13,7 @@ import (
 func Init(db *gorm.DB) (*gorm.DB, error) {
 	db = db.Set("gorm:auto_preload", true)
 	db = db.Set("gorm:association_autoupdate", false)
-	db.SetLogger(&zapLogger{})
+	db.SetLogger(&zapLogger{logger: zap.L().Named("vendor.gorm")})
 	db.SingularTable(true)
 	db.BlockGlobalUpdate(true)
 	db.LogMode(true)

--- a/core/sql/zaplogger.go
+++ b/core/sql/zaplogger.go
@@ -6,7 +6,9 @@ import (
 	"go.uber.org/zap"
 )
 
-type zapLogger struct{}
+type zapLogger struct {
+	logger *zap.Logger
+}
 
 func (l *zapLogger) Print(values ...interface{}) {
 	if len(values) < 2 {
@@ -15,7 +17,7 @@ func (l *zapLogger) Print(values ...interface{}) {
 
 	switch values[0] {
 	case "sql":
-		logger().Debug("gorm.debug.sql",
+		l.logger.Debug("gorm.debug.sql",
 			zap.String("query", values[3].(string)),
 			zap.Any("values", values[4]),
 			zap.Duration("duration", values[2].(time.Duration)),
@@ -23,7 +25,7 @@ func (l *zapLogger) Print(values ...interface{}) {
 			zap.String("source", values[1].(string)), // if AddCallerSkip(6) is well defined, we can safely remove this field
 		)
 	default:
-		logger().Debug("gorm.debug.other",
+		l.logger.Debug("gorm.debug.other",
 			zap.Any("values", values[2:]),
 			zap.String("source", values[1].(string)), // if AddCallerSkip(6) is well defined, we can safely remove this field
 		)


### PR DESCRIPTION
Usages:

```console
$ berty
  logs `name.match("core.*") && level >= info`
$ berty --log-level=debug
  logs `name.match("core.*") && level >= debug`
$ berty --log-namespaces="core.*,vendor.libp2p.*,gorm.*" --log-level=debug
  logs `name.match("core.*,vendor.libp2p.*,gorm.*") && level >= debug`
$ berty --log-namespaces="*" --log-level=debug
  logs everything
```

Fix #184