### PR TITLE
feat: semantic releases

### DIFF
--- a/.releaserc.js
+++ b/.releaserc.js
@@ -1,0 +1,8 @@
+module.exports = {
+    branch: 'master',
+    plugins: [
+        '@semantic-release/commit-analyzer',
+        '@semantic-release/release-notes-generator',
+        '@semantic-release/github',
+    ],
+};

--- a/workflows/release.yml
+++ b/workflows/release.yml
@@ -1,0 +1,13 @@
+name: Semantic Release
+
+on: push
+
+jobs:
+  semantic-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@master
+      - uses: codfish/semantic-release-action@v1
+        if: github.ref == 'refs/heads/master'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
example here of the result: https://github.com/moul/test-semantic-autotagging/

it still requires some tuning, i.e.; "chore: xxx" commits are just ignored with the default preset -> fine tuning can be done in a new PR