### PR TITLE
GH-Actions: Port circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2.1
 
 orbs:
-  codecov: codecov/codecov@1.0.5
   docker:  circleci/docker@0.5.13
   gotools: gotest/tools@0.0.10
   moul:    moul/build@1.12.1
@@ -44,8 +43,6 @@ jobs:
       - run: make tidy
       - moul/install_golangci-lint
       - run: PATH=$PATH:$(pwd)/bin make lint
-      - codecov/upload:
-          file: coverage.txt
   go-docker:
     working_directory: /go/src/berty.tech/go
     docker:

--- a/.github/workflows/js.yaml
+++ b/.github/workflows/js.yaml
@@ -1,0 +1,35 @@
+name: "Paths: js/**"
+on:
+  push:
+    paths:
+    - 'js/**'
+  pull_request:
+    paths:
+    - 'js/**'
+
+jobs:
+  js-generate:
+    name: "Js: Check generation"
+    runs-on: ubuntu-latest
+    container:
+      image: bertytech/protoc:20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      # TODO: cache
+      - run: cd js && make gen.clean gen
+      - run: |
+          git status | cat
+          git diff -w | cat
+          git diff-index -w --quiet HEAD --
+
+  js-lint:
+    name: "Js: Lint"
+    runs-on: ubuntu-latest
+    container:
+      image: bertytech/protoc:20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      # TODO: cache
+      - run: cd js && make lint

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,129 @@
+name: Main
+on: [push, pull_request]
+
+jobs:
+  go-docker:
+    name: "Docker: Build berty/berty"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Build berty/berty
+        uses: n0izn0iz/Publish-Docker-Github-Action@master
+        with:
+          name: berty/berty
+          workdir: go
+
+  go-generate:
+    name: "Go: Check generation"
+    runs-on: ubuntu-latest
+    container:
+      image: bertytech/protoc:20
+    steps:
+    - name: Checkout
+      uses: actions/checkout@master
+    - run: find . -name gen.sum -delete
+    - run: cd go && go mod vendor
+    - run: cd go && make generate_local && make tidy
+    - run: cd docs && make generate_local
+    - run: |
+        git status | cat
+        git diff -w | cat
+        git diff-index -w --quiet HEAD --
+
+  githooks:
+    name: "Githooks"
+    runs-on: ubuntu-latest
+    container:
+      image: bertytech/githooks:v1
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - run: ./githooks/pre-commit
+      - run: |
+          git status | cat
+          git diff -w | cat
+          git diff-index -w --quiet HEAD --
+
+  go-build-112:
+    name: "Go: Build"
+    runs-on: ${{ matrix.os }}
+    env:
+      GO111MODULE: on
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - name: Setup go
+        uses: actions/setup-go@v1
+        with:
+          go-version: 1.12.x
+      - name: Checkout
+        uses: actions/checkout@master
+
+      # TODO: cache $GOPATH/pkg/mod
+      - run: go mod download
+        working-directory: ./go
+
+      # https://circleci.com/orbs/registry/orb/gotest/tools#commands-mod-tidy-check
+      - run: go mod tidy -v
+        working-directory: ./go
+      - run: git --no-pager diff go.mod go.sum
+        working-directory: ./go
+      - run: git --no-pager diff --quiet go.mod go.sum
+        working-directory: ./go
+
+      - run: make go.install
+        working-directory: ./go
+      - run: make go.unittest GO_TEST_OPTS="-v -test.timeout=120s"
+        working-directory: ./go
+      - run: make tidy
+        working-directory: ./go
+      - name: Setup golangci-lint
+        working-directory: ./go
+        run: curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh| sh -s v1.21.0
+      - run: PATH=$PATH:$(pwd)/bin  make lint
+        working-directory: ./go
+      - if: matrix.os == 'ubuntu-latest'
+        uses: codecov/codecov-action@v1.0.3
+        with:
+          token: ${{secrets.CODECOV_TOKEN}}
+          file: ./go/coverage.txt
+
+  bazel-go:
+    name: "Go: Bazel"
+    strategy:
+      matrix:
+        bazel-target: [unittest, banner, build]
+        os: [macos-latest, ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - if: contains(matrix.os, 'macos-')
+      name: Install bazel (darwin)
+      working-directory: /tmp
+      run: |
+        curl -LO https://github.com/bazelbuild/bazel/releases/download/0.29.1/bazel-0.29.1-installer-darwin-x86_64.sh
+        chmod +x bazel-0.29.1-installer-darwin-x86_64.sh
+        ./bazel-0.29.1-installer-darwin-x86_64.sh --user
+    - if: contains(matrix.os, 'ubuntu-')
+      name: Install bazel (linux)
+      working-directory: /tmp
+      run: |
+        curl -LO https://github.com/bazelbuild/bazel/releases/download/0.29.1/bazel-0.29.1-installer-linux-x86_64.sh
+        chmod +x bazel-0.29.1-installer-linux-x86_64.sh
+        ./bazel-0.29.1-installer-linux-x86_64.sh --user
+    - name: Setup go
+      uses: actions/setup-go@v1
+      with:
+        go-version: 1.12.x
+    - name: Print versions
+      run: |
+        PATH=${PATH}:${HOME}/bin bazel --version
+        go version
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Run make bazel.${{ matrix.bazel-target }}
+      working-directory: ./go
+      env:
+        BAZEL_CMD_ARGS: --sandbox_debug --jobs=2 --local_ram_resources=HOST_RAM*.5
+      run: PATH=${PATH}:${HOME}/bin make bazel.${{ matrix.bazel-target }}


### PR DESCRIPTION
I'm not sure why the workflow is not triggered on the berty repo
You can see the result [here](https://github.com/n0izn0iz/berty/commit/b3e604d0bbecd0567fdaf6bbbf54d56ae70bea7e/checks)

### Caveats
- It's missing caching
- It's set to also trigger on `pull_request` which I don't fully understand yet
- The codecov upload is removed from circle

### Improvements
- The `bazel-*` and `go-build-112` jobs are now run on macos too