### PR TITLE
feat: add berty update (dry-run)

### DIFF
--- a/core/cmd/berty/root.go
+++ b/core/cmd/berty/root.go
@@ -90,6 +90,7 @@ func newRootCommand() *cobra.Command {
 		newClientCommand(),
 		newSQLCommand(),
 		newIdentityCommand(),
+		newUpdateCommand(),
 	)
 
 	viper.AutomaticEnv()

--- a/core/cmd/berty/update.go
+++ b/core/cmd/berty/update.go
@@ -1,0 +1,83 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
+
+	"berty.tech/core"
+)
+
+type updateOptions struct {
+}
+
+func updateSetupFlags(flags *pflag.FlagSet, opts *updateOptions) {
+	_ = viper.BindPFlags(flags)
+}
+
+func newUpdateCommand() *cobra.Command {
+	opts := &updateOptions{}
+	cmd := &cobra.Command{
+		Use: "update",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := viper.Unmarshal(opts); err != nil {
+				return err
+			}
+			return update(opts)
+		},
+	}
+
+	updateSetupFlags(cmd.Flags(), opts)
+	return cmd
+}
+
+func update(opts *updateOptions) error {
+	client := http.Client{}
+	req, err := http.NewRequest(http.MethodGet, "https://yolo.berty.io/release/ios.json", nil)
+	if err != nil {
+		return errors.Wrap(err, "failed to create http request")
+	}
+	resp, err := client.Do(req)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
+	if err != nil {
+		return errors.Wrap(err, "failed to fetch release file")
+	}
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return errors.Wrap(err, "failed to read body")
+	}
+	type release struct {
+		Branch      string    `json:"branch"`
+		StopTime    time.Time `json:"stop-time"`
+		Author      string    `json:"author"`
+		GitSha      string    `json:"git-sha"`
+		BuildURL    string    `json:"build-url"`
+		Body        string    `json:"body"`
+		ManifestURL string    `json:"manifest-url"`
+	}
+	ret := struct {
+		Master    *release   `json:"master"`
+		LatestPRs []*release `json:"latest-prs"`
+	}{}
+	if err := json.Unmarshal(body, &ret); err != nil {
+		return errors.Wrap(err, "invalid json body")
+	}
+
+	if core.CommitDate().Before(ret.Master.StopTime) {
+		out, _ := json.MarshalIndent(ret.Master, "", "  ")
+		fmt.Printf("new master update available: %s\n", string(out))
+	} else {
+		fmt.Println("you are already up to date")
+	}
+
+	return nil
+}

--- a/core/manager/account/account.go
+++ b/core/manager/account/account.go
@@ -210,7 +210,7 @@ func (a *Account) Open() error {
 		zap.String("git-sha", core.GitSha),
 		zap.String("git-branch", core.GitBranch),
 		zap.String("build-mode", core.BuildMode),
-		zap.String("commit-date", core.CommitDate()),
+		zap.String("commit-date", core.CommitDate().String()),
 		zap.String("db", a.dbPath()),
 		zap.String("name", a.Name),
 	)

--- a/core/version.go
+++ b/core/version.go
@@ -18,15 +18,14 @@ var (
 	commitDate = "undefined"
 )
 
-func CommitDate() string {
+func CommitDate() time.Time {
 	if commitDate == "undefined" {
-		return "undefined"
+		return time.Time{}
 	}
 
 	commitDateInt, err := strconv.ParseInt(commitDate, 10, 64)
 	if err != nil {
-		return "parse-error"
+		return time.Time{}
 	}
-	tm := time.Unix(commitDateInt, 0)
-	return tm.Format(time.RFC3339)
+	return time.Unix(commitDateInt, 0)
 }


### PR DESCRIPTION
this command does not actually updates the app but displays a message if there is a new update

this is not very useful in the daemon, but it's easier to test here before implementing this in mobile