### PR TITLE
fix(js/go-bridge): capitalize framework dir for case-sensitive systems

### DIFF
--- a/js/packages/go-bridge/Makefile
+++ b/js/packages/go-bridge/Makefile
@@ -3,7 +3,7 @@ export PATH := $(PWD)/node_modules/.bin:$(PATH)
 
 BAZEL_FRAMEWORK := $(PWD)/bazel-bin/ios/gobridge_framework.tar.gz
 FRAMEWORK_DIR := $(PWD)/ios/Frameworks
-FRAMEWORK := $(FRAMEWORK_DIR)/bertybridge.framework
+FRAMEWORK := $(FRAMEWORK_DIR)/Bertybridge.framework
 
 BAZEL_AAR := $(PWD)/bazel-bin/android/gobridge_library.aar
 AAR_DIR := $(PWD)/android/libs


### PR DESCRIPTION
I can't build the ios app because it seems the system expect a framework named "**B**ertybridge.framework"

I guess the issue is not caught by others/CI because of cache or case-insensitive systems