### PR TITLE
fix(web): bertychat/web docker image generation

### DIFF
--- a/client/react-native/.dockerignore
+++ b/client/react-native/.dockerignore
@@ -3,3 +3,5 @@ web/node_modules
 common/node_modules
 gomobile
 mobile
+fastlane
+patch

--- a/client/react-native/Dockerfile
+++ b/client/react-native/Dockerfile
@@ -16,6 +16,7 @@ RUN echo "@testing http://dl-4.alpinelinux.org/alpine/edge/testing" >> /etc/apk/
     apk update && apk add --no-cache watchman@testing
 
 # Install common dependencies
+COPY common/schema.graphql /usr/src/app/common/schema.graphql
 COPY package.json /usr/src/app/package.json
 COPY yarn.lock /usr/src/app/yarn.lock
 RUN cd /usr/src/app && yarn --silent


### PR DESCRIPTION
- Fix error during bertychat/web docker image generation (copy of common/schema.graphql)
- Add new folders in .dockerignore file