### PR TITLE
chore: gitignore /depviz/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ gin-bin
 
 # emacs
 .projectile
+
+# sub projects
+/depviz/


### PR DESCRIPTION
depviz is know go-gettable using `go get berty.tech/depviz`

in our current configuration, we have this:
* `go get berty.tech`: clones  https://github.com/berty/berty into `$GOPATH/berty.tech`
* `go get berty.tech/depviz`: clones https://github.com/berty/depviz into `$GOPATH/berty.tech/depviz`

This PR makes it more difficult to commit `depviz` in this repo by mistake