### PR TITLE
chore: switch to testify/assert testing library

### DIFF
--- a/go/framework/bpbridge/bridge_test.go
+++ b/go/framework/bpbridge/bridge_test.go
@@ -17,6 +17,7 @@ import (
 	"berty.tech/berty/go/internal/testutil"
 	"berty.tech/berty/go/pkg/bertyprotocol"
 	"github.com/gogo/protobuf/proto"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/zap"
 	"golang.org/x/net/context"
 	"google.golang.org/grpc"
@@ -40,9 +41,8 @@ func TestBridge(t *testing.T) {
 	})
 	checkErr(t, err)
 	defer func() {
-		if err = bridge.Close(); err != nil {
-			t.Fatalf("stop bridge: %v", err)
-		}
+		err = bridge.Close()
+		assert.NoErrorf(t, err, "bridge.Close")
 	}()
 
 	logger.Info(
@@ -54,9 +54,7 @@ func TestBridge(t *testing.T) {
 	// clients
 
 	bridgeClient = bridge.GRPCClient()
-	if bridgeClient == nil {
-		t.Fatalf("expected bridgeClient to be initialized, got nil.")
-	}
+	assert.NotNil(t, bridgeClient)
 
 	grpcClient, err = grpc.Dial(bridge.GRPCListenerAddr(), grpc.WithInsecure())
 	checkErr(t, err)

--- a/go/framework/bpbridge/testing_test.go
+++ b/go/framework/bpbridge/testing_test.go
@@ -1,11 +1,15 @@
 package bpbridge
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
 
 func checkErr(t *testing.T, err error) {
 	t.Helper()
 
-	if err != nil {
-		t.Fatalf("error: %+v", err)
+	if !assert.NoError(t, err) {
+		t.Fatal("fatal")
 	}
 }

--- a/go/go.mod
+++ b/go/go.mod
@@ -21,6 +21,7 @@ require (
 	github.com/oklog/run v1.0.0
 	github.com/peterbourgon/ff v1.6.0
 	github.com/pkg/errors v0.8.1
+	github.com/stretchr/testify v1.4.0
 	go.uber.org/multierr v1.2.0 // indirect
 	go.uber.org/zap v1.10.0
 	golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550

--- a/go/internal/handshake/crypto_test.go
+++ b/go/internal/handshake/crypto_test.go
@@ -8,15 +8,14 @@ import (
 	"berty.tech/berty/go/internal/crypto"
 	"berty.tech/berty/go/pkg/errcode"
 	p2pcrypto "github.com/libp2p/go-libp2p-core/crypto"
+	"github.com/stretchr/testify/assert"
 )
 
 func createNewIdentity(ctx context.Context, t *testing.T) (crypto.Manager, p2pcrypto.PrivKey) {
 	t.Helper()
 
 	c, privateKey, err := crypto.InitNewIdentity(ctx, nil)
-	if err != nil {
-		t.Fatalf("can't create new identity")
-	}
+	checkErr(t, err, "can't create new identity")
 
 	return c, privateKey
 }
@@ -28,32 +27,24 @@ func createTwoDevices(ctx context.Context, t *testing.T) (*handshakeSession, cry
 	c2, pk2 := createNewIdentity(ctx, t)
 
 	accountPublicKey, err := c2.GetAccountPublicKey()
-	if err != nil {
-		t.Fatalf("can't get public key for account")
-	}
+	checkErr(t, err, "can't get public key for account")
 
 	hss1, err := newCryptoRequest(pk1, c1.GetSigChain(), accountPublicKey, nil)
-	if err != nil || hss1 == nil {
-		t.Fatalf("can't get crypto request for c1")
-	}
+	checkErr(t, err, "can't get crypto request for c1")
+	assert.NotNil(t, hss1)
 
 	sign, box := hss1.GetPublicKeys()
 
 	hss2, err := newCryptoResponse(pk2, c2.GetSigChain(), nil)
-	if err != nil || hss2 == nil {
-		t.Fatalf("can't get crypto request for c2")
-	}
+	checkErr(t, err, "can't get crypto request for c2")
+	assert.NotNil(t, hss2)
 
 	err = hss2.SetOtherKeys(sign, box)
-	if err != nil {
-		t.Fatalf("can't set other keys on hss2")
-	}
+	checkErr(t, err, "can't set other keys on hss2")
 
 	sign, box = hss2.GetPublicKeys()
 	err = hss1.SetOtherKeys(sign, box)
-	if err != nil {
-		t.Fatalf("can't set other keys on hss1")
-	}
+	checkErr(t, err, "can't set other keys on hss1")
 
 	return hss1, c1, hss2, c2
 }
@@ -62,7 +53,9 @@ func TestNewHandshakeModule(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	_, _ = createNewIdentity(ctx, t)
+	manager, privKey := createNewIdentity(ctx, t)
+	assert.NotNil(t, manager)
+	assert.NotNil(t, privKey)
 }
 
 func TestModule_NewRequest(t *testing.T) {
@@ -73,14 +66,11 @@ func TestModule_NewRequest(t *testing.T) {
 	c2, _ := createNewIdentity(ctx, t)
 
 	accountPubKey, err := c2.GetAccountPublicKey()
-	if err != nil {
-		t.Fatalf("can't get account public key for c2")
-	}
+	checkErr(t, err, "can't get account public key for c2")
 
 	hss, err := newCryptoRequest(pk1, c1.GetSigChain(), accountPubKey, nil)
-	if err != nil || hss == nil {
-		t.Fatalf("can't get initiate crypto handshake request")
-	}
+	checkErr(t, err, "can't get initiate crypto handshake request")
+	assert.NotNil(t, hss)
 }
 
 func TestModule_NewResponse(t *testing.T) {
@@ -91,26 +81,18 @@ func TestModule_NewResponse(t *testing.T) {
 	c2, pk2 := createNewIdentity(ctx, t)
 
 	accountPubKey, err := c2.GetAccountPublicKey()
-	if err != nil {
-		t.Fatalf("err should be nil")
-	}
+	checkErr(t, err)
 
 	hss1, err := newCryptoRequest(pk1, c1.GetSigChain(), accountPubKey, nil)
-	if err != nil || hss1 == nil {
-		t.Fatalf("err should be nil")
-	}
+	checkErr(t, err)
 
 	sign, box := hss1.GetPublicKeys()
 
 	hss2, err := newCryptoResponse(pk2, c2.GetSigChain(), nil)
-	if err != nil || hss2 == nil {
-		t.Fatalf("err should be nil")
-	}
+	checkErr(t, err)
 
 	err = hss2.SetOtherKeys(sign, box)
-	if err != nil {
-		t.Fatalf("err should be nil")
-	}
+	checkErr(t, err)
 }
 
 func TestHandshakeSession_SetOtherKeys(t *testing.T) {
@@ -120,24 +102,16 @@ func TestHandshakeSession_SetOtherKeys(t *testing.T) {
 	hss1, _, hss2, _ := createTwoDevices(ctx, t)
 	sign, box := hss2.GetPublicKeys()
 	err := hss1.SetOtherKeys(sign, box)
-	if err != nil {
-		t.Fatalf("err should be nil")
-	}
+	assert.NoError(t, err)
 
 	err = hss1.SetOtherKeys(sign, box[0:3])
-	if err == nil {
-		t.Fatalf("err should not be nil")
-	}
+	assert.NotNil(t, err)
 
 	_, badSigningPubKey, err := p2pcrypto.GenerateSecp256k1Key(rand.Reader)
-	if err != nil {
-		t.Fatalf("err should be nil")
-	}
+	assert.NoError(t, err)
 
 	err = hss1.SetOtherKeys(badSigningPubKey, box)
-	if err == nil {
-		t.Fatalf("err should not be nil")
-	}
+	assert.NotNil(t, err)
 }
 
 func TestHandshakeSession_GetPublicKeys(t *testing.T) {
@@ -147,9 +121,8 @@ func TestHandshakeSession_GetPublicKeys(t *testing.T) {
 	hss1, _, _, _ := createTwoDevices(ctx, t)
 	sign, box := hss1.GetPublicKeys()
 
-	if int(sign.Type()) != SupportedKeyType || len(box) != 32 {
-		t.Fatalf("public keys seems improperly returned")
-	}
+	assert.Equal(t, SupportedKeyType, int(sign.Type()))
+	assert.Len(t, box, 32)
 }
 
 func TestHandshakeSession_ProveOtherKey_CheckOwnKeyProof(t *testing.T) {
@@ -158,22 +131,13 @@ func TestHandshakeSession_ProveOtherKey_CheckOwnKeyProof(t *testing.T) {
 
 	hss1, _, hss2, _ := createTwoDevices(ctx, t)
 	proof, err := hss1.ProveOtherKey()
-
-	if err != nil {
-		t.Fatalf("err should be nil")
-	}
+	checkErr(t, err)
 
 	err = hss2.CheckOwnKeyProof(proof)
-
-	if err != nil {
-		t.Fatalf("err should be nil")
-	}
+	checkErr(t, err)
 
 	err = hss2.CheckOwnKeyProof([]byte("oops"))
-
-	if err == nil {
-		t.Fatalf("err should not be nil")
-	}
+	testSameErrcodes(t, errcode.ErrHandshakeInvalidSignature, err)
 }
 
 func TestHandshakeSession_ProveOwnDeviceKey_CheckOtherKeyProof(t *testing.T) {
@@ -182,34 +146,23 @@ func TestHandshakeSession_ProveOwnDeviceKey_CheckOtherKeyProof(t *testing.T) {
 
 	hss1, c1, hss2, c2 := createTwoDevices(ctx, t)
 	proof, err := hss1.ProveOwnDeviceKey()
-
-	if err != nil {
-		t.Fatalf("err should be nil")
-	}
+	checkErr(t, err)
 
 	// Correct
 	err = hss2.CheckOtherKeyProof(proof, c1.GetSigChain(), c1.GetDevicePublicKey())
-	if err != nil {
-		t.Fatalf("err should be nil")
-	}
+	checkErr(t, err)
 
 	// Wrong signature
 	err = hss2.CheckOtherKeyProof([]byte("oops"), c1.GetSigChain(), c1.GetDevicePublicKey())
-	if err == nil {
-		t.Fatalf("err should not be nil")
-	}
+	testSameErrcodes(t, errcode.ErrHandshakeInvalidSignature, err)
 
 	// Wrong sig chain
 	err = hss2.CheckOtherKeyProof(proof, c2.GetSigChain(), c1.GetDevicePublicKey())
-	if err == nil {
-		t.Fatalf("err should not be nil")
-	}
+	testSameErrcodes(t, errcode.ErrHandshakeInvalidSignature, err)
 
 	// Key not found in sig chain
 	err = hss1.CheckOtherKeyProof(proof, c1.GetSigChain(), c1.GetDevicePublicKey())
-	if err == nil {
-		t.Fatalf("err should not be nil")
-	}
+	testSameErrcodes(t, errcode.ErrHandshakeInvalidSignature, err)
 }
 
 func TestHandshakeSession_ProveOtherKnownAccount_CheckOwnKnownAccountProof(t *testing.T) {
@@ -218,15 +171,10 @@ func TestHandshakeSession_ProveOtherKnownAccount_CheckOwnKnownAccountProof(t *te
 
 	hss1, c1, hss2, _ := createTwoDevices(ctx, t)
 	proof, err := hss1.ProveOtherKnownAccount()
-
-	if err != nil {
-		t.Fatalf("can't prove other known account")
-	}
+	checkErr(t, err, "can't prove other known account")
 
 	err = hss2.CheckOwnKnownAccountProof(c1.GetDevicePublicKey(), proof)
-	if err != nil {
-		t.Fatalf("can't check self account proof")
-	}
+	checkErr(t, err, "can't check self account proof")
 }
 
 func TestHandshakeSession_Encrypt_Decrypt(t *testing.T) {
@@ -241,51 +189,46 @@ func TestHandshakeSession_Encrypt_Decrypt(t *testing.T) {
 
 	// Should be able to encode the message
 	encrypted, err := hss1.Encrypt(testData1)
-	if err != nil || len(encrypted) == 0 || string(testData1) == string(encrypted) {
-		t.Fatalf("err should be nil and encrypted should not be empty, encrypted value should not be clear text")
-	}
+	checkErr(t, err)
+	assert.NotEmpty(t, encrypted)
+	assert.NotEqual(t, testData1, encrypted)
 
 	// Should decode the message properly
 	decrypted, err := hss2.Decrypt(encrypted)
-	if err != nil || string(testData1) != string(decrypted) {
-		t.Fatalf("err should be nil and decrypted should equal testData1")
-	}
+	checkErr(t, err)
+	assert.Equal(t, testData1, decrypted)
 
 	// Should not decode the message twice
 	decrypted, err = hss2.Decrypt(encrypted)
-	if err != errcode.ErrHandshakeDecrypt || string(decrypted) != "" {
-		t.Fatalf("err should be errcode.ErrHandshakeDecrypt and decrypted should be empty")
-	}
+	assert.Equal(t, errcode.ErrHandshakeDecrypt, err)
+	assert.Empty(t, decrypted)
 
 	// Should not decode a random string
 	decrypted, err = hss2.Decrypt([]byte("blahblah"))
-	if err != errcode.ErrHandshakeDecrypt || string(decrypted) != "" {
-		t.Fatalf("err should be errcode.ErrHandshakeDecrypt and decrypted should be empty")
-	}
+	testSameErrcodes(t, errcode.ErrHandshakeDecrypt, err)
+	assert.Empty(t, decrypted)
 
 	// Should be able to encode a second message
 	encrypted2, err := hss1.Encrypt(testData2)
-	if err != nil || len(encrypted2) == 0 || string(testData2) == string(encrypted2) {
-		t.Fatalf("err should be nil and encrypted2 should not be empty, encrypted2 value should not be clear text")
-	}
+	assert.NoError(t, err)
+	assert.NotEmpty(t, encrypted2)
+	assert.NotEqual(t, testData2, encrypted2)
 
 	// Should decode the second message properly
 	decrypted, err = hss2.Decrypt(encrypted2)
-	if err != nil || string(testData2) != string(decrypted) {
-		t.Fatalf("err should be nil and decrypted should equal testData2")
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, testData2, decrypted)
 
 	// Should be able to encode a message from second peer
 	encrypted3, err := hss2.Encrypt(testData3)
-	if err != nil || len(encrypted3) == 0 || string(testData3) == string(encrypted3) {
-		t.Fatalf("err should be nil and encrypted3 should not be empty, encrypted3 value should not be clear text")
-	}
+	assert.NoError(t, err)
+	assert.NotEmpty(t, encrypted3)
+	assert.NotEqual(t, testData3, encrypted3)
 
 	// Should decode the third message properly
 	decrypted, err = hss1.Decrypt(encrypted3)
-	if err != nil || string(testData3) != string(decrypted) {
-		t.Fatalf("err should be nil and decrypted should equal testData3")
-	}
+	assert.NoError(t, err)
+	assert.Equal(t, testData3, decrypted)
 }
 
 func TestHandshakeSession_Close(t *testing.T) {
@@ -293,11 +236,9 @@ func TestHandshakeSession_Close(t *testing.T) {
 	defer cancel()
 
 	hss1, _, hss2, _ := createTwoDevices(ctx, t)
-	if err := hss1.Close(); err != nil {
-		t.Fatalf("can't close hss1 properly")
-	}
+	err := hss1.Close()
+	checkErr(t, err)
 
-	if err := hss2.Close(); err != nil {
-		t.Fatalf("can't close hss2 properly")
-	}
+	err = hss2.Close()
+	checkErr(t, err)
 }

--- a/go/internal/handshake/testing_test.go
+++ b/go/internal/handshake/testing_test.go
@@ -1,0 +1,27 @@
+package handshake
+
+import (
+	"testing"
+
+	"berty.tech/berty/go/pkg/errcode"
+	"github.com/stretchr/testify/assert"
+)
+
+func checkErr(t *testing.T, err error, msgs ...interface{}) {
+	t.Helper()
+
+	if !assert.NoError(t, err, msgs...) {
+		t.Fatal("fatal")
+	}
+}
+
+func testSameErrcodes(t *testing.T, expected, got error) {
+	t.Helper()
+
+	assert.Equalf(
+		t,
+		errcode.ErrCode_name[errcode.Code(expected)],
+		errcode.ErrCode_name[errcode.Code(got)],
+		"%v", got,
+	)
+}

--- a/go/pkg/bertyprotocol/testing_test.go
+++ b/go/pkg/bertyprotocol/testing_test.go
@@ -1,34 +1,31 @@
 package bertyprotocol
 
 import (
-	"bytes"
 	"context"
-	"reflect"
 	"testing"
 
 	"berty.tech/berty/go/internal/testutil"
+	"berty.tech/berty/go/pkg/errcode"
 	"github.com/jinzhu/gorm"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTestingClient_impl(t *testing.T) {
 	client, cleanup := TestingClient(t, Opts{Logger: testutil.Logger(t)})
 	defer cleanup()
 
+	// test DB
 	db := testingClientDB(t, client)
-	if err := db.DB().Ping(); err != nil {
-		t.Fatalf("Failed to ping database: %v", err)
-	}
-	if !db.HasTable("migrations") {
-		t.Fatal("Expected table 'migrations' exists.")
-	}
+	err := db.DB().Ping()
+	assert.NoError(t, err, func() {
+		assert.True(t, db.HasTable("migrations"))
+	})
 
+	// test service
 	_, _ = client.InstanceGetConfiguration(context.Background(), &InstanceGetConfiguration_Request{})
-
 	status := client.Status()
 	expected := Status{}
-	if !reflect.DeepEqual(expected, status) {
-		t.Fatalf("Expected %v, got %v.", expected, status)
-	}
+	assert.Equal(t, expected, status)
 }
 
 func testingClientDB(t *testing.T, c Client) *gorm.DB {
@@ -41,55 +38,18 @@ func testingClientDB(t *testing.T, c Client) *gorm.DB {
 func checkErr(t *testing.T, err error) {
 	t.Helper()
 
-	if err != nil {
-		t.Fatalf("err: %v", err)
+	if !assert.NoError(t, err) {
+		t.Fatal("fatal")
 	}
 }
 
-func checkSameBytes(t *testing.T, expected, got []byte) {
+func testSameErrcodes(t *testing.T, expected, got error) {
 	t.Helper()
 
-	if !bytes.Equal(expected, got) {
-		t.Errorf("Expected %v, got %v.", expected, got)
-	}
-}
-
-func checkSameInt64s(t *testing.T, expected, got int64) {
-	t.Helper()
-
-	if expected != got {
-		t.Errorf("Expected %d, got %d.", expected, got)
-	}
-}
-
-func checkSameInts(t *testing.T, expected, got int) {
-	t.Helper()
-
-	if expected != got {
-		t.Errorf("Expected %d, got %d.", expected, got)
-	}
-}
-
-func checkSameInt32s(t *testing.T, expected, got int32) {
-	t.Helper()
-
-	if expected != got {
-		t.Errorf("Expected %d, got %d.", expected, got)
-	}
-}
-
-func checkSameDeep(t *testing.T, expected, got interface{}) {
-	t.Helper()
-
-	if !reflect.DeepEqual(expected, got) {
-		t.Errorf("Expected %v, got %v.", expected, got)
-	}
-}
-
-func checkNotNil(t *testing.T, got interface{}) {
-	t.Helper()
-
-	if got == nil {
-		t.Errorf("Expected non-nil, got nil.")
-	}
+	assert.Equalf(
+		t,
+		errcode.ErrCode_name[errcode.Code(expected)],
+		errcode.ErrCode_name[errcode.Code(got)],
+		"%v", got,
+	)
 }

--- a/go/pkg/errcode/error_test.go
+++ b/go/pkg/errcode/error_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestError(t *testing.T) {
@@ -29,115 +30,25 @@ func TestError(t *testing.T) {
 		expectedFirstCode int32
 		expectedLastCode  int32
 	}{
-		{
-			"ErrNotImplemented",
-			ErrNotImplemented,
-			"ErrNotImplemented(#777)",
-			ErrNotImplemented,
-			777,
-			777,
-			777,
-		}, {
-			"ErrInternal",
-			ErrInternal,
-			"ErrInternal(#999)",
-			ErrInternal,
-			999,
-			999,
-			999,
-		}, {
-			"ErrNotImplemented.Wrap(errStdHello)",
-			ErrNotImplemented.Wrap(errStdHello),
-			"ErrNotImplemented(#777): hello",
-			errStdHello,
-			777,
-			777,
-			777,
-		}, {
-			"ErrNotImplemented.Wrap(ErrInternal)",
-			ErrNotImplemented.Wrap(ErrInternal),
-			"ErrNotImplemented(#777): ErrInternal(#999)",
-			ErrInternal,
-			777,
-			777,
-			999,
-		}, {
-			"ErrNotImplemented.Wrap(ErrInternal.Wrap(errStdHello))",
-			ErrNotImplemented.Wrap(ErrInternal.Wrap(errStdHello)),
-			"ErrNotImplemented(#777): ErrInternal(#999): hello",
-			errStdHello,
-			777,
-			777,
-			999,
-		}, {
-			`errors.Wrap(ErrNotImplemented,blah)`,
-			errors.Wrap(ErrNotImplemented, "blah"),
-			"blah: ErrNotImplemented(#777)",
-			ErrNotImplemented,
-			-1,
-			777,
-			777,
-		}, {
-			`errors.Wrap(ErrNotImplemented.Wrap(ErrInternal),blah)`,
-			errors.Wrap(ErrNotImplemented.Wrap(ErrInternal), "blah"),
-			"blah: ErrNotImplemented(#777): ErrInternal(#999)",
-			ErrInternal,
-			-1,
-			777,
-			999,
-		}, {
-			"nil",
-			nil,
-			"<nil>",
-			nil,
-			-1,
-			-1,
-			-1,
-		}, {
-			"errStdHello",
-			errStdHello,
-			"hello",
-			errStdHello,
-			-1,
-			-1,
-			-1,
-		}, {
-			"errCodeUndef",
-			errCodeUndef,
-			"UNKNOWN_ERRCODE(#65530)",
-			errCodeUndef,
-			65530,
-			65530,
-			65530,
-		},
+		{"ErrNotImplemented", ErrNotImplemented, "ErrNotImplemented(#777)", ErrNotImplemented, 777, 777, 777},
+		{"ErrInternal", ErrInternal, "ErrInternal(#999)", ErrInternal, 999, 999, 999},
+		{"ErrNotImplemented.Wrap(errStdHello)", ErrNotImplemented.Wrap(errStdHello), "ErrNotImplemented(#777): hello", errStdHello, 777, 777, 777},
+		{"ErrNotImplemented.Wrap(ErrInternal)", ErrNotImplemented.Wrap(ErrInternal), "ErrNotImplemented(#777): ErrInternal(#999)", ErrInternal, 777, 777, 999},
+		{"ErrNotImplemented.Wrap(ErrInternal.Wrap(errStdHello))", ErrNotImplemented.Wrap(ErrInternal.Wrap(errStdHello)), "ErrNotImplemented(#777): ErrInternal(#999): hello", errStdHello, 777, 777, 999},
+		{`errors.Wrap(ErrNotImplemented,blah)`, errors.Wrap(ErrNotImplemented, "blah"), "blah: ErrNotImplemented(#777)", ErrNotImplemented, -1, 777, 777},
+		{`errors.Wrap(ErrNotImplemented.Wrap(ErrInternal),blah)`, errors.Wrap(ErrNotImplemented.Wrap(ErrInternal), "blah"), "blah: ErrNotImplemented(#777): ErrInternal(#999)", ErrInternal, -1, 777, 999},
+		{"nil", nil, "<nil>", nil, -1, -1, -1},
+		{"errStdHello", errStdHello, "hello", errStdHello, -1, -1, -1},
+		{"errCodeUndef", errCodeUndef, "UNKNOWN_ERRCODE(#65530)", errCodeUndef, 65530, 65530, 65530},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actualString := fmt.Sprint(test.input)
-			if test.expectedString != actualString {
-				t.Errorf("Expected string to be %q, got %q.", test.expectedString, actualString)
-			}
-
-			actualCode := Code(test.input)
-			if test.expectedCode != actualCode {
-				t.Errorf("Expected code to be %d, got %d.", test.expectedCode, actualCode)
-			}
-
-			actualCode = FirstCode(test.input)
-			if test.expectedFirstCode != actualCode {
-				t.Errorf("Expected first-code to be %d, got %d.", test.expectedCode, actualCode)
-			}
-
-			actualCode = LastCode(test.input)
-			if test.expectedLastCode != actualCode {
-				t.Errorf("Expected last-code to be %d, got %d.", test.expectedCode, actualCode)
-			}
-
-			actualCause := errors.Cause(test.input)
-			if test.expectedCause != actualCause {
-				t.Errorf("Expected cause to be %v, got %v.", test.expectedCause, actualCause)
-			}
+			assert.Equal(t, test.expectedString, fmt.Sprint(test.input))
+			assert.Equal(t, test.expectedCode, Code(test.input))
+			assert.Equal(t, test.expectedFirstCode, FirstCode(test.input))
+			assert.Equal(t, test.expectedLastCode, LastCode(test.input))
+			assert.Equal(t, test.expectedCause, errors.Cause(test.input))
 		})
 	}
 }


### PR DESCRIPTION
depends on #1560 

ported everything except `gormutil` and `orbitutil`