### PR TITLE
Some Makefile rules doesn't works inside the go folder

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -16,6 +16,22 @@ check-program = $(foreach exec,$(1),$(if $(shell PATH="$(PATH)" which $(exec)),,
 ## General rules
 ##
 
+.PHONY: build
+build:
+	$(MAKE) -C .. bazel.build
+
+.PHONY: run
+run:
+	$(MAKE) -C .. bazel.daemon
+
+.PHONY: dev
+dev:
+	$(MAKE) -C .. ibazel.daemon
+
+.PHONY: autotest
+autotest:
+	$(MAKE) -C .. ibazel.unittest
+
 .PHONY: unittest
 unittest: go.unittest
 
@@ -28,9 +44,11 @@ install: go.install
 .PHONY: clean
 clean: pb.clean
 	rm -rf vendor/ out/
+	$(MAKE) -C .. bazel.clean
 
 .PHONY: fclean
 fclean: clean
+	$(MAKE) -C .. bazel.fclean
 
 .PHONY: re
 re: clean build

--- a/go/Makefile
+++ b/go/Makefile
@@ -16,64 +16,28 @@ check-program = $(foreach exec,$(1),$(if $(shell PATH="$(PATH)" which $(exec)),,
 ## General rules
 ##
 
-.PHONY: install
-install: go.install
-
-.PHONY: build
-build: bazel.build
-
-.PHONY: run
-run: bazel.daemon
-
-.PHONY: dev
-dev: ibazel.daemon
-
-.PHONY: test
-test: unittest lint tidy
-
-.PHONY: lint
-lint: go.lint
-
-.PHONY: autotest
-autotest: ibazel.unittest
-
 .PHONY: unittest
 unittest: go.unittest
 
 .PHONY: generate
 generate: pb.generate
 
-.PHONY: tidy
-tidy: pb.generate
-	$(call check-program, $(GO))
-	GO111MODULE=on $(GO) mod tidy
-
-.PHONY: docker.build
-docker.build: pb.generate
-	$(call check-program, docker)
-	docker build -t bertytech/berty ..
-
-.PHONY: docker.fast
-docker.fast: args ?= -h
-docker.fast: run_opts ?=
-docker.fast: pb.generate
-	$(call check-program, $(GO) docker)
-	@mkdir -p out
-	GOOS=linux GOARCH=amd64 GO111MODULE=on $(GO) build -v -o ./out/berty-linux-static ./cmd/berty
-	docker run -it --rm -v $(PWD)/out/berty-linux-static:/bin/berty $(run_opts) ubuntu berty $(args)
+.PHONY: install
+install: go.install
 
 .PHONY: clean
-clean: pb.clean bazel.clean
+clean: pb.clean
 	rm -rf vendor/ out/
 
 .PHONY: fclean
-fclean: clean bazel.fclean
+fclean: clean
 
 .PHONY: re
 re: clean build
 
+
 ##
-## Go rules (without bazel)
+## Go rules
 ##
 
 .PHONY: go.lint
@@ -101,6 +65,31 @@ go.unittest.watch:
 go.install: pb.generate
 	$(call check-program, $(GO))
 	GO111MODULE=on $(GO) install -v ./cmd/...
+
+.PHONY: test
+test: unittest lint tidy
+
+.PHONY: lint
+lint: go.lint
+
+.PHONY: tidy
+tidy: pb.generate
+	$(call check-program, $(GO))
+	GO111MODULE=on $(GO) mod tidy
+
+.PHONY: docker.build
+docker.build: pb.generate
+	$(call check-program, docker)
+	docker build -t bertytech/berty ..
+
+.PHONY: docker.fast
+docker.fast: args ?= -h
+docker.fast: run_opts ?=
+docker.fast: pb.generate
+	$(call check-program, $(GO) docker)
+	@mkdir -p out
+	GOOS=linux GOARCH=amd64 GO111MODULE=on $(GO) build -v -o ./out/berty-linux-static ./cmd/berty
+	docker run -it --rm -v $(PWD)/out/berty-linux-static:/bin/berty $(run_opts) ubuntu berty $(args)
 
 ##
 ## Code gen

--- a/go/gen.sum
+++ b/go/gen.sum
@@ -3,4 +3,4 @@ f261ce8b5beb7a3dc25bc3dc562dc4b7122d631b  ../api/bertydemo.proto
 4cb5e151cf454bf18652eb46e95c77eac1f49800  ../api/bertytypes.proto
 be73e02731d03057fa2d8a7faacfc54aa574ed68  ../api/errcode.proto
 5589d560e33f2da4a466ad965eb9c8bd3d7612cd  ../api/go-internal/handshake.proto
-62e7fff083d975e103983ca97e32ec46ee15e3d8  Makefile
+98754afd30c337b4cfadf47033c082140069d951  Makefile

--- a/go/gen.sum
+++ b/go/gen.sum
@@ -3,4 +3,4 @@ f261ce8b5beb7a3dc25bc3dc562dc4b7122d631b  ../api/bertydemo.proto
 4cb5e151cf454bf18652eb46e95c77eac1f49800  ../api/bertytypes.proto
 be73e02731d03057fa2d8a7faacfc54aa574ed68  ../api/errcode.proto
 5589d560e33f2da4a466ad965eb9c8bd3d7612cd  ../api/go-internal/handshake.proto
-c971ac227c814f19b89412b1e6850725d8720c5c  Makefile
+62e7fff083d975e103983ca97e32ec46ee15e3d8  Makefile


### PR DESCRIPTION
Some makefile rules that depends on bazel doesn't works anymore
fix #1804