### PR TITLE
fix: launch error because of bluetooth privilege required

### DIFF
--- a/client/ios/Berty/Info.plist
+++ b/client/ios/Berty/Info.plist
@@ -46,6 +46,8 @@
 			</dict>
 		</dict>
 	</dict>
+	<key>NSBluetoothAlwaysUsageDescription</key>
+	<string>Berty would like to access your bluetooth</string>
 	<key>NSBluetoothPeripheralUsageDescription</key>
 	<string>Berty would like to access your bluetooth</string>
 	<key>NSCameraUsageDescription</key>


### PR DESCRIPTION
When launching the app, an error occurred at startup:
```
This app has crashed because it attempted to access privacy-sensitive data without a usage description.  The app's Info.plist must contain an NSBluetoothAlwaysUsageDescription key with a string value explaining to the user how the app uses this data.
```

According to this error message, I add that key to Info.plist.