### PR TITLE
refactor: disambiguate rand packages and reorganize cryptoutil

### DIFF
--- a/go/cmd/berty/main.go
+++ b/go/cmd/berty/main.go
@@ -6,7 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"math/rand"
+	mrand "math/rand"
 	"net"
 	"os"
 	"path"
@@ -20,7 +20,7 @@ import (
 	"berty.tech/berty/v2/go/pkg/bertyprotocol"
 	"berty.tech/berty/v2/go/pkg/errcode"
 	"berty.tech/go-orbit-db/cache/cacheleveldown"
-	"github.com/ipfs/go-datastore"
+	datastore "github.com/ipfs/go-datastore"
 	sync_ds "github.com/ipfs/go-datastore/sync"
 	badger "github.com/ipfs/go-ds-badger"
 	"github.com/juju/fslock"
@@ -60,7 +60,7 @@ func main() {
 	)
 
 	globalPreRun := func() error {
-		rand.Seed(srand.Secure())
+		mrand.Seed(srand.Secure())
 		if *globalDebug {
 			config := zap.NewDevelopmentConfig()
 			config.Level.SetLevel(zap.DebugLevel)

--- a/go/cmd/rdvp/main.go
+++ b/go/cmd/rdvp/main.go
@@ -5,7 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"log"
-	"math/rand"
+	mrand "math/rand"
 	"net"
 	"os"
 	"strings"
@@ -42,7 +42,7 @@ func main() {
 	)
 
 	globalPreRun := func() error {
-		rand.Seed(srand.Secure())
+		mrand.Seed(srand.Secure())
 		if *globalDebug {
 			config := zap.NewDevelopmentConfig()
 			config.Level.SetLevel(zap.DebugLevel)

--- a/go/internal/banner/quote.go
+++ b/go/internal/banner/quote.go
@@ -2,7 +2,7 @@ package banner
 
 import (
 	"fmt"
-	"math/rand"
+	mrand "math/rand"
 	"time"
 )
 
@@ -27,13 +27,13 @@ var quotes = []Quote{
 }
 
 func RandomQuote() Quote {
-	return quotes[rand.Intn(len(quotes))]
+	return quotes[mrand.Intn(len(quotes))]
 }
 
 func QOTD() Quote {
 	base := time.Date(2000, time.January, 1, 0, 0, 0, 0, time.UTC) // FIXME: use local timezone if available
 	seed := time.Now().Sub(base).Hours() / 24
-	r := rand.New(rand.NewSource(int64(seed)))
+	r := mrand.New(mrand.NewSource(int64(seed)))
 	return quotes[r.Intn(len(quotes))]
 }
 

--- a/go/internal/cryptoutil/cryptoutil.go
+++ b/go/internal/cryptoutil/cryptoutil.go
@@ -1,12 +1,69 @@
 package cryptoutil
 
 import (
+	crand "crypto/rand"
+	"crypto/sha256"
+	"fmt"
+
 	"berty.tech/berty/v2/go/pkg/errcode"
+
 	cconv "github.com/agl/ed25519/extra25519"
 	"github.com/libp2p/go-libp2p-core/crypto"
 	pb "github.com/libp2p/go-libp2p-core/crypto/pb"
 	"golang.org/x/crypto/ed25519"
 )
+
+const (
+	KeySize   = 32 // Key size required by box
+	NonceSize = 24 // Nonce size required by box
+)
+
+func ConcatAndHashSha256(slices ...[]byte) *[sha256.Size]byte {
+	var concat []byte
+
+	for _, slice := range slices {
+		concat = append(concat, slice...)
+	}
+	checksum := sha256.Sum256(concat)
+
+	return &checksum
+}
+
+func GenerateNonce() (*[NonceSize]byte, error) {
+	var nonce [NonceSize]byte
+
+	size, err := crand.Read(nonce[:])
+	if size != NonceSize {
+		err = fmt.Errorf("size read: %d (required %d)", size, NonceSize)
+	}
+	if err != nil {
+		return nil, errcode.ErrCryptoRandomGeneration.Wrap(err)
+	}
+
+	return &nonce, nil
+}
+
+func NonceSliceToArray(nonceSlice []byte) (*[NonceSize]byte, error) {
+	var nonceArray [NonceSize]byte
+
+	if len(nonceSlice) != NonceSize {
+		return nil, errcode.ErrInvalidInput
+	}
+	copy(nonceArray[:], nonceSlice)
+
+	return &nonceArray, nil
+}
+
+func KeySliceToArray(keySlice []byte) (*[KeySize]byte, error) {
+	var keyArray [KeySize]byte
+
+	if len(keySlice) != KeySize {
+		return nil, errcode.ErrInvalidInput
+	}
+	copy(keyArray[:], keySlice)
+
+	return &keyArray, nil
+}
 
 func SeedFromEd25519PrivateKey(key crypto.PrivKey) ([]byte, error) {
 	// Similar to (*ed25519).Seed()
@@ -26,36 +83,64 @@ func SeedFromEd25519PrivateKey(key crypto.PrivKey) ([]byte, error) {
 	return r[:ed25519.PrivateKeySize-ed25519.PublicKeySize], nil
 }
 
-// EdwardsToMontgomery converts ed25519 keys to curve25519 keys
+// EdwardsToMontgomery converts ed25519 priv/pub keys to X25519 keys
 func EdwardsToMontgomery(privKey crypto.PrivKey, pubKey crypto.PubKey) (*[32]byte, *[32]byte, error) {
-	var edPriv [64]byte
-	var edPub, mongPriv, mongPub [32]byte
-
-	if privKey.Type() != pb.KeyType_Ed25519 || pubKey.Type() != pb.KeyType_Ed25519 {
-		return nil, nil, errcode.ErrInvalidInput
+	mongPriv, err := EdwardsToMontgomeryPriv(privKey)
+	if err != nil {
+		return nil, nil, err
 	}
 
-	privKeyBytes, err := privKey.Raw()
+	mongPub, err := EdwardsToMontgomeryPub(pubKey)
 	if err != nil {
-		return nil, nil, errcode.ErrSerialization.Wrap(err)
-	} else if len(privKeyBytes) != 64 {
-		return nil, nil, errcode.ErrInvalidInput
+		return nil, nil, err
+	}
+
+	return mongPriv, mongPub, nil
+}
+
+// EdwardsToMontgomeryPub converts ed25519 pub key to X25519 pub key
+func EdwardsToMontgomeryPub(pubKey crypto.PubKey) (*[KeySize]byte, error) {
+	var edPub, mongPub [KeySize]byte
+
+	if pubKey.Type() != pb.KeyType_Ed25519 {
+		return nil, errcode.ErrInvalidInput
 	}
 
 	pubKeyBytes, err := pubKey.Raw()
 	if err != nil {
-		return nil, nil, errcode.ErrSerialization.Wrap(err)
-	} else if len(pubKeyBytes) != 32 {
-		return nil, nil, errcode.ErrInvalidInput
+		return nil, errcode.ErrSerialization.Wrap(err)
+	} else if len(pubKeyBytes) != KeySize {
+		return nil, errcode.ErrInvalidInput
+	}
+
+	copy(edPub[:], pubKeyBytes)
+
+	if !cconv.PublicKeyToCurve25519(&mongPub, &edPub) {
+		return nil, errcode.ErrInvalidInput.Wrap(err)
+	}
+
+	return &mongPub, nil
+}
+
+// EdwardsToMontgomeryPriv converts ed25519 priv key to X25519 priv key
+func EdwardsToMontgomeryPriv(privKey crypto.PrivKey) (*[KeySize]byte, error) {
+	var edPriv [64]byte
+	var mongPriv [KeySize]byte
+
+	if privKey.Type() != pb.KeyType_Ed25519 {
+		return nil, errcode.ErrInvalidInput
+	}
+
+	privKeyBytes, err := privKey.Raw()
+	if err != nil {
+		return nil, errcode.ErrSerialization.Wrap(err)
+	} else if len(privKeyBytes) != 64 {
+		return nil, errcode.ErrInvalidInput
 	}
 
 	copy(edPriv[:], privKeyBytes)
-	copy(edPub[:], pubKeyBytes)
 
 	cconv.PrivateKeyToCurve25519(&mongPriv, &edPriv)
-	if !cconv.PublicKeyToCurve25519(&mongPub, &edPub) {
-		return nil, nil, errcode.ErrCryptoKeyConversion.Wrap(err)
-	}
 
-	return &mongPriv, &mongPub, nil
+	return &mongPriv, nil
 }

--- a/go/internal/ipfsutil/api_inmemory.go
+++ b/go/internal/ipfsutil/api_inmemory.go
@@ -2,7 +2,7 @@ package ipfsutil
 
 import (
 	"context"
-	"crypto/rand"
+	crand "crypto/rand"
 	"encoding/base64"
 
 	"berty.tech/berty/v2/go/pkg/errcode"
@@ -54,7 +54,7 @@ func createBuildConfig(listeners ...string) (*ipfs_node.BuildCfg, error) {
 
 func createRepo(dstore ipfs_repo.Datastore, listeners ...string) (ipfs_repo.Repo, error) {
 	c := ipfs_cfg.Config{}
-	priv, pub, err := libp2p_ci.GenerateKeyPairWithReader(libp2p_ci.RSA, 2048, rand.Reader) // nolint:staticcheck
+	priv, pub, err := libp2p_ci.GenerateKeyPairWithReader(libp2p_ci.RSA, 2048, crand.Reader) // nolint:staticcheck
 	if err != nil {
 		return nil, errcode.TODO.Wrap(err)
 	}

--- a/go/internal/ipfsutil/cfg.go
+++ b/go/internal/ipfsutil/cfg.go
@@ -1,7 +1,7 @@
 package ipfsutil
 
 import (
-	"crypto/rand"
+	crand "crypto/rand"
 	"encoding/base64"
 	"fmt"
 	"math/big"
@@ -49,7 +49,7 @@ func CreateBuildConfigWithDatastore(opts *BuildOpts, ds ipfs_datastore.Batching)
 
 func CreateRepo(dstore ipfs_datastore.Batching, opts *BuildOpts) (ipfs_repo.Repo, error) {
 	c := ipfs_cfg.Config{}
-	priv, pub, err := libp2p_ci.GenerateKeyPairWithReader(libp2p_ci.RSA, 2048, rand.Reader) // nolint:staticcheck
+	priv, pub, err := libp2p_ci.GenerateKeyPairWithReader(libp2p_ci.RSA, 2048, crand.Reader) // nolint:staticcheck
 	if err != nil {
 		return nil, errcode.TODO.Wrap(err)
 	}
@@ -69,7 +69,7 @@ func CreateRepo(dstore ipfs_datastore.Batching, opts *BuildOpts) (ipfs_repo.Repo
 	if len(opts.SwarmAddresses) != 0 {
 		c.Addresses.Swarm = opts.SwarmAddresses
 	} else {
-		portOffsetBI, err := rand.Int(rand.Reader, big.NewInt(100))
+		portOffsetBI, err := crand.Int(crand.Reader, big.NewInt(100))
 		if err != nil {
 			return nil, errcode.TODO.Wrap(err)
 		}

--- a/go/internal/ipfsutil/testing.go
+++ b/go/internal/ipfsutil/testing.go
@@ -2,7 +2,7 @@ package ipfsutil
 
 import (
 	"context"
-	"crypto/rand"
+	crand "crypto/rand"
 	"encoding/base64"
 	"testing"
 
@@ -34,7 +34,7 @@ func TestingRepo(t testing.TB) ipfs_repo.Repo {
 	t.Helper()
 
 	c := ipfs_cfg.Config{}
-	priv, pub, err := libp2p_ci.GenerateKeyPairWithReader(libp2p_ci.RSA, 2048, rand.Reader)
+	priv, pub, err := libp2p_ci.GenerateKeyPairWithReader(libp2p_ci.RSA, 2048, crand.Reader)
 	if err != nil {
 		t.Fatalf("failed to generate pair key: %v", err)
 	}

--- a/go/internal/tinder/driver_rdv.go
+++ b/go/internal/tinder/driver_rdv.go
@@ -6,7 +6,7 @@ package tinder
 import (
 	"context"
 	"math"
-	"math/rand"
+	mrand "math/rand"
 	"sync"
 	"time"
 
@@ -21,7 +21,7 @@ type rendezvousDiscovery struct {
 	rp           p2p_rp.RendezvousPoint
 	peerCache    map[string]*rpCache
 	peerCacheMux sync.RWMutex
-	rng          *rand.Rand
+	rng          *mrand.Rand
 	rngMux       sync.Mutex
 }
 
@@ -36,7 +36,7 @@ type rpRecord struct {
 	expire int64
 }
 
-func NewRendezvousDiscovery(host host.Host, rdvPeer peer.ID, rng *rand.Rand) Driver {
+func NewRendezvousDiscovery(host host.Host, rdvPeer peer.ID, rng *mrand.Rand) Driver {
 	rp := p2p_rp.NewRendezvousPoint(host, rdvPeer)
 	return &rendezvousDiscovery{
 		rp:        rp,

--- a/go/pkg/bertydemo/client.go
+++ b/go/pkg/bertydemo/client.go
@@ -2,7 +2,7 @@ package bertydemo
 
 import (
 	"context"
-	"crypto/rand"
+	crand "crypto/rand"
 	"encoding/hex"
 	"encoding/json"
 	"sync"
@@ -128,7 +128,7 @@ func (d *Client) logFromToken(ctx context.Context, token string) (orbitdb.EventL
 }
 
 func (d *Client) LogToken(ctx context.Context, _ *LogToken_Request) (*LogToken_Reply, error) {
-	sigk, _, err := crypto.GenerateEd25519Key(rand.Reader)
+	sigk, _, err := crypto.GenerateEd25519Key(crand.Reader)
 	if err != nil {
 		return nil, errcode.TODO.Wrap(err)
 	}

--- a/go/pkg/bertyprotocol/group.go
+++ b/go/pkg/bertyprotocol/group.go
@@ -327,7 +327,7 @@ func openDeviceSecret(m *bertytypes.GroupMetadata, localMemberPrivateKey crypto.
 	return senderDevicePubKey, decryptedSecret, nil
 }
 
-func groupIDToNonce(group *bertytypes.Group) (*[24]byte, error) {
+func groupIDToNonce(group *bertytypes.Group) (*[cryptoutil.NonceSize]byte, error) {
 	// Nonce doesn't need to be secret, random nor unpredictable, it just needs
 	// to be used only once for a given {sender, receiver} set and we will send
 	// only one SecretEntryPayload per {localDevicePrivKey, remoteMemberPubKey}
@@ -336,7 +336,7 @@ func groupIDToNonce(group *bertytypes.Group) (*[24]byte, error) {
 	//
 	// See https://pynacl.readthedocs.io/en/stable/secret/#nonce
 	// See Security Model here: https://nacl.cr.yp.to/box.html
-	var nonce [24]byte
+	var nonce [cryptoutil.NonceSize]byte
 
 	gid := group.GetPublicKey()
 

--- a/go/pkg/bertyprotocol/group.go
+++ b/go/pkg/bertyprotocol/group.go
@@ -3,7 +3,7 @@ package bertyprotocol
 import (
 	"context"
 	"crypto/ed25519"
-	"crypto/rand"
+	crand "crypto/rand"
 	"crypto/sha256"
 	"io"
 	"io/ioutil"
@@ -23,7 +23,7 @@ const CurrentGroupVersion = 1
 // NewGroupMultiMember creates a new Group object and an invitation to be used by
 // the first member of the group
 func NewGroupMultiMember() (*bertytypes.Group, crypto.PrivKey, error) {
-	priv, pub, err := crypto.GenerateEd25519Key(rand.Reader)
+	priv, pub, err := crypto.GenerateEd25519Key(crand.Reader)
 	if err != nil {
 		return nil, nil, errcode.ErrCryptoKeyGeneration.Wrap(err)
 	}
@@ -33,7 +33,7 @@ func NewGroupMultiMember() (*bertytypes.Group, crypto.PrivKey, error) {
 		return nil, nil, errcode.ErrSerialization.Wrap(err)
 	}
 
-	signing, _, err := crypto.GenerateEd25519Key(rand.Reader)
+	signing, _, err := crypto.GenerateEd25519Key(crand.Reader)
 	if err != nil {
 		return nil, nil, errcode.ErrCryptoKeyGeneration.Wrap(err)
 	}

--- a/go/pkg/bertyprotocol/group_test.go
+++ b/go/pkg/bertyprotocol/group_test.go
@@ -1,7 +1,7 @@
 package bertyprotocol
 
 import (
-	"crypto/rand"
+	crand "crypto/rand"
 	"testing"
 
 	"berty.tech/berty/v2/go/pkg/bertytypes"
@@ -10,7 +10,7 @@ import (
 )
 
 func TestGetGroupForContact(t *testing.T) {
-	sk, _, err := crypto.GenerateEd25519Key(rand.Reader)
+	sk, _, err := crypto.GenerateEd25519Key(crand.Reader)
 	require.NoError(t, err)
 
 	g, err := getGroupForContact(sk)
@@ -22,7 +22,7 @@ func TestGetGroupForContact(t *testing.T) {
 }
 
 func TestGetKeysForGroupOfContact(t *testing.T) {
-	sk, _, err := crypto.GenerateEd25519Key(rand.Reader)
+	sk, _, err := crypto.GenerateEd25519Key(crand.Reader)
 	require.NoError(t, err)
 
 	sk1, sk2, err := getKeysForGroupOfContact(sk)

--- a/go/pkg/bertyprotocol/orbitdb_many_adds_test.go
+++ b/go/pkg/bertyprotocol/orbitdb_many_adds_test.go
@@ -2,7 +2,7 @@ package bertyprotocol
 
 import (
 	"context"
-	"crypto/rand"
+	crand "crypto/rand"
 	"fmt"
 	"os"
 	"testing"
@@ -36,7 +36,7 @@ func TestAdd(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	sigk, _, err := crypto.GenerateEd25519Key(rand.Reader)
+	sigk, _, err := crypto.GenerateEd25519Key(crand.Reader)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/go/pkg/bertyprotocol/store_metadata.go
+++ b/go/pkg/bertyprotocol/store_metadata.go
@@ -2,7 +2,7 @@ package bertyprotocol
 
 import (
 	"context"
-	"crypto/rand"
+	crand "crypto/rand"
 	"io"
 	"io/ioutil"
 
@@ -454,7 +454,7 @@ func (m *metadataStore) ContactRequestReferenceReset(ctx context.Context) (opera
 		return nil, errcode.ErrGroupInvalidType
 	}
 
-	seed, err := ioutil.ReadAll(io.LimitReader(rand.Reader, bertytypes.RendezvousSeedLength))
+	seed, err := ioutil.ReadAll(io.LimitReader(crand.Reader, bertytypes.RendezvousSeedLength))
 	if err != nil {
 		return nil, errcode.ErrCryptoKeyGeneration.Wrap(err)
 	}

--- a/go/pkg/bertyprotocol/store_metadata_test.go
+++ b/go/pkg/bertyprotocol/store_metadata_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	crand "crypto/rand"
 	"fmt"
-	"math/rand"
+	mrand "math/rand"
 	"testing"
 	"time"
 
@@ -74,7 +74,7 @@ func TestMetadataStoreMember(t *testing.T) {
 
 	// If seed is not set, it will default to 1, explicitly setting it and displaying it if the test fails
 	seed := time.Now().UTC().UnixNano()
-	rand.Seed(seed)
+	mrand.Seed(seed)
 
 	for _, tc := range []struct {
 		memberCount int


### PR DESCRIPTION
This PR:
- Moves all common crypto utils in cryptoutil internal package
- Refactores methods that were using these utils
- Aliases `math/rand` -> `mrand` and `crypto/rand` -> `crand` to disambiguate the random source when reading the code