### PR TITLE
test golang@1.11 to golang@1.13

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ orbs:
   moul:    moul/build@1.12.1
 
 jobs:
-  go-build:
+  go-build-113:
     working_directory: /go/src/berty.tech/go
     docker:
       - image: circleci/golang:1.13
@@ -23,6 +23,36 @@ jobs:
       - run: PATH=$PATH:$(pwd)/bin make lint
       - codecov/upload:
           file: coverage.txt
+  go-build-112:
+    working_directory: /go/src/berty.tech/go
+    environment:
+      - GO111MODULE=on
+    docker:
+      - image: circleci/golang:1.12
+    steps:
+      - checkout:
+          path: /go/src/berty.tech
+      - moul/mod-download
+      - gotools/mod-tidy-check
+      - run: make install
+      - run: make unittest
+      - moul/install_golangci-lint
+      - run: PATH=$PATH:$(pwd)/bin make lint
+  go-build-111:
+    working_directory: /go/src/berty.tech/go
+    environment:
+      - GO111MODULE=on
+    docker:
+      - image: circleci/golang:1.11
+    steps:
+      - checkout:
+          path: /go/src/berty.tech
+      - moul/mod-download
+      - gotools/mod-tidy-check
+      - run: make install
+      - run: make unittest
+      - moul/install_golangci-lint
+      - run: PATH=$PATH:$(pwd)/bin make lint
   go-docker:
     working_directory: /go/src/berty.tech/go
     docker:
@@ -86,7 +116,9 @@ jobs:
 workflows:
   main:
     jobs:
-      - go-build
+      - go-build-113
+      - go-build-112
+      - go-build-111
       - go-docker
       - go-generate
       - githooks

--- a/go/Makefile
+++ b/go/Makefile
@@ -1,13 +1,13 @@
 .PHONY: install
 install: generate
-	go install -v ./cmd/...
+	GO111MODULE=on go install -v ./cmd/...
 
 .PHONY: test
 test: unittest lint tidy
 
 .PHONY: unittest
 unittest: generate
-	go test -v -cover -coverprofile=coverage.txt -covermode=atomic -race ./...
+	GO111MODULE=on go test -v -cover -coverprofile=coverage.txt -covermode=atomic -race ./...
 
 .PHONY: lint
 lint: generate
@@ -15,7 +15,7 @@ lint: generate
 
 .PHONY: tidy
 tidy: generate
-	go mod tidy
+	GO111MODULE=on go mod tidy
 
 .PHONY: docker.build
 docker.build: generate

--- a/go/gen.sum
+++ b/go/gen.sum
@@ -3,4 +3,4 @@
 961a4952e56eb176d8239981794e0bff5ebe9238  ../api/entity.proto
 b139403f729a7cf26f2d2ecbde2d9b6524b5efe2  ../api/baz.proto
 bb0d4bdd5e638b97f5dd350eb3505645de48eda5  ../api/internal/bar.proto
-e42a143c0964f230b4083b6800759ff60a97e167  Makefile
+fa7eda8122869538112957b6ad651476a41203fc  Makefile


### PR DESCRIPTION
We are still using go1.11 for go mobile, so this PR makes sure that our code base can run on all version from go1.11 to current