### PR TITLE
feat(devtools): device infos now returns the amount of sql rows

### DIFF
--- a/core/node/nodeapi_devtools.go
+++ b/core/node/nodeapi_devtools.go
@@ -19,6 +19,7 @@ import (
 	"berty.tech/core/crypto/keypair"
 	"berty.tech/core/crypto/sigchain"
 	"berty.tech/core/entity"
+	"berty.tech/core/sql"
 	"berty.tech/core/testrunner"
 	"github.com/brianvoe/gofakeit"
 	"github.com/gogo/protobuf/proto"
@@ -118,6 +119,21 @@ func (n *Node) DeviceInfos(_ context.Context, input *node.Void) (*node.DeviceInf
 		m.Sys/1024/1024,
 		m.NumGC,
 	)})
+
+	for _, table := range sql.AllTables() {
+		var count uint32
+		if err := n.sql.Table(table).Count(&count).Error; err != nil {
+			output.Infos = append(output.Infos, &node.DeviceInfo{
+				Key:   fmt.Sprintf("sql: %s (error)", table),
+				Value: err.Error(),
+			})
+		} else {
+			output.Infos = append(output.Infos, &node.DeviceInfo{
+				Key:   fmt.Sprintf("sql: %s", table),
+				Value: fmt.Sprintf("%d entries", count),
+			})
+		}
+	}
 
 	output.Infos = append(output.Infos, &node.DeviceInfo{Key: "Versions", Value: fmt.Sprintf("core=%s (p2p=%d, node=%d)", core.Version, p2p.Version, node.Version)})
 	output.Infos = append(output.Infos, &node.DeviceInfo{Key: "Platform", Value: fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH)})

--- a/core/sql/common.go
+++ b/core/sql/common.go
@@ -1,0 +1,22 @@
+package sql
+
+func AllTables() []string {
+	return []string{
+		// events
+		"event",
+
+		// entities
+		"sender_alias",
+		"device",
+		"contact",
+		"conversation",
+		"conversation_member",
+		"config",
+
+		// association tables
+		// FIXME: add m2m
+
+		// internal
+		"migrations",
+	}
+}

--- a/core/sql/gorm.go
+++ b/core/sql/gorm.go
@@ -26,15 +26,7 @@ func Migrate(db *gorm.DB) error {
 		{
 			ID: "1",
 			Migrate: func(tx *gorm.DB) error {
-				return tx.AutoMigrate(
-					p2p.Event{},
-					entity.Contact{},
-					entity.Conversation{},
-					entity.ConversationMember{},
-					entity.Device{},
-					entity.Config{},
-					entity.SenderAlias{},
-				).Error
+				return tx.AutoMigrate(append(entity.AllEntities(), p2p.Event{})...).Error
 			},
 			Rollback: func(tx *gorm.DB) error {
 				return DropDatabase(tx)
@@ -49,13 +41,9 @@ func Migrate(db *gorm.DB) error {
 }
 
 func DropDatabase(db *gorm.DB) error {
-	return db.DropTableIfExists(
-		// base entities
-		"config", "contact", "event", "device", "conversation", "conversation_member",
-
-		// association tables
-
-		// internal
-		"migrations",
-	).Error
+	var tables []interface{}
+	for _, table := range AllTables() {
+		tables = append(tables, table)
+	}
+	return db.DropTableIfExists(tables...).Error
 }


### PR DESCRIPTION
Fix #529

```console
$ berty client berty.node.DeviceInfos | jq -r '.[][] | .key + ": " + .value' | grep sql:
sql: event: 0 entries
sql: sender_alias: 0 entries
sql: device: 1 entries
sql: contact: 1 entries
sql: conversation: 0 entries
sql: conversation_member: 0 entries
sql: config: 1 entries
sql: migrations: 1 entries

~
$ berty client berty.node.GenerateFakeData
{}

~
$ berty client berty.node.DeviceInfos | jq -r '.[][] | .key + ": " + .value' | grep sql:
sql: event: 15 entries
sql: sender_alias: 0 entries
sql: device: 11 entries
sql: contact: 11 entries
sql: conversation: 10 entries
sql: conversation_member: 25 entries
sql: config: 1 entries
sql: migrations: 1 entries
```