### PR TITLE
Warn user for using the v1 version.

### DIFF
--- a/core/cmd/berty/main.go
+++ b/core/cmd/berty/main.go
@@ -1,5 +1,8 @@
 package main
 
+// #warning This version is outdated please use github.com/berty/berty/v2 instead.
+import "C"
+
 import (
 	"fmt"
 	"math/rand"

--- a/core/cmd/berty/main.go
+++ b/core/cmd/berty/main.go
@@ -1,6 +1,6 @@
 package main
 
-// #warning This version is outdated please use github.com/berty/berty/v2 instead.
+// #warning This version is outdated please use berty.tech/berty/v2 instead.
 import "C"
 
 import (


### PR DESCRIPTION
Fixes #1754.5 :
```
$ go build .
# berty.tech/core/cmd/berty
./warning.go:3:3: warning: #warning This version is outdated please use github.com/berty/berty/v2 instead. [-Wcpp]
    3 | // #warning This version is outdated please use github.com/berty/berty/v2 instead.
      |   ^~~~~~~
```
It may be placed elsewhere in the repo (I would suggest to move it in the entry point of the lib) so user using `go mod` would also get the warn but I'm not sure of where it is.