### PR TITLE
chore: add rdvp deployment helpers + configure docker to use host network

### DIFF
--- a/deployments/rdvp-dev/Makefile
+++ b/deployments/rdvp-dev/Makefile
@@ -9,3 +9,9 @@ logs:
 
 down:
 	docker-compose down
+
+genkey:
+	echo RDVP_PK=`docker-compose run server genkey` > .env
+
+ip:
+	curl ifconfig.co

--- a/deployments/rdvp-dev/docker-compose.yml
+++ b/deployments/rdvp-dev/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     environment:
       - RDVP_PK # loaded from .env
     entrypoint: rdvp
+    network_mode: host
     labels:
       com.centurylinklabs.watchtower.enable: "true"
     command:


### PR DESCRIPTION
First deployment here: `/ip4/167.99.223.55/tcp/4040/p2p/QmTo3RS6Uc8aCS5Cxx8EBHkNCe4C7vKRanbMEboxkA92Cn`

[DNSADDR](https://github.com/multiformats/multiaddr/blob/master/protocols/DNSADDR.md) configured: `/dnsaddr/rdvp.berty.io`