### PR TITLE
Fix long write iOS to android

### DIFF
--- a/client/react-native/android/ble/src/main/java/chat/berty/ble/Manager.java
+++ b/client/react-native/android/ble/src/main/java/chat/berty/ble/Manager.java
@@ -291,6 +291,14 @@ public class Manager {
                 }
 
                 @Override
+                public void onExecuteWrite (BluetoothDevice device,
+                                            int requestId,
+                                            boolean execute) {
+                    Log.e(TAG, "EXECUTE WRITE " + requestId + " EXECUTE " + execute);
+                    super.onExecuteWrite(device, requestId, execute);
+                }
+
+                @Override
                 public void onCharacteristicWriteRequest(BluetoothDevice device, int requestId, BluetoothGattCharacteristic characteristic, boolean preparedWrite, boolean responseNeeded, int offset, byte[] value) {
                     UUID charID = characteristic.getUuid();
                     BertyDevice bDevice = getDeviceFromAddr(device.getAddress());
@@ -304,8 +312,12 @@ public class Manager {
                         } catch (Exception e) {
                             Log.e(TAG, "FAIL AWAIT " + e.getMessage());
                         }
+                        Log.e(TAG, "rep needed" + responseNeeded+ "prepared " + preparedWrite + " transid " + requestId  + " offset " + offset + " len: " + value.length);
                         Core.bytesToConn(bDevice.ma, value);
-                        mBluetoothGattServer.sendResponse(device, requestId, GATT_SUCCESS, offset, null);
+                        if (responseNeeded) {
+                            mBluetoothGattServer.sendResponse(device, requestId, GATT_SUCCESS, offset, value);
+                        }
+
                     } else if (charID.equals(CLOSER_UUID)) {
                         // TODO
                     } else if (charID.equals(IS_READY_UUID)) {


### PR DESCRIPTION
When android connect to an iOS device it set the mtu and the callback onMTUchanged is called on the android side, with an iphone 6S+ for example it'll set the mtu to 185, even through on the iOS part we will still retrieve 512 when we call maximumWriteValueLengthForType cause iOS automaticly chunck the data to fit in the correct MTU for the android device, in order to iOS to know what was read we need to send back the value when we send the gatt response, on the android side we can either send the chunk to yamux since it'll buffer it as long as it hasn't received the whole frame or buffer it and send it when the onExecuteWrite is called with the execute parameter set to true, i've choose the 1st option in order to not taking more time on this issue