### PR TITLE
fix(ble): fix not advertised service

### DIFF
--- a/core/network/ble/ble.m
+++ b/core/network/ble/ble.m
@@ -462,7 +462,7 @@ didDiscoverServices:(NSError *)error {
             break;
         case CBManagerStatePoweredOn:
             stateString = @"CBManagerStatePoweredOn";
-            if (self.centralManager.state == CBManagerStatePoweredOn && self.serviceAdded == NO) {
+            if (self.serviceAdded == NO) {
                 self.serviceAdded = YES;
                 [self.peripheralManager addService:self.bertyService];
             }


### PR DESCRIPTION
2nd part of the fix of #427, you don't have to check CBCentralManagerState otherwise if the state isn't update you'll end up unable to read any characteristic