### PR TITLE
chore: make CI fail again (always run ios-build)

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -122,7 +122,7 @@ steps:
       - "js/packages/berty-app/android/app/build/outputs/bundle/release/app-release.aab"
 
   - label: ios-build
-    if: build.branch == "master" || build.message =~ /\[run ios-build\]/i
+    #if: build.branch == "master" || build.message =~ /\[run ios-build\]/i
     agents:
       queue: "macos"
     plugins:


### PR DESCRIPTION
This PR forces the ios-build to always be executed

To merge this PR we need to fix the ios-build step before

If you want to delay this fix, feel free to merge #1688 instead

Fixes #1684
Related with #1688