### PR TITLE
fix(android): ask permission before saving QR code

### DIFF
--- a/client/react-native/common/helpers/saveViewToCamera.js
+++ b/client/react-native/common/helpers/saveViewToCamera.js
@@ -1,8 +1,10 @@
 import ViewShot from 'react-native-view-shot'
 import React, { Component } from 'react'
-import { View, CameraRoll, Platform } from 'react-native'
+import { View, CameraRoll, Platform, PermissionsAndroid } from 'react-native'
 import { StackActions } from 'react-navigation'
 import NavigationService from './NavigationService'
+import { requestAndroidPermission } from './permissions'
+import I18n from '../i18n'
 
 export class ViewExportComponent extends Component {
   async componentDidMount () {
@@ -36,7 +38,19 @@ export class ViewExportComponent extends Component {
 }
 
 export default async ({ view }) => {
-  if (Platform.os === 'web') {
+  if (Platform.OS === 'android') {
+    const allowed = await requestAndroidPermission({
+      permission: PermissionsAndroid.PERMISSIONS.WRITE_EXTERNAL_STORAGE,
+      title: I18n.t('settings.save-picture-perm'),
+      message: I18n.t('settings.save-picture-perm-desc'),
+    })
+
+    if (!allowed) {
+      throw new Error(I18n.t('settings.save-picture-perm-denied'))
+    }
+  }
+
+  if (Platform.OS === 'web') {
     throw new Error('unsupported on web')
   }
 
@@ -48,6 +62,7 @@ export default async ({ view }) => {
         view,
       })
     })
+
     await CameraRoll.saveToCameraRoll(uri, 'photo')
   } catch (e) {
     throw e

--- a/client/react-native/common/i18n/en/messages.json
+++ b/client/react-native/common/i18n/en/messages.json
@@ -102,7 +102,10 @@
     "update-available": "An update is available",
     "update-write-fail": "Unable to download app, not allowed to write file",
     "update-write-perm": "Write to external storage",
-    "update-write-perm-desc": "This permission is required to download the application update"
+    "update-write-perm-desc": "This permission is required to download the application update",
+    "save-picture-perm": "Save picture",
+    "save-picture-perm-desc": "This permission is required to save the image to your Camera Roll",
+    "save-picture-perm-denied": "Unable to save the picture"
   },
   "chats": {
     "title": "Chats",

--- a/client/react-native/common/i18n/fr/messages.json
+++ b/client/react-native/common/i18n/fr/messages.json
@@ -102,7 +102,10 @@
     "update-available": "Une mise à jour est disponible",
     "update-write-fail": "Erreur du téléchargement de l'app, impossible de sauvegarder la mise à jour",
     "update-write-perm": "Enregistrer des fichiers",
-    "update-write-perm-desc": "Cette permission est nécessaire au téléchargement de la mise à jour"
+    "update-write-perm-desc": "Cette permission est nécessaire au téléchargement de la mise à jour",
+    "save-picture-perm": "Enregistrer des images",
+    "save-picture-perm-desc": "Cette permission est nécessaire à l'enregistrement d'images dans votre galerie",
+    "save-picture-perm-denied": "Impossible d'enregister l'image"
   },
   "chats": {
     "title": "Conversations",


### PR DESCRIPTION
fixes #1001  Bug fix : "Permission denied" on save QR code [Android]