### PR TITLE
feat: add more device infos

### DIFF
--- a/core/node/node.go
+++ b/core/node/node.go
@@ -4,6 +4,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/gogo/protobuf/proto"
 	"github.com/jinzhu/gorm"
@@ -29,14 +30,14 @@ type Node struct {
 	handleMutex             sync.Mutex
 	networkDriver           network.Driver
 	asyncWaitGroup          sync.WaitGroup
+	pubkey                  []byte // FIXME: use a crypto instance, i.e., enclave
+	b64pubkey               string // FIXME: same as above
+	sigchain                *sigchain.SigChain
+	crypto                  keypair.Interface
+	createdAt               time.Time // used for uptime calculation
 	devtools                struct {
 		mapset map[string]string
 	}
-
-	pubkey    []byte // FIXME: use a crypto instance, i.e., enclave
-	b64pubkey string // FIXME: same as above
-	sigchain  *sigchain.SigChain
-	crypto    keypair.Interface
 }
 
 // New initializes a new Node object
@@ -45,6 +46,7 @@ func New(opts ...NewNodeOption) (*Node, error) {
 		// FIXME: fetch myself from db
 		outgoingEvents: make(chan *p2p.Event, 100),
 		clientEvents:   make(chan *p2p.Event, 100),
+		createdAt:      time.Now(),
 	}
 
 	// apply optioners


### PR DESCRIPTION
```console
$ berty client berty.node.DeviceInfos | jq -r '.[][] | .key + ": " + .value' | head -n 15
uptime: 5.251975505s
OS: darwin
Arch: amd64
CPUs: 4
Go version: go1.11
Go compiler: gc
Go 'cgo' calls: 1116
Go routines: 46
pid: 86642
uid: 501
queues: client events: 0
queues: clients: 0
queues: outgoing events: 0
env: LC_CTYPE=en_US.UTF-8
env: SHELL=/bin/zsh
env: _=/usr/bin/make
...
```