### PR TITLE
fix: add top-level go package with deprecation warning

### DIFF
--- a/deprecated.go
+++ b/deprecated.go
@@ -1,0 +1,4 @@
+package main
+
+// #warning This version is outdated please use berty.tech/berty/v2 instead.
+import "C"


### PR DESCRIPTION
continues #1772 