### PR TITLE
feat: add 'make docker.fast args="demo"' command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
+out/
 gen.sum.tmp
-
-# junk
 profile.out
 *#
 *~

--- a/go/Makefile
+++ b/go/Makefile
@@ -64,9 +64,18 @@ docker.build: pb.generate
 	$(call check-program, docker)
 	docker build -t bertytech/berty .
 
+.PHONY: docker.fast
+docker.fast: args ?= -h
+docker.fast: run_opts ?=
+docker.fast: pb.generate
+	$(call check-program, $(GO) docker)
+	@mkdir -p out
+	GOOS=linux GOARCH=amd64 GO111MODULE=on $(GO) build -v -o ./out/berty-linux-static ./cmd/berty
+	docker run -it --rm -v $(PWD)/out/berty-linux-static:/bin/berty $(run_opts) ubuntu berty $(args)
+
 .PHONY: clean
 clean: pb.clean bazel.clean
-	rm -rf vendor/
+	rm -rf vendor/ out/
 
 .PHONY: fclean
 fclean: clean bazel.fclean

--- a/go/gen.sum
+++ b/go/gen.sum
@@ -3,4 +3,4 @@ f261ce8b5beb7a3dc25bc3dc562dc4b7122d631b  ../api/bertydemo.proto
 98410a19337dcf897f1c4860ee75d38c24209825  ../api/errcode.proto
 64164131d5e3a2ad9e6af7d8857b11a13e7bcbb4  ../api/go-internal/handshake.proto
 365bc276a7d8ccc215a0779a08aaa5cfb3fbe43e  ../api/go-internal/protocolmodel.proto
-724598116f4e4a762b84e72d206401b08d9168dd  Makefile
+4888be556b4d850225cf9b3a8faa7bc1c7f0241a  Makefile


### PR DESCRIPTION
This PR introduces a new Makefile command in the `go/` directory:

```console
$ make docker.fast 
GOOS=linux GOARCH=amd64 GO111MODULE=on go build -v -o ./out/berty-linux-static ./cmd/berty
docker run -it --rm -v /home/moul/go/src/berty.tech/berty/go/out/berty-linux-static:/bin/berty  ubuntu berty -h
USAGE
  berty [global flags] <subcommand> [flags] [args...]

SUBCOMMANDS
  daemon   
  demo     
  banner   
  version  

FLAGS
  -debug false  debug mode
$ make docker.fast args=version
GOOS=linux GOARCH=amd64 GO111MODULE=on go build -v -o ./out/berty-linux-static ./cmd/berty
docker run -it --rm -v /home/moul/go/src/berty.tech/berty/go/out/berty-linux-static:/bin/berty  ubuntu berty version
dev
$ make docker.fast args="daemon -h"
GOOS=linux GOARCH=amd64 GO111MODULE=on go build -v -o ./out/berty-linux-static ./cmd/berty
docker run -it --rm -v /home/moul/go/src/berty.tech/berty/go/out/berty-linux-static:/bin/berty  ubuntu berty daemon -h
USAGE
  berty daemon

FLAGS
  -l /ip4/127.0.0.1/tcp/9091/grpc  client listeners
  -protocol-urn :memory:           protocol sqlite URN
```

it can be particularly useful to quickly launch a big amount of `berty mini` instances with isolated networks etc

following this PR and the berty mini PR, I will try to make some "labs" that consist of docker-compose.yml file simulating different network graphs