### PR TITLE
chore: temporarily increase queue sizes

### DIFF
--- a/core/node/node.go
+++ b/core/node/node.go
@@ -65,8 +65,8 @@ func New(ctx context.Context, opts ...NewNodeOption) (*Node, error) {
 
 	n := &Node{
 		// FIXME: fetch myself from db
-		outgoingEvents: make(chan *entity.EventDispatch, 100),
-		clientEvents:   make(chan *entity.Event, 100),
+		outgoingEvents: make(chan *entity.EventDispatch, 1000),
+		clientEvents:   make(chan *entity.Event, 1000),
 		createdAt:      time.Now().UTC(),
 		rootSpan:       tracer.Span(),
 		rootContext:    ctx,


### PR DESCRIPTION
We need to test more the app, some devices are locked

The real solution will be to investigate why the limit is reached (probably because of a mutex).

Todo later: decrease the queue size to something a lot smaller, i.e., `10` and fix the root cause.