### PR TITLE
feat(core): make network driver hot reconfigurable (#194)

### DIFF
--- a/core/cmd/berty/daemon.go
+++ b/core/cmd/berty/daemon.go
@@ -148,6 +148,11 @@ func daemon(opts *daemonOptions) error {
 		if err != nil {
 			return err
 		}
+		defer func() {
+			if err := driver.Close(); err != nil {
+				logger().Warn("failed to close network driver", zap.Error(err))
+			}
+		}()
 	}
 
 	if driver == nil {
@@ -165,6 +170,11 @@ func daemon(opts *daemonOptions) error {
 	if err != nil {
 		return errors.Wrap(err, "failed to initialize node")
 	}
+	defer func() {
+		if err := n.Close(); err != nil {
+			logger().Warn("failed to close node", zap.Error(err))
+		}
+	}()
 
 	if opts.initOnly {
 		return nil

--- a/core/network/driver.go
+++ b/core/network/driver.go
@@ -15,4 +15,7 @@ type Driver interface {
 
 	// OnEnvelopeHandler sets the callback that will handle each new received envelope
 	OnEnvelopeHandler(func(context.Context, *p2p.Envelope) (*p2p.Void, error))
+
+	// Close cleanups things
+	Close() error
 }

--- a/core/network/p2p/p2p.go
+++ b/core/network/p2p/p2p.go
@@ -169,11 +169,15 @@ func (d *Driver) getPeerInfo(addr string) (*pstore.PeerInfo, error) {
 }
 
 func (d *Driver) Close() error {
+	// FIXME: save cache to speedup next connections
+
+	// close dht
 	err := d.dht.Close()
 	if err != nil {
 		return err
 	}
 
+	// close host
 	return d.host.Close()
 }
 

--- a/core/node/network.go
+++ b/core/node/network.go
@@ -1,9 +1,32 @@
 package node
 
-import "berty.tech/core/network"
+import (
+	"context"
+
+	"berty.tech/core/network"
+	"go.uber.org/zap"
+)
 
 func WithNetworkDriver(driver network.Driver) NewNodeOption {
 	return func(n *Node) {
 		n.networkDriver = driver
 	}
+}
+
+func (n *Node) UseNetworkDriver(driver network.Driver) error {
+	// FIXME: use a locking system
+
+	n.networkDriver = driver
+
+	// configure network
+	n.networkDriver.OnEnvelopeHandler(n.HandleEnvelope)
+	if err := n.networkDriver.Join(context.Background(), n.UserID()); err != nil {
+		logger().Warn("failed to join user channel",
+			zap.String("id", n.UserID()),
+			zap.Error(err),
+		)
+	}
+	// FIXME: subscribe to every owned device IDs
+	// FIXME: subscribe to every joined conversations
+	return nil
 }

--- a/core/node/node.go
+++ b/core/node/node.go
@@ -1,7 +1,6 @@
 package node
 
 import (
-	"context"
 	"encoding/base64"
 	"fmt"
 	"sync"
@@ -72,13 +71,11 @@ func New(opts ...NewNodeOption) (*Node, error) {
 	n.b64pubkey = base64.StdEncoding.EncodeToString(n.pubkey)
 
 	// configure network
-	n.networkDriver.OnEnvelopeHandler(n.HandleEnvelope)
-	if err := n.networkDriver.Join(context.Background(), n.UserID()); err != nil {
-		return nil, err
+	if n.networkDriver != nil {
+		if err := n.UseNetworkDriver(n.networkDriver); err != nil {
+			return nil, errors.Wrap(err, "failed to setup network driver")
+		}
 	}
-
-	// FIXME: subscribe to every owned device IDs
-	// FIXME: subscribe to every joined conversations
 
 	return n, nil
 }


### PR DESCRIPTION
this PRs allows to configure the network driver "later" or even to udpate an existing one

it can be useful to update the network configuration without requiring to restart the app

fix #194