### PR TITLE
feat(tool): berty mini cluster with tmux

### DIFF
--- a/go/cmd/berty/mini/main.go
+++ b/go/cmd/berty/mini/main.go
@@ -100,6 +100,9 @@ func Main(opts *Opts) {
 				panic(err)
 			}
 		}
+
+		// if at least a group is specified, switch the active view to the first one
+		tabbedView.NextGroup()
 	}
 
 	input := tview.NewInputField().

--- a/tool/berty-mini-cluster/commander
+++ b/tool/berty-mini-cluster/commander
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+if [ ! -f .env ]; then
+    echo "GRP_KEY=`berty groupinit`" > .env
+fi
+
+TMUX=                                                                                       `# force TMUX to run, even if nested` \
+    tmux \
+    new-session ". .env && berty mini -g \$GRP_KEY; read" \;                                 `# run a simple instance` \
+    split-window ". .env && docker run -it --rm bertytech/berty mini -g \$GRP_KEY; read" \;  `# run an instance within docker` \
+    split-window "docker-compose run aaron; read" \;                                         `# run an instance within docker-compose` \
+    split-window "docker-compose run betty; read" \;                                         `# run an instance within docker-compose` \
+    split-window "docker-compose run chris; read" \;                                         `# run an instance within docker-compose` \
+    select-layout even-vertical

--- a/tool/berty-mini-cluster/commander
+++ b/tool/berty-mini-cluster/commander
@@ -21,7 +21,7 @@ fi
 
 # cleanup and warm up docker-compose before starting
 docker network rm $(docker network ls | grep berty-mini-cluster | awk '{print $1}') 2>/dev/null
-docker-compose create
+docker-compose up --no-start
 
 # cleanup
 function cleanup {
@@ -30,11 +30,13 @@ function cleanup {
 trap cleanup EXIT
 
 # the tmux
-TMUX=                                                                                             `# force TMUX to run, even if nested` \
+TMUX=                                                                                                                      `# force TMUX to run, even if nested` \
     tmux \
-    new-session "source .env && berty mini -g \$GRP_KEY; read" \;                                 `# run a simple instance` \
-    split-window "source .env && docker run -it --rm bertytech/berty mini -g \$GRP_KEY; read" \;  `# run an instance within docker` \
-    split-window "docker-compose run aaron; read" \;                                              `# run an instance within docker-compose` \
-    split-window "sleep 1; docker-compose run betty; read" \;                                     `# run an instance within docker-compose` \
-    split-window "sleep 1; docker-compose run chris; read" \;                                     `# run an instance within docker-compose` \
-    select-layout even-vertical
+    new-session "source .env && berty mini -g \$GRP_KEY; read" \; select-pane -T no-docker \;                              `# run a simple instance` \
+    split-window "source .env && docker run -it --rm bertytech/berty mini -g \$GRP_KEY; read" \; select-pane -T docker \;  `# run an instance within docker` \
+    split-window "docker-compose run aaron; read" \; select-pane -T compose-aaron \;                                       `# run instances within docker-compose` \
+    split-window "docker-compose run betty; read" \; select-pane -T compose-betty \; \
+    split-window "docker-compose run chris; read" \; select-pane -T compose-chris \; \
+    select-layout even-vertical \;                                                                                         `# tmux styling` \
+    set pane-border-status top \; \
+    set pane-border-format "#{pane_index} #{pane_current_command} #{pane_title}"

--- a/tool/berty-mini-cluster/commander
+++ b/tool/berty-mini-cluster/commander
@@ -1,14 +1,40 @@
-#!/bin/sh
+#!/bin/bash
 
+# check deps
+if ! [ -x "$(command -v berty)" ]; then
+    echo "Error: 'berty' not found, you need to compile it before running this script." >&2
+    exit 1
+fi
+if ! [ -x "$(command -v docker)" ]; then
+    echo "Error: 'docker' is not installed." >&2
+    exit 1
+fi
+if ! [ -x "$(command -v docker-compose)" ]; then
+    echo "Error: 'docker-compose' is not installed." >&2
+    exit 1
+fi
+
+# init env
 if [ ! -f .env ]; then
     echo "GRP_KEY=`berty groupinit`" > .env
 fi
 
-TMUX=                                                                                       `# force TMUX to run, even if nested` \
+# cleanup and warm up docker-compose before starting
+docker network rm $(docker network ls | grep berty-mini-cluster | awk '{print $1}') 2>/dev/null
+docker-compose create
+
+# cleanup
+function cleanup {
+    docker-compose down >/dev/null 2>/dev/null
+}
+trap cleanup EXIT
+
+# the tmux
+TMUX=                                                                                             `# force TMUX to run, even if nested` \
     tmux \
-    new-session ". .env && berty mini -g \$GRP_KEY; read" \;                                 `# run a simple instance` \
-    split-window ". .env && docker run -it --rm bertytech/berty mini -g \$GRP_KEY; read" \;  `# run an instance within docker` \
-    split-window "docker-compose run aaron; read" \;                                         `# run an instance within docker-compose` \
-    split-window "docker-compose run betty; read" \;                                         `# run an instance within docker-compose` \
-    split-window "docker-compose run chris; read" \;                                         `# run an instance within docker-compose` \
+    new-session "source .env && berty mini -g \$GRP_KEY; read" \;                                 `# run a simple instance` \
+    split-window "source .env && docker run -it --rm bertytech/berty mini -g \$GRP_KEY; read" \;  `# run an instance within docker` \
+    split-window "docker-compose run aaron; read" \;                                              `# run an instance within docker-compose` \
+    split-window "sleep 1; docker-compose run betty; read" \;                                     `# run an instance within docker-compose` \
+    split-window "sleep 1; docker-compose run chris; read" \;                                     `# run an instance within docker-compose` \
     select-layout even-vertical

--- a/tool/berty-mini-cluster/docker-compose.yml
+++ b/tool/berty-mini-cluster/docker-compose.yml
@@ -1,0 +1,42 @@
+version: '3.7'
+
+# 5 letter names found on http://www.babynamescience.com/baby-names-by-length/5-letter-boy-baby-names
+
+x-common: &common
+  image: bertytech/berty
+  environment:
+    - GRP_KEY
+  command: 'mini -g $GRP_KEY'
+
+services:
+  aaron:
+    <<: *common
+  betty:
+    <<: *common
+    network_mode: host
+  chris:
+    <<: *common
+    network_mode: bridge
+  #diane
+  #emily
+  #frank
+  #greta
+  #helen
+  #irene
+  #james
+  #karen
+  #linda
+  #maria
+  #nancy
+  #oscar
+  #peter
+  #quinn
+  #riley
+  #susan
+  #tyler
+  #uriel
+  #venus
+  #willy
+  #xenia
+  #yoana
+  #zooey


### PR DESCRIPTION
This PR bootstraps the mini tool `./tool/berty-mini-cluster` which allows starting `berty mini` under various contexts (with/without docker, with/without network bridge, etc)

The current state is relatively poor in term of use cases, but can easily be updated as soon as we find new testing ideas

Replaces #1748