### PR TITLE
[BUG] UX - Navigation display two loader when remove conversation (and stay in that state)

### DIFF
--- a/client/packages/screen/Chats/Settings/List.js
+++ b/client/packages/screen/Chats/Settings/List.js
@@ -78,10 +78,14 @@ export class SettingsScreen extends PureComponent {
     const { id } = conversation
     try {
       await context.node.service.conversationRemove({ id })
-      this.props.goBack()
     } catch (err) {
       console.error(err)
+      if (this.props.context.entity.conversation.has(id)) {
+        return
+      }
     }
+    this.props.goBack()
+    this.props.navigation.popToTop()
   }
 
   render() {


### PR DESCRIPTION
This could be link with split navigator