### PR TITLE
Fix: JS code gen failing

### DIFF
--- a/js/packages/berty-app/Makefile
+++ b/js/packages/berty-app/Makefile
@@ -381,7 +381,7 @@ run.android.store: config := production
 run.android.store: target := store
 run.android.store: run.android
 run.android: platform := android
-run.android: device := $(shell which adb >/dev/null && (adb adb devices | tail +2 | head -1 | cut -f 1) || echo "missing-adb-binary")
+run.android: device := $(shell which adb >/dev/null && (adb devices | tail +2 | head -1 | cut -f 1) || echo "missing-adb-binary")
 run.android: deps.android run
 
 run.web.debug: config := development


### PR DESCRIPTION
Already fixed the `adb: usage: unknown command adb`.
Still need to fix this error: `make[1]: *** No rule to make target '/Users/aeddi/go/src/berty.tech/js/packages/api-chat/package.json', needed by '/Users/aeddi/go/src/berty.tech/js/node_modules'.  Stop.`

Ok solution for the second problem: `rm -rf js/packages/api-chat` (obsolete folder)