### PR TITLE
feat(devtools): add config lifetime in device infos

### DIFF
--- a/core/node/nodeapi_devtools.go
+++ b/core/node/nodeapi_devtools.go
@@ -107,7 +107,8 @@ func (n *Node) DeviceInfos(_ context.Context, input *node.Void) (*node.DeviceInf
 	output := &node.DeviceInfosOutput{}
 
 	// system, platform, os, etc
-	output.Infos = append(output.Infos, &node.DeviceInfo{Key: "Uptime", Value: fmt.Sprintf("%s", time.Since(n.createdAt))})
+	output.Infos = append(output.Infos, &node.DeviceInfo{Key: "Node lifetime (uptime)", Value: fmt.Sprintf("%s", time.Since(n.createdAt))})
+	output.Infos = append(output.Infos, &node.DeviceInfo{Key: "Config lifetime", Value: fmt.Sprintf("%s", time.Since(n.config.CreatedAt))})
 
 	var m runtime.MemStats
 	runtime.ReadMemStats(&m)


### PR DESCRIPTION
```console
$ berty client berty.node.DeviceInfos | jq -r '.[][] | .key + ": " + .value' | grep lifetime
Node lifetime (uptime): 2m13.858093s
Config lifetime: 2m40.425318s
```