### PR TITLE
fix(bazel): openssl linking on macos

### DIFF
--- a/bazel/com_github_spacemonkeygo_openssl.BUILD.bazel
+++ b/bazel/com_github_spacemonkeygo_openssl.BUILD.bazel
@@ -40,10 +40,21 @@ go_library(
         "tickets.go",
     ],
     cgo = True,
-    clinkopts = [
+    clinkopts = select({
+        "@bazel_tools//src/conditions:darwin": [
+            "-L/usr/local/opt/openssl/lib"
+        ],
+        "//conditions:default": [],
+    }) + [
         "-lssl",
         "-lcrypto",
     ],
+    copts = select({
+        "@bazel_tools//src/conditions:darwin": [
+            "-I/usr/local/opt/openssl/include"
+        ],
+        "//conditions:default": [],
+    }),
     importmap = "berty.tech/go/vendor/github.com/spacemonkeygo/openssl",
     importpath = "github.com/spacemonkeygo/openssl",
     visibility = ["//visibility:public"],


### PR DESCRIPTION
tested on mojave with `openssl: stable 1.0.2t (bottled) [keg-only]`
and arch linux with `openssl 1.1.1.d-1`