### PR TITLE
chore: temporarily stop building ios-build on CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -122,7 +122,7 @@ steps:
       - "js/packages/berty-app/android/app/build/outputs/bundle/release/app-release.aab"
 
   - label: ios-build
-    if: build.branch == "master" || build.message =~ /\[run ios-build\]/i
+    if: build.message =~ /\[run ios-build\]/i
     agents:
       queue: "macos"
     plugins:


### PR DESCRIPTION
This PR temporarily disables ios-build on master, still enforceable using the `[run ios-build]` commit message

by merging this PR we go back to a green master branch and delay the actual fix to later, if you prefer to fix the root cause now, feel free to continue #1687 instead

Fixes #1684
Related with #1687