### PR TITLE
fix: Moving depreacation in node for go mod user.

### DIFF
--- a/core/cmd/berty/main.go
+++ b/core/cmd/berty/main.go
@@ -1,8 +1,5 @@
 package main
 
-// #warning This version is outdated please use berty.tech/berty/v2 instead.
-import "C"
-
 import (
 	"fmt"
 	"math/rand"

--- a/core/node/node.go
+++ b/core/node/node.go
@@ -1,5 +1,8 @@
 package node
 
+// #warning This version is outdated please use berty.tech/berty/v2 instead.
+import "C"
+
 import (
 	"context"
 	"encoding/base64"


### PR DESCRIPTION
This place is better because we are sure everyone is gonna be warned, someone using it as a lib (which for the first version its very improbable) is still gonna see the error message.