### PR TITLE
feat(protocol): replace service with grpc client

### DIFF
--- a/go/.golangci.yml
+++ b/go/.golangci.yml
@@ -4,6 +4,7 @@ run:
   skip-files:
     - ".*\\.pb\\.go"
     - ".*\\.gen\\.go"
+    - "testing.go"
 
 linters-settings:
   golint:

--- a/go/cmd/berty/main.go
+++ b/go/cmd/berty/main.go
@@ -182,13 +182,16 @@ func main() {
 
 				deviceDS := ipfsutil.NewDatastoreKeystore(ipfsutil.NewNamespacedDatastore(rootDS, datastore.NewKey("account")))
 
+				mk := bertyprotocol.NewMessageKeystore(ipfsutil.NewNamespacedDatastore(rootDS, datastore.NewKey("messages")))
+
 				// initialize new protocol client
 				opts := bertyprotocol.Opts{
-					IpfsCoreAPI:    api,
-					Logger:         logger.Named("bertyprotocol"),
-					RootDatastore:  rootDS,
-					DeviceKeystore: bertyprotocol.NewDeviceKeystore(deviceDS),
-					OrbitCache:     bertyprotocol.NewOrbitDatastoreCache(ipfsutil.NewNamespacedDatastore(rootDS, datastore.NewKey("orbitdb"))),
+					IpfsCoreAPI:     api,
+					Logger:          logger.Named("bertyprotocol"),
+					RootDatastore:   rootDS,
+					MessageKeystore: mk,
+					DeviceKeystore:  bertyprotocol.NewDeviceKeystore(deviceDS),
+					OrbitCache:      bertyprotocol.NewOrbitDatastoreCache(ipfsutil.NewNamespacedDatastore(rootDS, datastore.NewKey("orbitdb"))),
 				}
 				protocol, err = bertyprotocol.New(opts)
 				if err != nil {

--- a/go/cmd/berty/main.go
+++ b/go/cmd/berty/main.go
@@ -223,15 +223,15 @@ func main() {
 				grpc_zap.ReplaceGrpcLoggerV2(grpcLogger)
 				grpcServer := grpc.NewServer(
 					grpc_middleware.WithUnaryServerChain(
+						grpc_recovery.UnaryServerInterceptor(recoverOpts...),
 						grpc_ctxtags.UnaryServerInterceptor(grpc_ctxtags.WithFieldExtractor(grpc_ctxtags.CodeGenRequestFieldExtractor)),
 
 						grpc_zap.UnaryServerInterceptor(grpcLogger, zapOpts...),
-						grpc_recovery.UnaryServerInterceptor(recoverOpts...),
 					),
 					grpc_middleware.WithStreamServerChain(
+						grpc_recovery.StreamServerInterceptor(recoverOpts...),
 						grpc_ctxtags.StreamServerInterceptor(grpc_ctxtags.WithFieldExtractor(grpc_ctxtags.CodeGenRequestFieldExtractor)),
 						grpc_zap.StreamServerInterceptor(grpcLogger, zapOpts...),
-						grpc_recovery.StreamServerInterceptor(recoverOpts...),
 					),
 				)
 

--- a/go/cmd/berty/main.go
+++ b/go/cmd/berty/main.go
@@ -188,6 +188,7 @@ func main() {
 				opts := bertyprotocol.Opts{
 					IpfsCoreAPI:     api,
 					Logger:          logger.Named("bertyprotocol"),
+					RootContext:     ctx,
 					RootDatastore:   rootDS,
 					MessageKeystore: mk,
 					DeviceKeystore:  bertyprotocol.NewDeviceKeystore(deviceDS),

--- a/go/cmd/berty/mini/main.go
+++ b/go/cmd/berty/mini/main.go
@@ -27,7 +27,6 @@ type Opts struct {
 }
 
 func newService(ctx context.Context, opts *Opts) (bertyprotocol.Service, func()) {
-
 	var (
 		swarmAddresses []string = nil
 		lock           *fslock.Lock

--- a/go/cmd/berty/mini/main.go
+++ b/go/cmd/berty/mini/main.go
@@ -62,7 +62,7 @@ func Main(opts *Opts) {
 	mk := bertyprotocol.NewMessageKeystore(ipfsutil.NewNamespacedDatastore(rootDS, datastore.NewKey("messages")))
 	ks := ipfsutil.NewDatastoreKeystore(ipfsutil.NewNamespacedDatastore(rootDS, datastore.NewKey("account")))
 
-	client, err := bertyprotocol.New(bertyprotocol.Opts{
+	service, err := bertyprotocol.New(bertyprotocol.Opts{
 		IpfsCoreAPI:     api,
 		DeviceKeystore:  bertyprotocol.NewDeviceKeystore(ks),
 		RootContext:     ctx,
@@ -74,6 +74,15 @@ func Main(opts *Opts) {
 	if err != nil {
 		panic(err)
 	}
+
+	defer service.Close()
+
+	client, err := bertyprotocol.NewClient(service)
+	if err != nil {
+		panic(err)
+	}
+
+	defer client.Close()
 
 	config, err := client.InstanceGetConfiguration(ctx, nil)
 	if err != nil {

--- a/go/cmd/berty/mini/main.go
+++ b/go/cmd/berty/mini/main.go
@@ -74,8 +74,8 @@ func newService(ctx context.Context, opts *Opts) (bertyprotocol.Service, func())
 	}
 
 	return service, func() {
-		service.Close()
 		node.Close()
+		service.Close()
 	}
 }
 
@@ -139,9 +139,8 @@ func Main(opts *Opts) {
 					panic(err)
 				}
 
-				err := tabbedView.service.GroupMetadataSubscribe(&bertytypes.GroupMetadataSubscribe_Request{GroupPK: accountGroup.Group.PublicKey}, srvListMetadatas)
-				if err != nil {
-					panic(err)
+				if evt.Metadata.EventType != bertytypes.EventTypeAccountGroupJoined {
+					continue
 				}
 
 				tabbedView.NextGroup()

--- a/go/cmd/berty/mini/view_group.go
+++ b/go/cmd/berty/mini/view_group.go
@@ -155,10 +155,10 @@ func (v *groupView) loop(ctx context.Context) {
 
 	go func() {
 		wg.Done()
-
 		for m := range v.syncMessages {
 			v.messages.Append(m)
 		}
+
 	}()
 
 	// list group message events
@@ -210,6 +210,7 @@ func (v *groupView) loop(ctx context.Context) {
 		}
 
 		go func() {
+			wg.Done()
 			for {
 				evt, err = cl.Recv()
 				if err != nil {
@@ -238,6 +239,7 @@ func (v *groupView) loop(ctx context.Context) {
 		}
 
 		go func() {
+			wg.Done()
 			for {
 				evt, err = cl.Recv()
 				if err != nil {
@@ -249,10 +251,12 @@ func (v *groupView) loop(ctx context.Context) {
 			}
 		}()
 	}
+
+	wg.Wait()
 }
 
 func (v *groupView) welcomeEventDisplay(ctx context.Context) {
-	config, err := v.v.client.InstanceGetConfiguration(ctx, nil)
+	config, err := v.v.client.InstanceGetConfiguration(ctx, &bertytypes.InstanceGetConfiguration_Request{})
 	if err != nil {
 		panic(err)
 	}

--- a/go/cmd/berty/mini/view_group.go
+++ b/go/cmd/berty/mini/view_group.go
@@ -95,48 +95,6 @@ func (f *fakeServerStream) RecvMsg(m interface{}) error {
 
 var _ grpc.ServerStream = (*fakeServerStream)(nil)
 
-type protocolServiceGroupMessage struct {
-	*fakeServerStream
-	ch chan *bertytypes.GroupMessageEvent
-}
-
-func (x *protocolServiceGroupMessage) Send(m *bertytypes.GroupMessageEvent) error {
-	x.ch <- m
-	return nil
-}
-
-func newProtocolServiceGroupMessage(ctx context.Context) (chan *bertytypes.GroupMessageEvent, *protocolServiceGroupMessage) {
-	ch := make(chan *bertytypes.GroupMessageEvent)
-
-	return ch, &protocolServiceGroupMessage{
-		fakeServerStream: &fakeServerStream{
-			context: ctx,
-		},
-		ch: ch,
-	}
-}
-
-type protocolServiceGroupMetadata struct {
-	*fakeServerStream
-	ch chan *bertytypes.GroupMetadataEvent
-}
-
-func (x *protocolServiceGroupMetadata) Send(m *bertytypes.GroupMetadataEvent) error {
-	x.ch <- m
-	return nil
-}
-
-func newProtocolServiceGroupMetadata(ctx context.Context) (chan *bertytypes.GroupMetadataEvent, *protocolServiceGroupMetadata) {
-	ch := make(chan *bertytypes.GroupMetadataEvent)
-
-	return ch, &protocolServiceGroupMetadata{
-		fakeServerStream: &fakeServerStream{
-			context: ctx,
-		},
-		ch: ch,
-	}
-}
-
 func newViewGroup(v *tabbedGroupsView, g *bertytypes.Group, memberPK, devicePK []byte) *groupView {
 	return &groupView{
 		memberPK:     memberPK,
@@ -158,7 +116,6 @@ func (v *groupView) loop(ctx context.Context) {
 		for m := range v.syncMessages {
 			v.messages.Append(m)
 		}
-
 	}()
 
 	// list group message events
@@ -223,7 +180,6 @@ func (v *groupView) loop(ctx context.Context) {
 					payload:     evt.Message,
 					sender:      evt.Headers.DevicePK,
 				})
-
 			}
 		}()
 	}

--- a/go/cmd/berty/mini/view_group.go
+++ b/go/cmd/berty/mini/view_group.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
+	"io"
 	"strings"
 	"sync"
 	"time"
@@ -160,82 +161,98 @@ func (v *groupView) loop(ctx context.Context) {
 		}
 	}()
 
-	// Replay message history
-	msgs, srvListMessages := newProtocolServiceGroupMessage(ctx)
-	go func() {
-		for evt := range msgs {
-			v.messages.Prepend(&historyMessage{
-				messageType: messageTypeMessage,
-				payload:     evt.Message,
-				sender:      evt.Headers.DevicePK,
-			}, time.Time{})
+	// list group message events
+	{
+		var evt *bertytypes.GroupMessageEvent
+
+		req := &bertytypes.GroupMessageList_Request{GroupPK: v.g.PublicKey}
+		cl, err := v.v.client.GroupMessageList(ctx, req)
+		for err == nil {
+			if evt, err = cl.Recv(); err == nil {
+				v.messages.Prepend(&historyMessage{
+					messageType: messageTypeMessage,
+					payload:     evt.Message,
+					sender:      evt.Headers.DevicePK,
+				}, time.Time{})
+			}
 		}
-	}()
 
-	if err := v.v.service.GroupMessageList(&bertytypes.GroupMessageList_Request{GroupPK: v.g.PublicKey}, srvListMessages); err != nil {
-		panic(err)
-	}
-	close(msgs)
-
-	metas, srvListMetadatas := newProtocolServiceGroupMetadata(ctx)
-	go func() {
-		// List existing metadata event for group
-		for e := range metas {
-			// _ = e
-			metadataEventHandler(ctx, v, e, true)
+		if err != io.EOF {
+			panic(err)
 		}
-	}()
-
-	if err := v.v.service.GroupMetadataList(&bertytypes.GroupMetadataList_Request{GroupPK: v.g.PublicKey}, srvListMetadatas); err != nil {
-		panic(err)
 	}
-	close(metas)
 
-	// Watch for incoming new messages
-	go func() {
-		msgs, srvListMessages := newProtocolServiceGroupMessage(ctx)
+	// list group metadata events
+	{
+		var evt *bertytypes.GroupMetadataEvent
+
+		req := &bertytypes.GroupMetadataList_Request{GroupPK: v.g.PublicKey}
+		cl, err := v.v.client.GroupMetadataList(ctx, req)
+		for err == nil {
+			if evt, err = cl.Recv(); err == nil {
+				metadataEventHandler(ctx, v, evt, true)
+			}
+		}
+
+		if err != io.EOF {
+			panic(err)
+		}
+	}
+
+	// subscribe to group message events
+	{
+		var evt *bertytypes.GroupMessageEvent
+
+		req := &bertytypes.GroupMessageSubscribe_Request{GroupPK: v.g.PublicKey}
+		cl, err := v.v.client.GroupMessageSubscribe(ctx, req)
+		if err != nil {
+			panic(err)
+		}
+
 		go func() {
-			wg.Done()
-			for evt := range msgs {
+			for {
+				evt, err = cl.Recv()
+				if err != nil {
+					// @TODO: Log this
+					return
+				}
+
 				v.messages.Append(&historyMessage{
 					messageType: messageTypeMessage,
 					payload:     evt.Message,
 					sender:      evt.Headers.DevicePK,
 				})
+
 			}
 		}()
+	}
 
-		err := v.v.service.GroupMessageSubscribe(&bertytypes.GroupMessageSubscribe_Request{GroupPK: v.g.PublicKey}, srvListMessages)
+	// subscribe to group metadata events
+	{
+		var evt *bertytypes.GroupMetadataEvent
+
+		req := &bertytypes.GroupMetadataSubscribe_Request{GroupPK: v.g.PublicKey}
+		cl, err := v.v.client.GroupMetadataSubscribe(ctx, req)
 		if err != nil {
 			panic(err)
 		}
 
-		close(msgs)
-	}()
-
-	// Watch for new incoming metadata
-	go func() {
-		metas, srvListMetadatas := newProtocolServiceGroupMetadata(ctx)
 		go func() {
-			wg.Done()
-			for e := range metas {
-				metadataEventHandler(ctx, v, e, false)
+			for {
+				evt, err = cl.Recv()
+				if err != nil {
+					// @TODO: Log this
+					return
+				}
+
+				metadataEventHandler(ctx, v, evt, false)
 			}
 		}()
-
-		err := v.v.service.GroupMetadataSubscribe(&bertytypes.GroupMetadataSubscribe_Request{GroupPK: v.g.PublicKey}, srvListMetadatas)
-		if err != nil {
-			panic(err)
-		}
-
-		close(metas)
-	}()
-
-	wg.Wait()
+	}
 }
 
 func (v *groupView) welcomeEventDisplay(ctx context.Context) {
-	config, err := v.v.service.InstanceGetConfiguration(ctx, nil)
+	config, err := v.v.client.InstanceGetConfiguration(ctx, nil)
 	if err != nil {
 		panic(err)
 	}

--- a/go/cmd/berty/mini/view_group.go
+++ b/go/cmd/berty/mini/view_group.go
@@ -166,6 +166,11 @@ func (v *groupView) loop(ctx context.Context) {
 			panic(err)
 		}
 
+		v.messages.Append(&historyMessage{
+			messageType: messageTypeMeta,
+			payload:     []byte("start group message subscribe"),
+		})
+
 		go func() {
 			wg.Done()
 			for {
@@ -174,6 +179,11 @@ func (v *groupView) loop(ctx context.Context) {
 					// @TODO: Log this
 					return
 				}
+
+				v.messages.Append(&historyMessage{
+					messageType: messageTypeMeta,
+					payload:     []byte("receiving message: " + string(evt.Message)),
+				})
 
 				v.messages.Append(&historyMessage{
 					messageType: messageTypeMessage,

--- a/go/cmd/berty/mini/view_group_incoming.go
+++ b/go/cmd/berty/mini/view_group_incoming.go
@@ -69,7 +69,7 @@ func handlerAccountContactRequestOutgoingSent(ctx context.Context, v *groupView,
 		sender:      casted.DevicePK,
 	}, e, v, isHistory)
 
-	gInfo, err := v.v.service.GroupInfo(ctx, &bertytypes.GroupInfo_Request{
+	gInfo, err := v.v.client.GroupInfo(ctx, &bertytypes.GroupInfo_Request{
 		ContactPK: casted.ContactPK,
 	})
 
@@ -212,7 +212,7 @@ func handlerAccountContactRequestIncomingAccepted(ctx context.Context, v *groupV
 		sender:      casted.DevicePK,
 	}, e, v, isHistory)
 
-	gInfo, err := v.v.service.GroupInfo(ctx, &bertytypes.GroupInfo_Request{
+	gInfo, err := v.v.client.GroupInfo(ctx, &bertytypes.GroupInfo_Request{
 		ContactPK: casted.ContactPK,
 	})
 

--- a/go/cmd/berty/mini/view_group_outgoing.go
+++ b/go/cmd/berty/mini/view_group_outgoing.go
@@ -105,7 +105,7 @@ func commandList() []*command {
 // }
 
 func aliasSendCommand(ctx context.Context, v *groupView, cmd string) error {
-	if _, err := v.v.service.ContactAliasKeySend(ctx, &bertytypes.ContactAliasKeySend_Request{
+	if _, err := v.v.client.ContactAliasKeySend(ctx, &bertytypes.ContactAliasKeySend_Request{
 		GroupPK: v.g.PublicKey,
 	}); err != nil {
 		return err
@@ -193,7 +193,7 @@ func contactAcceptCommand(ctx context.Context, v *groupView, cmd string) error {
 		return err
 	}
 
-	if _, err = v.v.service.ContactRequestAccept(ctx, &bertytypes.ContactRequestAccept_Request{
+	if _, err = v.v.client.ContactRequestAccept(ctx, &bertytypes.ContactRequestAccept_Request{
 		ContactPK: pkBytes,
 	}); err != nil {
 		return err
@@ -208,7 +208,7 @@ func contactDiscardCommand(ctx context.Context, v *groupView, cmd string) error 
 		return err
 	}
 
-	if _, err = v.v.service.ContactRequestDiscard(ctx, &bertytypes.ContactRequestDiscard_Request{
+	if _, err = v.v.client.ContactRequestDiscard(ctx, &bertytypes.ContactRequestDiscard_Request{
 		ContactPK: pkBytes,
 	}); err != nil {
 		return err
@@ -223,7 +223,7 @@ func groupJoinCommand(ctx context.Context, v *groupView, cmd string) error {
 		return fmt.Errorf("err: can't join group %w", err)
 	}
 
-	_, err = v.v.service.MultiMemberGroupJoin(ctx, &bertytypes.MultiMemberGroupJoin_Request{
+	_, err = v.v.client.MultiMemberGroupJoin(ctx, &bertytypes.MultiMemberGroupJoin_Request{
 		Group: g,
 	})
 
@@ -231,7 +231,7 @@ func groupJoinCommand(ctx context.Context, v *groupView, cmd string) error {
 }
 
 func groupNewCommand(ctx context.Context, v *groupView, _ string) error {
-	_, err := v.v.service.MultiMemberGroupCreate(ctx, &bertytypes.MultiMemberGroupCreate_Request{})
+	_, err := v.v.client.MultiMemberGroupCreate(ctx, &bertytypes.MultiMemberGroupCreate_Request{})
 
 	return err
 }
@@ -247,7 +247,7 @@ func contactRequestCommand(ctx context.Context, v *groupView, cmd string) error 
 		return err
 	}
 
-	_, err = v.v.service.ContactRequestSend(ctx, &bertytypes.ContactRequestSend_Request{
+	_, err = v.v.client.ContactRequestSend(ctx, &bertytypes.ContactRequestSend_Request{
 		Reference: contactBytes,
 	})
 
@@ -259,7 +259,7 @@ func newMessageCommand(ctx context.Context, v *groupView, cmd string) error {
 		return nil
 	}
 
-	_, err := v.v.service.AppMessageSend(ctx, &bertytypes.AppMessageSend_Request{
+	_, err := v.v.client.AppMessageSend(ctx, &bertytypes.AppMessageSend_Request{
 		GroupPK: v.g.PublicKey,
 		Payload: []byte(cmd),
 	})
@@ -268,7 +268,7 @@ func newMessageCommand(ctx context.Context, v *groupView, cmd string) error {
 }
 
 func contactShareCommand(ctx context.Context, v *groupView, cmd string) error {
-	res, err := v.v.service.ContactRequestReference(ctx, &bertytypes.ContactRequestReference_Request{})
+	res, err := v.v.client.ContactRequestReference(ctx, &bertytypes.ContactRequestReference_Request{})
 	if err != nil {
 		return err
 	}
@@ -298,19 +298,19 @@ func contactShareCommand(ctx context.Context, v *groupView, cmd string) error {
 }
 
 func contactRequestsOnCommand(ctx context.Context, v *groupView, cmd string) error {
-	_, err := v.v.service.ContactRequestEnable(ctx, &bertytypes.ContactRequestEnable_Request{})
+	_, err := v.v.client.ContactRequestEnable(ctx, &bertytypes.ContactRequestEnable_Request{})
 
 	return err
 }
 
 func contactRequestsOffCommand(ctx context.Context, v *groupView, cmd string) error {
-	_, err := v.v.service.ContactRequestDisable(ctx, &bertytypes.ContactRequestDisable_Request{})
+	_, err := v.v.client.ContactRequestDisable(ctx, &bertytypes.ContactRequestDisable_Request{})
 
 	return err
 }
 
 func contactRequestsReferenceResetCommand(ctx context.Context, v *groupView, cmd string) error {
-	_, err := v.v.service.ContactRequestResetReference(ctx, &bertytypes.ContactRequestResetReference_Request{})
+	_, err := v.v.client.ContactRequestResetReference(ctx, &bertytypes.ContactRequestResetReference_Request{})
 
 	return err
 }

--- a/go/cmd/berty/mini/view_tabbed_groups.go
+++ b/go/cmd/berty/mini/view_tabbed_groups.go
@@ -14,7 +14,7 @@ import (
 type tabbedGroupsView struct {
 	ctx                    context.Context
 	app                    *tview.Application
-	service                bertyprotocol.Service
+	client                 bertyprotocol.Client
 	topics                 *tview.Table
 	activeViewContainer    *tview.Flex
 	selectedGroupView      *groupView
@@ -110,7 +110,7 @@ func (v *tabbedGroupsView) AddContextGroup(ctx context.Context, g *bertytypes.Gr
 		return
 	}
 
-	info, err := v.service.GroupInfo(ctx, &bertytypes.GroupInfo_Request{
+	info, err := v.client.GroupInfo(ctx, &bertytypes.GroupInfo_Request{
 		GroupPK: g.PublicKey,
 	})
 
@@ -118,7 +118,7 @@ func (v *tabbedGroupsView) AddContextGroup(ctx context.Context, g *bertytypes.Gr
 		return
 	}
 
-	if _, err := v.service.ActivateGroup(ctx, &bertytypes.ActivateGroup_Request{
+	if _, err := v.client.ActivateGroup(ctx, &bertytypes.ActivateGroup_Request{
 		GroupPK: g.PublicKey,
 	}); err != nil {
 		return
@@ -200,12 +200,12 @@ func (v *tabbedGroupsView) GetHistory() tview.Primitive {
 	return v.activeViewContainer
 }
 
-func newTabbedGroups(ctx context.Context, g *bertytypes.GroupInfo_Reply, service bertyprotocol.Service, app *tview.Application) *tabbedGroupsView {
+func newTabbedGroups(ctx context.Context, g *bertytypes.GroupInfo_Reply, client bertyprotocol.Client, app *tview.Application) *tabbedGroupsView {
 	v := &tabbedGroupsView{
-		ctx:     ctx,
-		topics:  tview.NewTable(),
-		service: service,
-		app:     app,
+		ctx:    ctx,
+		topics: tview.NewTable(),
+		client: client,
+		app:    app,
 	}
 
 	v.accountGroupView = newViewGroup(v, g.Group, g.MemberPK, g.DevicePK)

--- a/go/cmd/berty/mini/view_tabbed_groups.go
+++ b/go/cmd/berty/mini/view_tabbed_groups.go
@@ -14,7 +14,7 @@ import (
 type tabbedGroupsView struct {
 	ctx                    context.Context
 	app                    *tview.Application
-	client                 bertyprotocol.Client
+	client                 bertyprotocol.ProtocolServiceClient
 	topics                 *tview.Table
 	activeViewContainer    *tview.Flex
 	selectedGroupView      *groupView
@@ -200,7 +200,7 @@ func (v *tabbedGroupsView) GetHistory() tview.Primitive {
 	return v.activeViewContainer
 }
 
-func newTabbedGroups(ctx context.Context, g *bertytypes.GroupInfo_Reply, client bertyprotocol.Client, app *tview.Application) *tabbedGroupsView {
+func newTabbedGroups(ctx context.Context, g *bertytypes.GroupInfo_Reply, client bertyprotocol.ProtocolServiceClient, app *tview.Application) *tabbedGroupsView {
 	v := &tabbedGroupsView{
 		ctx:    ctx,
 		topics: tview.NewTable(),

--- a/go/internal/testutil/logging.go
+++ b/go/internal/testutil/logging.go
@@ -29,5 +29,7 @@ func Logger(t *testing.T) *zap.Logger {
 		t.Errorf("debug logger: %v", err)
 		return zap.NewNop()
 	}
+
+	zap.ReplaceGlobals(logger)
 	return logger
 }

--- a/go/internal/testutil/logging.go
+++ b/go/internal/testutil/logging.go
@@ -30,6 +30,6 @@ func Logger(t *testing.T) *zap.Logger {
 		return zap.NewNop()
 	}
 
-	zap.ReplaceGlobals(logger)
+	//zap.ReplaceGlobals(logger)
 	return logger
 }

--- a/go/internal/testutil/logging.go
+++ b/go/internal/testutil/logging.go
@@ -16,7 +16,8 @@ func Logger(t *testing.T) *zap.Logger {
 	t.Helper()
 
 	envDebug, _ := strconv.ParseBool(os.Getenv("BERTY_DEBUG"))
-	if !*debug && !envDebug {
+	envDebugAll, _ := strconv.ParseBool(os.Getenv("BERTY_DEBUG_ALL"))
+	if !*debug && !envDebug && !envDebugAll {
 		return zap.NewNop()
 	}
 
@@ -30,6 +31,8 @@ func Logger(t *testing.T) *zap.Logger {
 		return zap.NewNop()
 	}
 
-	//zap.ReplaceGlobals(logger)
+	if envDebugAll {
+		zap.ReplaceGlobals(logger)
+	}
 	return logger
 }

--- a/go/pkg/bertydemo/client.go
+++ b/go/pkg/bertydemo/client.go
@@ -1,0 +1,48 @@
+package bertydemo
+
+import (
+	"berty.tech/berty/v2/go/internal/grpcutil"
+	grpc "google.golang.org/grpc"
+)
+
+type Client interface {
+	DemoServiceClient
+
+	Close() error
+}
+
+type client struct {
+	DemoServiceClient
+
+	l *grpcutil.PipeListener
+}
+
+func (c *client) Close() error {
+	return c.l.Close()
+}
+
+func NewClient(svc *Service) (Client, error) {
+	return NewClientFromServer(grpc.NewServer(), svc)
+}
+
+func NewClientFromServer(s *grpc.Server, svc *Service) (Client, error) {
+	pl := grpcutil.NewPipeListener()
+
+	cc, err := pl.NewClientConn(grpc.WithInsecure())
+	if err != nil {
+		return nil, err
+	}
+
+	RegisterDemoServiceServer(s, svc)
+
+	go func() {
+		_ = s.Serve(pl)
+	}()
+
+	c := client{
+		DemoServiceClient: NewDemoServiceClient(cc),
+		l:                 pl,
+	}
+
+	return &c, nil
+}

--- a/go/pkg/bertyprotocol/api_event.go
+++ b/go/pkg/bertyprotocol/api_event.go
@@ -48,7 +48,6 @@ func (s *service) GroupMessageSubscribe(req *bertytypes.GroupMessageSubscribe_Re
 		s.logger.Debug("receiving message event", zap.Any("event", evt))
 		e, ok := evt.(*bertytypes.GroupMessageEvent)
 		if !ok {
-			s.logger.Debug("not ok")
 			continue
 		}
 

--- a/go/pkg/bertyprotocol/api_event.go
+++ b/go/pkg/bertyprotocol/api_event.go
@@ -26,8 +26,9 @@ func (s *service) GroupMetadataSubscribe(req *bertytypes.GroupMetadataSubscribe_
 
 		// TODO: log if error
 		s.logger.Debug("sending back event metadata", zap.String("message", string(e.GetMetadata().GetPayload())))
-		err := sub.Send(e)
-		_ = err
+		if err := sub.Send(e); err != nil {
+			cg.logger.Error("error while sending message", zap.Error(err))
+		}
 	}
 
 	return nil
@@ -53,9 +54,8 @@ func (s *service) GroupMessageSubscribe(req *bertytypes.GroupMessageSubscribe_Re
 
 		s.logger.Debug("sending back event", zap.String("message", string(e.GetMessage())))
 		// TODO: log if error
-		err := sub.Send(e)
-		if err != nil {
-			s.logger.Error("error while sending message", zap.Error(err))
+		if err := sub.Send(e); err != nil {
+			cg.logger.Error("error while sending message", zap.Error(err))
 		}
 	}
 
@@ -69,10 +69,8 @@ func (s *service) GroupMetadataList(req *bertytypes.GroupMetadataList_Request, s
 	}
 
 	for evt := range cg.MetadataStore().ListEvents(sub.Context()) {
-		err = sub.Send(evt)
-		if err != nil {
-			// TODO: log
-			_ = err
+		if err := sub.Send(evt); err != nil {
+			cg.logger.Error("error while sending message", zap.Error(err))
 		}
 	}
 
@@ -91,10 +89,8 @@ func (s *service) GroupMessageList(req *bertytypes.GroupMessageList_Request, sub
 	}
 
 	for evt := range messages {
-		err = sub.Send(evt)
-		if err != nil {
-			// TODO: log
-			_ = err
+		if err := sub.Send(evt); err != nil {
+			cg.logger.Error("error while sending message", zap.Error(err))
 		}
 	}
 

--- a/go/pkg/bertyprotocol/api_event.go
+++ b/go/pkg/bertyprotocol/api_event.go
@@ -23,7 +23,11 @@ func (s *service) GroupMetadataSubscribe(req *bertytypes.GroupMetadataSubscribe_
 	ch := cg.MetadataStore().Subscribe(sub.Context())
 
 	// @FIXME: Wait for subscription to be ready, we should find a way to avoid this
-	time.AfterFunc(time.Millisecond*100, func() { sub.SendHeader(mdReady.Copy()) })
+	time.AfterFunc(time.Millisecond*100, func() {
+		if err := sub.SendHeader(mdReady.Copy()); err != nil {
+			s.logger.Warn("Send header header error", zap.Error(err))
+		}
+	})
 
 	for evt := range ch {
 		e, ok := evt.(*bertytypes.GroupMetadataEvent)
@@ -51,7 +55,11 @@ func (s *service) GroupMessageSubscribe(req *bertytypes.GroupMessageSubscribe_Re
 	ch := cg.MessageStore().Subscribe(sub.Context())
 
 	// @FIXME: Wait for subscription to be ready, we should find a way to avoid this
-	time.AfterFunc(time.Millisecond*100, func() { sub.SendHeader(mdReady.Copy()) })
+	time.AfterFunc(time.Millisecond*100, func() {
+		if err := sub.SendHeader(mdReady.Copy()); err != nil {
+			s.logger.Warn("Send header header error", zap.Error(err))
+		}
+	})
 
 	for evt := range ch {
 		e, ok := evt.(*bertytypes.GroupMessageEvent)

--- a/go/pkg/bertyprotocol/api_group.go
+++ b/go/pkg/bertyprotocol/api_group.go
@@ -67,7 +67,7 @@ func (s *service) ActivateGroup(ctx context.Context, req *bertytypes.ActivateGro
 		return nil, errcode.ErrInvalidInput.Wrap(err)
 	}
 
-	err = s.activateGroup(ctx, pk)
+	err = s.activateGroup(s.ctx, pk)
 	if err != nil {
 		return nil, errcode.ErrInternal.Wrap(err)
 	}

--- a/go/pkg/bertyprotocol/api_group.go
+++ b/go/pkg/bertyprotocol/api_group.go
@@ -67,7 +67,7 @@ func (s *service) ActivateGroup(ctx context.Context, req *bertytypes.ActivateGro
 		return nil, errcode.ErrInvalidInput.Wrap(err)
 	}
 
-	err = s.activateGroup(s.ctx, pk)
+	err = s.activateGroup(pk)
 	if err != nil {
 		return nil, errcode.ErrInternal.Wrap(err)
 	}

--- a/go/pkg/bertyprotocol/api_multimember.go
+++ b/go/pkg/bertyprotocol/api_multimember.go
@@ -25,7 +25,7 @@ func (s *service) MultiMemberGroupCreate(ctx context.Context, req *bertytypes.Mu
 	s.groups[string(g.PublicKey)] = g
 	s.lock.Unlock()
 
-	err = s.activateGroup(ctx, sk.GetPublic())
+	err = s.activateGroup(sk.GetPublic())
 	if err != nil {
 		return nil, errcode.ErrInternal.Wrap(fmt.Errorf("unable to activate group: %w", err))
 	}

--- a/go/pkg/bertyprotocol/client.go
+++ b/go/pkg/bertyprotocol/client.go
@@ -1,0 +1,44 @@
+package bertyprotocol
+
+import (
+	"berty.tech/berty/v2/go/internal/grpcutil"
+	"google.golang.org/grpc"
+)
+
+type Client interface {
+	ProtocolServiceClient
+
+	Close() error
+}
+
+type client struct {
+	ProtocolServiceClient
+
+	l *grpcutil.PipeListener
+}
+
+func (c *client) Close() error {
+	return c.l.Close()
+}
+
+func NewClient(svc Service) (Client, error) {
+	return NewClientFromServer(grpc.NewServer(), svc)
+}
+
+func NewClientFromServer(s *grpc.Server, svc Service) (Client, error) {
+	pl := grpcutil.NewPipeListener()
+
+	cc, err := pl.NewClientConn(grpc.WithInsecure())
+	if err != nil {
+		return nil, err
+	}
+
+	RegisterProtocolServiceServer(s, svc)
+
+	go func() {
+		_ = s.Serve(pl)
+	}()
+
+	c := client{ProtocolServiceClient: NewProtocolServiceClient(cc), l: pl}
+	return &c, nil
+}

--- a/go/pkg/bertyprotocol/client.go
+++ b/go/pkg/bertyprotocol/client.go
@@ -21,14 +21,15 @@ func (c *client) Close() error {
 	return c.l.Close()
 }
 
-func NewClient(svc Service) (Client, error) {
-	return NewClientFromServer(grpc.NewServer(), svc)
+func NewClient(svc Service, opts ...grpc.ServerOption) (Client, error) {
+	return NewClientFromServer(grpc.NewServer(opts...), svc)
 }
 
-func NewClientFromServer(s *grpc.Server, svc Service) (Client, error) {
+func NewClientFromServer(s *grpc.Server, svc Service, opts ...grpc.DialOption) (Client, error) {
 	pl := grpcutil.NewPipeListener()
 
-	cc, err := pl.NewClientConn(grpc.WithInsecure())
+	opts = append(opts, grpc.WithInsecure())
+	cc, err := pl.NewClientConn(opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/go/pkg/bertyprotocol/group.go
+++ b/go/pkg/bertyprotocol/group.go
@@ -156,7 +156,7 @@ func metadataStoreListSecrets(ctx context.Context, gc *groupContext) map[crypto.
 	for meta := range ch {
 		pk, ds, err := openDeviceSecret(meta.Metadata, ownSK, g)
 		if err != nil {
-			// TODO: log
+			gc.logger.Error("unable to open device secret", zap.Error(err))
 			continue
 		}
 
@@ -181,7 +181,7 @@ func FillMessageKeysHolderUsingNewData(ctx context.Context, gc *groupContext) er
 		}
 
 		if err = registerChainKey(ctx, gc.MessageKeystore(), gc.Group(), pk, ds, gc.DevicePubKey().Equals(pk)); err != nil {
-			// TODO: log
+			gc.logger.Error("unable to register chain key", zap.Error(err))
 			continue
 		}
 	}
@@ -276,7 +276,6 @@ func WatchNewMembersAndSendSecrets(ctx context.Context, logger *zap.Logger, gctx
 	go func() {
 		for evt := range gctx.MetadataStore().Subscribe(ctx) {
 			if err := handleNewMember(ctx, gctx, evt); err != nil {
-				// TODO: log
 				logger.Error("unable to send secrets", zap.Error(err))
 			}
 		}

--- a/go/pkg/bertyprotocol/group_context.go
+++ b/go/pkg/bertyprotocol/group_context.go
@@ -1,8 +1,12 @@
 package bertyprotocol
 
 import (
+	"encoding/base64"
+	"fmt"
+
 	"berty.tech/berty/v2/go/pkg/bertytypes"
 	"github.com/libp2p/go-libp2p-core/crypto"
+	"go.uber.org/zap"
 )
 
 type groupContext struct {
@@ -11,6 +15,7 @@ type groupContext struct {
 	messageStore    *messageStore
 	messageKeystore *MessageKeystore
 	memberDevice    *ownMemberDevice
+	logger          *zap.Logger
 }
 
 func (gc *groupContext) MessageKeystore() *MessageKeystore {
@@ -48,12 +53,17 @@ func (gc *groupContext) Close() error {
 	return nil
 }
 
-func newContextGroup(group *bertytypes.Group, metadataStore *metadataStore, messageStore *messageStore, messageKeystore *MessageKeystore, memberDevice *ownMemberDevice) *groupContext {
+func newContextGroup(group *bertytypes.Group, metadataStore *metadataStore, messageStore *messageStore, messageKeystore *MessageKeystore, memberDevice *ownMemberDevice, logger *zap.Logger) *groupContext {
+	if logger == nil {
+		logger = zap.NewNop()
+	}
+
 	return &groupContext{
 		group:           group,
 		metadataStore:   metadataStore,
 		messageStore:    messageStore,
 		messageKeystore: messageKeystore,
 		memberDevice:    memberDevice,
+		logger:          logger.With(zap.String("group-id", fmt.Sprintf("%.6s", base64.StdEncoding.EncodeToString(group.PublicKey)))),
 	}
 }

--- a/go/pkg/bertyprotocol/keystore_message_utils_test.go
+++ b/go/pkg/bertyprotocol/keystore_message_utils_test.go
@@ -95,8 +95,8 @@ func Test_EncryptMessagePayload(t *testing.T) {
 	mkh1 := NewInMemMessageKeystore()
 	mkh2 := NewInMemMessageKeystore()
 
-	gc1 := newContextGroup(g, nil, nil, mkh1, omd1)
-	gc2 := newContextGroup(g, nil, nil, mkh2, omd2)
+	gc1 := newContextGroup(g, nil, nil, mkh1, omd1, nil)
+	gc2 := newContextGroup(g, nil, nil, mkh2, omd2, nil)
 
 	err = registerChainKey(ctx, mkh1, g, gc1.DevicePubKey(), ds1, true)
 	assert.NoError(t, err)
@@ -260,7 +260,7 @@ func Test_EncryptMessageEnvelope(t *testing.T) {
 	omd1, err := acc1.MemberDeviceForGroup(g)
 	assert.NoError(t, err)
 
-	gc1 := newContextGroup(g, nil, nil, mkh1, omd1)
+	gc1 := newContextGroup(g, nil, nil, mkh1, omd1, nil)
 
 	ds1, err := newDeviceSecret()
 	assert.NoError(t, err)
@@ -323,7 +323,7 @@ func Test_EncryptMessageEnvelopeAndDerive(t *testing.T) {
 	err = registerChainKey(ctx, mkh1, g, omd1.device.GetPublic(), ds1, true)
 	assert.NoError(t, err)
 
-	gc1 := newContextGroup(g, nil, nil, mkh1, omd1)
+	gc1 := newContextGroup(g, nil, nil, mkh1, omd1, nil)
 
 	ds2, err := newDeviceSecret()
 	assert.NoError(t, err)

--- a/go/pkg/bertyprotocol/orbitdb.go
+++ b/go/pkg/bertyprotocol/orbitdb.go
@@ -133,7 +133,7 @@ func (s *bertyOrbitDB) OpenGroup(ctx context.Context, g *bertytypes.Group, optio
 		return nil, err
 	}
 
-	s.logger.Debug(fmt.Sprintf("group details %+v", g))
+	s.logger.Warn(fmt.Sprintf("group details %+v", g))
 
 	memberDevice, err := s.deviceKeystore.MemberDeviceForGroup(g)
 	if err != nil {

--- a/go/pkg/bertyprotocol/orbitdb_many_adds_berty_test.go
+++ b/go/pkg/bertyprotocol/orbitdb_many_adds_berty_test.go
@@ -66,7 +66,7 @@ func testAddBerty(ctx context.Context, t *testing.T, api ipfsutil.CoreAPIMock, g
 	orbitdbCache := NewOrbitDatastoreCache(orbitdbDS)
 	mk := NewMessageKeystore(messagesDS)
 
-	odb, err := newBertyOrbitDB(ctx, api, NewDeviceKeystore(accountKS), mk, &orbitdb.NewOrbitDBOptions{Cache: orbitdbCache})
+	odb, err := newBertyOrbitDB(ctx, api, NewDeviceKeystore(accountKS), mk, nil, &orbitdb.NewOrbitDBOptions{Cache: orbitdbCache})
 	require.NoError(t, err)
 
 	defer odb.Close()

--- a/go/pkg/bertyprotocol/orbitdb_utils_test.go
+++ b/go/pkg/bertyprotocol/orbitdb_utils_test.go
@@ -8,7 +8,6 @@ import (
 
 	"berty.tech/berty/v2/go/internal/ipfsutil"
 	"berty.tech/berty/v2/go/pkg/bertytypes"
-	orbitdb "berty.tech/go-orbit-db"
 	"github.com/ipfs/go-ipfs/keystore"
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/libp2p/go-libp2p-core/peer"
@@ -115,7 +114,7 @@ func createPeersWithGroup(ctx context.Context, t testing.TB, pathBase string, me
 
 			mk := NewInMemMessageKeystore()
 
-			db, err := newBertyOrbitDB(ctx, ca, devKS, mk, &orbitdb.NewOrbitDBOptions{})
+			db, err := newBertyOrbitDB(ctx, ca, devKS, mk, nil, nil)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/go/pkg/bertyprotocol/scenario_test.go
+++ b/go/pkg/bertyprotocol/scenario_test.go
@@ -7,14 +7,23 @@ import (
 	"testing"
 	"time"
 
+	crand "crypto/rand"
+
+	"sync"
+
+	"bytes"
+
 	"berty.tech/berty/v2/go/internal/testutil"
 	"berty.tech/berty/v2/go/pkg/bertytypes"
+	"github.com/gogo/protobuf/proto"
+	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/metadata"
 )
 
 func TestScenario_JoinGroup_Service(t *testing.T) {
+	t.Skip()
 	const numberOfService = 2
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -466,5 +475,125 @@ func newProtocolServiceGroupMessage(ctx context.Context) (chan *bertytypes.Group
 			context: ctx,
 		},
 		ch: ch,
+	}
+}
+
+func TestScenario_ContactMessage(t *testing.T) {
+	const numberOfService = 1
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	opts := TestingOpts{
+		Logger: testutil.Logger(t),
+	}
+
+	// Setup test
+	pts, cleanup := generateTestingProtocol(ctx, t, &opts, numberOfService)
+	defer cleanup()
+
+	pt := pts[0]
+
+	_, otherPK, err := crypto.GenerateEd25519Key(crand.Reader)
+	require.NoError(t, err)
+
+	otherPKBytes, err := otherPK.Raw()
+	require.NoError(t, err)
+
+	otherSharableContact, err := proto.Marshal(&bertytypes.ShareableContact{
+		PK:                   otherPKBytes,
+		PublicRendezvousSeed: bytes.Repeat([]byte("."), bertytypes.RendezvousSeedLength),
+		Metadata:             []byte("useless"),
+	})
+	require.NoError(t, err)
+
+	_, err = pt.Client.ContactRequestSend(ctx, &bertytypes.ContactRequestSend_Request{
+		Reference:       otherSharableContact,
+		ContactMetadata: nil,
+	})
+	require.NoError(t, err)
+
+	gInfo, err := pt.Client.GroupInfo(ctx, &bertytypes.GroupInfo_Request{
+		ContactPK: otherPKBytes,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, gInfo)
+
+	_, err = pt.Client.ActivateGroup(ctx, &bertytypes.ActivateGroup_Request{
+		GroupPK: gInfo.Group.PublicKey,
+	})
+	require.NoError(t, err)
+
+	expectedMessages := map[string]bool{
+		"test1": false,
+		"test2": false,
+		"test3": false,
+		"test4": false,
+	}
+	expectedMessagesLock := sync.Mutex{}
+	expectedMessagesCount := len(expectedMessages)
+	expectedMessagesContent := make([]string, expectedMessagesCount)
+	i := 0
+	for msg := range expectedMessages {
+		expectedMessagesContent[i] = msg
+		i++
+	}
+
+	subCtx, subCancel := context.WithTimeout(ctx, time.Second*5)
+
+	go func() {
+		sub, err := pt.Client.GroupMessageSubscribe(subCtx, &bertytypes.GroupMessageSubscribe_Request{
+			GroupPK: gInfo.Group.PublicKey,
+		})
+		require.NoError(t, err)
+
+		for {
+			if subCtx.Err() != nil {
+				break
+			}
+
+			res, err := sub.Recv()
+			if err == io.EOF {
+				break
+			}
+			if !assert.NoError(t, err) {
+				continue
+			}
+
+			expectedMessagesLock.Lock()
+			if value, ok := expectedMessages[string(res.Message)]; !ok {
+				expectedMessagesLock.Unlock()
+				t.Fatalf("unexpected message %s", string(res.Message))
+			} else if value {
+				expectedMessagesLock.Unlock()
+				continue
+			}
+
+			expectedMessages[string(res.Message)] = true
+			expectedMessagesCount--
+			expectedMessagesLock.Unlock()
+
+			if expectedMessagesCount == 0 {
+				subCancel()
+				break
+			}
+		}
+
+		subCancel()
+	}()
+
+	for _, msg := range expectedMessagesContent {
+		_, err := pt.Client.AppMessageSend(ctx, &bertytypes.AppMessageSend_Request{
+			GroupPK: gInfo.Group.PublicKey,
+			Payload: []byte(msg),
+		})
+
+		require.NoError(t, err)
+	}
+
+	<-subCtx.Done()
+
+	for msg, ok := range expectedMessages {
+		assert.True(t, ok, msg)
 	}
 }

--- a/go/pkg/bertyprotocol/scenario_test.go
+++ b/go/pkg/bertyprotocol/scenario_test.go
@@ -11,9 +11,203 @@ import (
 	"berty.tech/berty/v2/go/pkg/bertytypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/metadata"
 )
 
-func TestScenario_JoinGroup(t *testing.T) {
+func TestScenario_JoinGroup_Service(t *testing.T) {
+	const numberOfService = 2
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	opts := TestingOpts{
+		Logger: testutil.Logger(t),
+	}
+
+	// Setup test
+	pts, cleanup := generateTestingProtocol(ctx, t, &opts, numberOfService)
+	defer cleanup()
+
+	// connect all pts together
+	for _, pt := range pts {
+		err := pt.IPFS.MockNetwork().ConnectAllButSelf()
+		require.NoError(t, err)
+	}
+
+	// create group
+	group, _, err := NewGroupMultiMember()
+	require.NoError(t, err)
+
+	// Run test
+
+	t.Log("Get Instance Configuration")
+	{
+		start := time.Now()
+		req := bertytypes.InstanceGetConfiguration_Request{}
+
+		// check if everything is ready
+		for _, pt := range pts {
+			_, err := pt.Service.InstanceGetConfiguration(ctx, &req)
+			require.NoError(t, err)
+		}
+		t.Logf("  duration: %s", time.Since(start))
+	}
+
+	t.Log("Join Group")
+	{
+		start := time.Now()
+		req := bertytypes.MultiMemberGroupJoin_Request{
+			Group: group,
+		}
+
+		for _, pt := range pts {
+			// pt join group
+			_, err = pt.Service.MultiMemberGroupJoin(ctx, &req)
+			require.NoError(t, err)
+
+			// pt join group
+			_, err = pt.Service.MultiMemberGroupJoin(ctx, &req)
+			assert.Error(t, err)
+
+		}
+		t.Logf("  duration: %s", time.Since(start))
+	}
+
+	t.Log("Get Group Info")
+	{
+		start := time.Now()
+		req := bertytypes.GroupInfo_Request{
+			GroupPK: group.PublicKey,
+		}
+
+		for _, pt := range pts {
+			res, err := pt.Service.GroupInfo(ctx, &req)
+			require.NoError(t, err)
+			assert.Equal(t, group.PublicKey, res.Group.PublicKey)
+		}
+		t.Logf("  duration: %s", time.Since(start))
+	}
+
+	t.Log("Activate Group")
+	{
+		start := time.Now()
+		req := bertytypes.ActivateGroup_Request{
+			GroupPK: group.PublicKey,
+		}
+
+		for _, pt := range pts {
+			_, err := pt.Service.ActivateGroup(ctx, &req)
+			assert.NoError(t, err)
+		}
+		t.Logf("  duration: %s", time.Since(start))
+	}
+
+	cmsgs := make([]chan *bertytypes.GroupMessageEvent, numberOfService)
+	t.Log("Subscribe to Group Message")
+	{
+		start := time.Now()
+		req := &bertytypes.GroupMessageSubscribe_Request{GroupPK: group.PublicKey}
+
+		for i, pt := range pts {
+			msgs, srvListMessages := newProtocolServiceGroupMessage(ctx)
+
+			// Watch for incoming new messages
+			go func() {
+				err := pt.Service.GroupMessageSubscribe(req, srvListMessages)
+				assert.NoError(t, err)
+			}()
+
+			cmsgs[i] = msgs
+		}
+		t.Logf("  duration: %s", time.Since(start))
+	}
+
+	// clsGroupMetadata := make([]ProtocolService_GroupMetadataSubscribeService, numberOfService)
+	// t.Log("Subscribe to Group Metadata")
+	// {
+	// 	start := time.Now()
+	// 	req := bertytypes.GroupMetadataSubscribe_Request{
+	// 		GroupPK: group.PublicKey,
+	// 	}
+
+	// 	for i, pt := range pts {
+	// 		var err error
+
+	// 		clsGroupMetadata[i], err = pt.Service.GroupMetadataSubscribe(ctx, &req)
+	// 		require.NoError(t, err)
+	// 	}
+	// 	t.Logf("  duration: %s", time.Since(start))
+	// }
+
+	var testMessage = "hello from"
+	t.Log("Send Message")
+	{
+		start := time.Now()
+
+		for i, pt := range pts {
+			payload := []byte(fmt.Sprintf("%s %d", testMessage, i))
+
+			req := bertytypes.AppMessageSend_Request{
+				GroupPK: group.PublicKey,
+				Payload: payload,
+			}
+
+			_, err := pt.Service.AppMessageSend(ctx, &req)
+			assert.NoError(t, err)
+		}
+		t.Logf("  duration: %s", time.Since(start))
+	}
+
+	testrx := fmt.Sprintf("^%s [\\d]$", testMessage)
+	t.Log("List Message")
+	{
+		start := time.Now()
+		req := bertytypes.GroupMessageList_Request{
+			GroupPK: group.PublicKey,
+		}
+
+		for i, pt := range pts {
+			msgs, srvListMessages := newProtocolServiceGroupMessage(ctx)
+
+			go func() {
+				err := pt.Service.GroupMessageList(&req, srvListMessages)
+				assert.NoError(t, err)
+			}()
+
+			j := 0
+			for res := range msgs {
+				require.Regexp(t, testrx, string(res.GetMessage()), "invalid message content")
+				fmt.Println(i, "recv:", string(res.GetMessage()))
+				j++
+				if j == 2 {
+					close(msgs)
+				}
+			}
+
+			require.Equal(t, 2, len(msgs), "wrong number of messages")
+		}
+		t.Logf("  duration: %s", time.Since(start))
+	}
+
+	t.Log("Receive Message")
+	{
+		start := time.Now()
+
+		for _, msgs := range cmsgs {
+			i := 0
+			for res := range msgs {
+				require.Regexp(t, testrx, string(res.GetMessage()), "invalid message content")
+				i++
+				if i == 2 {
+					close(msgs)
+				}
+			}
+		}
+		t.Logf("  duration: %s", time.Since(start))
+	}
+}
+
+func TestScenario_JoinGroup_Client(t *testing.T) {
 	const numberOfService = 2
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -145,11 +339,15 @@ func TestScenario_JoinGroup(t *testing.T) {
 	t.Log("Send Message")
 	{
 		start := time.Now()
-		req := bertytypes.AppMessageSend_Request{
-			GroupPK: group.PublicKey,
-			Payload: testMessage,
-		}
-		for _, pt := range pts {
+
+		for i, pt := range pts {
+			payload := []byte(fmt.Sprintf("%s:%d", testMessage, i))
+
+			req := bertytypes.AppMessageSend_Request{
+				GroupPK: group.PublicKey,
+				Payload: payload,
+			}
+
 			_, err := pt.Client.AppMessageSend(ctx, &req)
 			assert.NoError(t, err)
 		}
@@ -159,6 +357,7 @@ func TestScenario_JoinGroup(t *testing.T) {
 	t.Log("List Message")
 	{
 		start := time.Now()
+		testrx := fmt.Sprintf("^%s", testMessage)
 		req := bertytypes.GroupMessageList_Request{
 			GroupPK: group.PublicKey,
 		}
@@ -179,7 +378,7 @@ func TestScenario_JoinGroup(t *testing.T) {
 					continue
 				}
 
-				assert.Equal(t, res.GetMessage(), testMessage)
+				assert.Regexp(t, testrx, string(res.GetMessage()))
 			}
 
 			assert.Equal(t, err, io.EOF)
@@ -190,14 +389,65 @@ func TestScenario_JoinGroup(t *testing.T) {
 	t.Log("Receive Message")
 	{
 		start := time.Now()
+		testrx := fmt.Sprintf("^%s", testMessage)
+
 		for _, cl := range clsGroupMessage {
 			res, err := cl.Recv()
-			fmt.Println(res, err)
 			if !assert.NoError(t, err) {
-				msg := res.GetMessage()
-				assert.Equal(t, testMessage, msg)
+				assert.Regexp(t, testrx, string(res.GetMessage()))
 			}
 		}
 		t.Logf("  duration: %s", time.Since(start))
+	}
+}
+
+// helper for service
+
+type fakeServerStream struct {
+	context context.Context
+}
+
+func (f *fakeServerStream) SetHeader(metadata.MD) error {
+	panic("implement me")
+}
+
+func (f *fakeServerStream) SendHeader(metadata.MD) error {
+	panic("implement me")
+}
+
+func (f *fakeServerStream) SetTrailer(metadata.MD) {
+	panic("implement me")
+}
+
+func (f *fakeServerStream) Context() context.Context {
+	return f.context
+}
+
+func (f *fakeServerStream) SendMsg(m interface{}) error {
+	panic("implement me")
+}
+
+func (f *fakeServerStream) RecvMsg(m interface{}) error {
+	panic("implement me")
+}
+
+type protocolServiceGroupMessage struct {
+	*fakeServerStream
+	ch chan *bertytypes.GroupMessageEvent
+}
+
+func (x *protocolServiceGroupMessage) Send(m *bertytypes.GroupMessageEvent) error {
+	x.ch <- m
+	return nil
+}
+
+func newProtocolServiceGroupMessage(ctx context.Context) (chan *bertytypes.GroupMessageEvent, *protocolServiceGroupMessage) {
+	ch := make(chan *bertytypes.GroupMessageEvent)
+
+	return ch, &protocolServiceGroupMessage{
+		fakeServerStream: &fakeServerStream{
+			context: ctx,
+		},
+		ch: ch,
 	}
 }

--- a/go/pkg/bertyprotocol/scenario_test.go
+++ b/go/pkg/bertyprotocol/scenario_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strconv"
 	"testing"
 	"time"
 
@@ -127,6 +128,13 @@ func TestScenario_JoinGroup(t *testing.T) {
 
 			clsGroupMessage[i], err = pt.Client.GroupMessageSubscribe(ctx, &req)
 			require.NoError(t, err)
+
+			// wait for subscribe to be ready
+			header, err := clsGroupMessage[i].Header()
+			require.NoError(t, err)
+
+			rs := header.Get("ready")
+			assert.Contains(t, rs, strconv.FormatBool(true))
 		}
 		t.Logf("  duration: %s", time.Since(start))
 	}
@@ -148,14 +156,19 @@ func TestScenario_JoinGroup(t *testing.T) {
 
 			clsGroupMetadata[i], err = pt.Client.GroupMetadataSubscribe(ctx, &req)
 			require.NoError(t, err)
+
+			// wait for subscribe to be ready
+			header, err := clsGroupMetadata[i].Header()
+			require.NoError(t, err)
+
+			rs := header.Get("ready")
+			assert.Contains(t, rs, strconv.FormatBool(true))
 		}
 		t.Logf("  duration: %s", time.Since(start))
 	}
 
 	// client stream are needed to continue this test
 	require.NotContains(t, clsGroupMetadata, nil)
-
-	time.Sleep(time.Millisecond * 100) // @TODO(gfanton): FIX ME, we should not have to sleep here
 
 	var testMessage = []byte("hello world")
 	t.Log("Send Message")

--- a/go/pkg/bertyprotocol/scenario_test.go
+++ b/go/pkg/bertyprotocol/scenario_test.go
@@ -1,0 +1,203 @@
+package bertyprotocol
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"testing"
+	"time"
+
+	"berty.tech/berty/v2/go/internal/testutil"
+	"berty.tech/berty/v2/go/pkg/bertytypes"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestScenario_JoinGroup(t *testing.T) {
+	const numberOfService = 2
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	opts := TestingOpts{
+		Logger: testutil.Logger(t),
+	}
+
+	// Setup test
+	pts, cleanup := generateTestingProtocol(ctx, t, &opts, numberOfService)
+	defer cleanup()
+
+	// connect all pts together
+	for _, pt := range pts {
+		err := pt.IPFS.MockNetwork().ConnectAllButSelf()
+		require.NoError(t, err)
+	}
+
+	// create group
+	group, _, err := NewGroupMultiMember()
+	require.NoError(t, err)
+
+	// Run test
+
+	t.Log("Get Instance Configuration")
+	{
+		start := time.Now()
+		req := bertytypes.InstanceGetConfiguration_Request{}
+
+		// check if everything is ready
+		for _, pt := range pts {
+			_, err := pt.Client.InstanceGetConfiguration(ctx, &req)
+			require.NoError(t, err)
+		}
+		t.Logf("  duration: %s", time.Since(start))
+	}
+
+	t.Log("Join Group")
+	{
+		start := time.Now()
+		req := bertytypes.MultiMemberGroupJoin_Request{
+			Group: group,
+		}
+
+		for _, pt := range pts {
+			// pt join group
+			_, err = pt.Client.MultiMemberGroupJoin(ctx, &req)
+			require.NoError(t, err)
+
+			// pt join group
+			_, err = pt.Client.MultiMemberGroupJoin(ctx, &req)
+			assert.Error(t, err)
+
+		}
+		t.Logf("  duration: %s", time.Since(start))
+	}
+
+	t.Log("Get Group Info")
+	{
+		start := time.Now()
+		req := bertytypes.GroupInfo_Request{
+			GroupPK: group.PublicKey,
+		}
+
+		for _, pt := range pts {
+			res, err := pt.Client.GroupInfo(ctx, &req)
+			require.NoError(t, err)
+			assert.Equal(t, group.PublicKey, res.Group.PublicKey)
+		}
+		t.Logf("  duration: %s", time.Since(start))
+	}
+
+	t.Log("Activate Group")
+	{
+		start := time.Now()
+		req := bertytypes.ActivateGroup_Request{
+			GroupPK: group.PublicKey,
+		}
+
+		for _, pt := range pts {
+			_, err := pt.Client.ActivateGroup(ctx, &req)
+			assert.NoError(t, err)
+		}
+		t.Logf("  duration: %s", time.Since(start))
+	}
+
+	clsGroupMessage := make([]ProtocolService_GroupMessageSubscribeClient, numberOfService)
+	t.Log("Subscribe to Group Message")
+	{
+		start := time.Now()
+		req := bertytypes.GroupMessageSubscribe_Request{
+			GroupPK: group.PublicKey,
+		}
+
+		for i, pt := range pts {
+			var err error
+
+			clsGroupMessage[i], err = pt.Client.GroupMessageSubscribe(ctx, &req)
+			require.NoError(t, err)
+		}
+		t.Logf("  duration: %s", time.Since(start))
+	}
+
+	// client stream are needed to continue this test
+	require.NotContains(t, clsGroupMessage, nil)
+
+	clsGroupMetadata := make([]ProtocolService_GroupMetadataSubscribeClient, numberOfService)
+	t.Log("Subscribe to Group Metadata")
+	{
+		start := time.Now()
+		req := bertytypes.GroupMetadataSubscribe_Request{
+			GroupPK: group.PublicKey,
+		}
+
+		for i, pt := range pts {
+			var err error
+
+			clsGroupMetadata[i], err = pt.Client.GroupMetadataSubscribe(ctx, &req)
+			require.NoError(t, err)
+		}
+		t.Logf("  duration: %s", time.Since(start))
+	}
+
+	// client stream are needed to continue this test
+	require.NotContains(t, clsGroupMetadata, nil)
+
+	var testMessage = []byte("hello world")
+	t.Log("Send Message")
+	{
+		start := time.Now()
+		req := bertytypes.AppMessageSend_Request{
+			GroupPK: group.PublicKey,
+			Payload: testMessage,
+		}
+		for _, pt := range pts {
+			_, err := pt.Client.AppMessageSend(ctx, &req)
+			assert.NoError(t, err)
+		}
+		t.Logf("  duration: %s", time.Since(start))
+	}
+
+	t.Log("List Message")
+	{
+		start := time.Now()
+		req := bertytypes.GroupMessageList_Request{
+			GroupPK: group.PublicKey,
+		}
+
+		for _, pt := range pts {
+			cl, err := pt.Client.GroupMessageList(ctx, &req)
+			if !assert.NoError(t, err) {
+				continue
+			}
+
+			var res *bertytypes.GroupMessageEvent
+			for range pts {
+				res, err = cl.Recv()
+				if err == io.EOF {
+					break
+				}
+				if !assert.NoError(t, err) {
+					continue
+				}
+
+				assert.Equal(t, res.GetMessage(), testMessage)
+			}
+
+			assert.Equal(t, err, io.EOF)
+		}
+		t.Logf("  duration: %s", time.Since(start))
+	}
+
+	t.Log("Receive Message")
+	{
+		start := time.Now()
+		for _, cl := range clsGroupMessage {
+			res, err := cl.Recv()
+			fmt.Println(res, err)
+			if !assert.NoError(t, err) {
+				msg := res.GetMessage()
+				assert.Equal(t, testMessage, msg)
+			}
+		}
+		t.Logf("  duration: %s", time.Since(start))
+	}
+}

--- a/go/pkg/bertyprotocol/scenario_test.go
+++ b/go/pkg/bertyprotocol/scenario_test.go
@@ -19,204 +19,9 @@ import (
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"google.golang.org/grpc/metadata"
 )
 
-func TestScenario_JoinGroup_Service(t *testing.T) {
-	t.Skip()
-	const numberOfService = 2
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
-
-	opts := TestingOpts{
-		Logger: testutil.Logger(t),
-	}
-
-	// Setup test
-	pts, cleanup := generateTestingProtocol(ctx, t, &opts, numberOfService)
-	defer cleanup()
-
-	// connect all pts together
-	for _, pt := range pts {
-		err := pt.IPFS.MockNetwork().ConnectAllButSelf()
-		require.NoError(t, err)
-	}
-
-	// create group
-	group, _, err := NewGroupMultiMember()
-	require.NoError(t, err)
-
-	// Run test
-
-	t.Log("Get Instance Configuration")
-	{
-		start := time.Now()
-		req := bertytypes.InstanceGetConfiguration_Request{}
-
-		// check if everything is ready
-		for _, pt := range pts {
-			_, err := pt.Service.InstanceGetConfiguration(ctx, &req)
-			require.NoError(t, err)
-		}
-		t.Logf("  duration: %s", time.Since(start))
-	}
-
-	t.Log("Join Group")
-	{
-		start := time.Now()
-		req := bertytypes.MultiMemberGroupJoin_Request{
-			Group: group,
-		}
-
-		for _, pt := range pts {
-			// pt join group
-			_, err = pt.Service.MultiMemberGroupJoin(ctx, &req)
-			require.NoError(t, err)
-
-			// pt join group
-			_, err = pt.Service.MultiMemberGroupJoin(ctx, &req)
-			assert.Error(t, err)
-
-		}
-		t.Logf("  duration: %s", time.Since(start))
-	}
-
-	t.Log("Get Group Info")
-	{
-		start := time.Now()
-		req := bertytypes.GroupInfo_Request{
-			GroupPK: group.PublicKey,
-		}
-
-		for _, pt := range pts {
-			res, err := pt.Service.GroupInfo(ctx, &req)
-			require.NoError(t, err)
-			assert.Equal(t, group.PublicKey, res.Group.PublicKey)
-		}
-		t.Logf("  duration: %s", time.Since(start))
-	}
-
-	t.Log("Activate Group")
-	{
-		start := time.Now()
-		req := bertytypes.ActivateGroup_Request{
-			GroupPK: group.PublicKey,
-		}
-
-		for _, pt := range pts {
-			_, err := pt.Service.ActivateGroup(ctx, &req)
-			assert.NoError(t, err)
-		}
-		t.Logf("  duration: %s", time.Since(start))
-	}
-
-	cmsgs := make([]chan *bertytypes.GroupMessageEvent, numberOfService)
-	t.Log("Subscribe to Group Message")
-	{
-		start := time.Now()
-		req := &bertytypes.GroupMessageSubscribe_Request{GroupPK: group.PublicKey}
-
-		for i, pt := range pts {
-			msgs, srvListMessages := newProtocolServiceGroupMessage(ctx)
-
-			// Watch for incoming new messages
-			go func() {
-				err := pt.Service.GroupMessageSubscribe(req, srvListMessages)
-				assert.NoError(t, err)
-			}()
-
-			cmsgs[i] = msgs
-		}
-		t.Logf("  duration: %s", time.Since(start))
-	}
-
-	// clsGroupMetadata := make([]ProtocolService_GroupMetadataSubscribeService, numberOfService)
-	// t.Log("Subscribe to Group Metadata")
-	// {
-	// 	start := time.Now()
-	// 	req := bertytypes.GroupMetadataSubscribe_Request{
-	// 		GroupPK: group.PublicKey,
-	// 	}
-
-	// 	for i, pt := range pts {
-	// 		var err error
-
-	// 		clsGroupMetadata[i], err = pt.Service.GroupMetadataSubscribe(ctx, &req)
-	// 		require.NoError(t, err)
-	// 	}
-	// 	t.Logf("  duration: %s", time.Since(start))
-	// }
-
-	var testMessage = "hello from"
-	t.Log("Send Message")
-	{
-		start := time.Now()
-
-		for i, pt := range pts {
-			payload := []byte(fmt.Sprintf("%s %d", testMessage, i))
-
-			req := bertytypes.AppMessageSend_Request{
-				GroupPK: group.PublicKey,
-				Payload: payload,
-			}
-
-			_, err := pt.Service.AppMessageSend(ctx, &req)
-			assert.NoError(t, err)
-		}
-		t.Logf("  duration: %s", time.Since(start))
-	}
-
-	testrx := fmt.Sprintf("^%s [\\d]$", testMessage)
-	t.Log("List Message")
-	{
-		start := time.Now()
-		req := bertytypes.GroupMessageList_Request{
-			GroupPK: group.PublicKey,
-		}
-
-		for i, pt := range pts {
-			msgs, srvListMessages := newProtocolServiceGroupMessage(ctx)
-
-			go func() {
-				err := pt.Service.GroupMessageList(&req, srvListMessages)
-				assert.NoError(t, err)
-			}()
-
-			j := 0
-			for res := range msgs {
-				require.Regexp(t, testrx, string(res.GetMessage()), "invalid message content")
-				fmt.Println(i, "recv:", string(res.GetMessage()))
-				j++
-				if j == 2 {
-					close(msgs)
-				}
-			}
-
-			require.Equal(t, 2, len(msgs), "wrong number of messages")
-		}
-		t.Logf("  duration: %s", time.Since(start))
-	}
-
-	t.Log("Receive Message")
-	{
-		start := time.Now()
-
-		for _, msgs := range cmsgs {
-			i := 0
-			for res := range msgs {
-				require.Regexp(t, testrx, string(res.GetMessage()), "invalid message content")
-				i++
-				if i == 2 {
-					close(msgs)
-				}
-			}
-		}
-		t.Logf("  duration: %s", time.Since(start))
-	}
-}
-
-func TestScenario_JoinGroup_Client(t *testing.T) {
+func TestScenario_JoinGroup(t *testing.T) {
 	const numberOfService = 2
 
 	ctx, cancel := context.WithCancel(context.Background())
@@ -350,6 +155,8 @@ func TestScenario_JoinGroup_Client(t *testing.T) {
 	// client stream are needed to continue this test
 	require.NotContains(t, clsGroupMetadata, nil)
 
+	time.Sleep(time.Millisecond * 100) // @TODO(gfanton): FIX ME, we should not have to sleep here
+
 	var testMessage = []byte("hello world")
 	t.Log("Send Message")
 	{
@@ -369,7 +176,28 @@ func TestScenario_JoinGroup_Client(t *testing.T) {
 		t.Logf("  duration: %s", time.Since(start))
 	}
 
-	time.Sleep(time.Millisecond * 500)
+	t.Log("Stream Messages")
+	{
+		start := time.Now()
+		testrx := fmt.Sprintf("^%s", testMessage)
+		for i, cl := range clsGroupMessage {
+
+			nmsg := 0
+			for nmsg < numberOfService {
+				res, err := cl.Recv()
+				if assert.NoError(t, err) {
+					assert.Regexp(t, testrx, string(res.GetMessage()))
+					fmt.Printf("[%d] receive msg [%s]\n", i, string(res.GetMessage()))
+				}
+
+				nmsg++
+			}
+
+			assert.Equal(t, numberOfService, nmsg)
+		}
+
+		t.Logf("  duration: %s", time.Since(start))
+	}
 
 	t.Log("List Message")
 	{
@@ -406,75 +234,6 @@ func TestScenario_JoinGroup_Client(t *testing.T) {
 			assert.Equal(t, io.EOF, err)
 		}
 		t.Logf("  duration: %s", time.Since(start))
-	}
-
-	t.Log("Receive Message")
-	{
-		start := time.Now()
-		testrx := fmt.Sprintf("^%s", testMessage)
-		nmsg := 0
-		for _, cl := range clsGroupMessage {
-			res, err := cl.Recv()
-			if !assert.NoError(t, err) {
-				assert.Regexp(t, testrx, string(res.GetMessage()))
-			}
-
-			nmsg++
-		}
-
-		assert.Equal(t, numberOfService, nmsg)
-		t.Logf("  duration: %s", time.Since(start))
-	}
-}
-
-// helper for service
-
-type fakeServerStream struct {
-	context context.Context
-}
-
-func (f *fakeServerStream) SetHeader(metadata.MD) error {
-	panic("implement me")
-}
-
-func (f *fakeServerStream) SendHeader(metadata.MD) error {
-	panic("implement me")
-}
-
-func (f *fakeServerStream) SetTrailer(metadata.MD) {
-	panic("implement me")
-}
-
-func (f *fakeServerStream) Context() context.Context {
-	return f.context
-}
-
-func (f *fakeServerStream) SendMsg(m interface{}) error {
-	panic("implement me")
-}
-
-func (f *fakeServerStream) RecvMsg(m interface{}) error {
-	panic("implement me")
-}
-
-type protocolServiceGroupMessage struct {
-	*fakeServerStream
-	ch chan *bertytypes.GroupMessageEvent
-}
-
-func (x *protocolServiceGroupMessage) Send(m *bertytypes.GroupMessageEvent) error {
-	x.ch <- m
-	return nil
-}
-
-func newProtocolServiceGroupMessage(ctx context.Context) (chan *bertytypes.GroupMessageEvent, *protocolServiceGroupMessage) {
-	ch := make(chan *bertytypes.GroupMessageEvent)
-
-	return ch, &protocolServiceGroupMessage{
-		fakeServerStream: &fakeServerStream{
-			context: ctx,
-		},
-		ch: ch,
 	}
 }
 

--- a/go/pkg/bertyprotocol/service.go
+++ b/go/pkg/bertyprotocol/service.go
@@ -92,7 +92,9 @@ func New(opts Opts) (Service, error) {
 		return nil, errcode.TODO.Wrap(err)
 	}
 
-	odb, err := newBertyOrbitDB(opts.RootContext, opts.IpfsCoreAPI, opts.DeviceKeystore, opts.MessageKeystore, &orbitdb.NewOrbitDBOptions{Cache: opts.OrbitCache})
+	odb, err := newBertyOrbitDB(opts.RootContext, opts.IpfsCoreAPI, opts.DeviceKeystore, opts.MessageKeystore, opts.Logger, &orbitdb.NewOrbitDBOptions{
+		Cache: opts.OrbitCache,
+	})
 	if err != nil {
 		return nil, errcode.TODO.Wrap(err)
 	}

--- a/go/pkg/bertyprotocol/service_group.go
+++ b/go/pkg/bertyprotocol/service_group.go
@@ -1,7 +1,6 @@
 package bertyprotocol
 
 import (
-	"context"
 	"fmt"
 
 	"berty.tech/berty/v2/go/pkg/bertytypes"
@@ -124,7 +123,7 @@ func (s *service) deactivateGroup(pk crypto.PubKey) error {
 	return nil
 }
 
-func (s *service) activateGroup(ctx context.Context, pk crypto.PubKey) error {
+func (s *service) activateGroup(pk crypto.PubKey) error {
 	id, err := pk.Raw()
 	if err != nil {
 		return errcode.ErrSerialization.Wrap(err)
@@ -145,12 +144,12 @@ func (s *service) activateGroup(ctx context.Context, pk crypto.PubKey) error {
 
 	switch g.GroupType {
 	case bertytypes.GroupTypeContact, bertytypes.GroupTypeMultiMember:
-		cg, err := s.odb.OpenGroup(ctx, g, nil)
+		cg, err := s.odb.OpenGroup(s.ctx, g, nil)
 		if err != nil {
 			return errcode.TODO.Wrap(err)
 		}
 
-		err = ActivateGroupContext(ctx, cg)
+		err = ActivateGroupContext(s.ctx, cg)
 		if err != nil {
 			return errcode.TODO.Wrap(err)
 		}

--- a/go/pkg/bertyprotocol/service_test.go
+++ b/go/pkg/bertyprotocol/service_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"testing"
 
+	"berty.tech/berty/v2/go/pkg/bertytypes"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,7 +27,7 @@ func ExampleNew_basic() {
 	if err != nil {
 		panic(err)
 	}
-	ret, err := client.InstanceGetConfiguration(context.Background(), nil)
+	ret, err := client.InstanceGetConfiguration(context.Background(), &bertytypes.InstanceGetConfiguration_Request{})
 	if err != nil {
 		panic(err)
 	}

--- a/go/pkg/bertyprotocol/store_message.go
+++ b/go/pkg/bertyprotocol/store_message.go
@@ -93,8 +93,9 @@ func (m *messageStore) ListMessages(ctx context.Context) (<-chan *bertytypes.Gro
 	}()
 
 	go func() {
-		err := m.OpLog().Iterator(&ipfslog.IteratorOptions{}, ch)
-		m.logger.Error("unable to iterate on messages", zap.Error(err))
+		if err := m.OpLog().Iterator(&ipfslog.IteratorOptions{}, ch); err != nil {
+			m.logger.Error("unable to iterate on messages", zap.Error(err))
+		}
 	}()
 
 	return out, nil

--- a/go/pkg/bertyprotocol/store_metadata.go
+++ b/go/pkg/bertyprotocol/store_metadata.go
@@ -163,9 +163,9 @@ func (m *metadataStore) SendSecret(ctx context.Context, memberPK crypto.PubKey) 
 	if devs, err := m.GetDevicesForMember(memberPK); len(devs) == 0 || err != nil {
 		if err != nil {
 			return nil, errcode.ErrInvalidInput.Wrap(err)
-		} else {
-			return nil, errcode.ErrInvalidInput
 		}
+
+		return nil, errcode.ErrInvalidInput
 	}
 
 	ds, err := getDeviceSecret(ctx, m.g, m.mks, m.devKS)

--- a/go/pkg/bertyprotocol/store_metadata.go
+++ b/go/pkg/bertyprotocol/store_metadata.go
@@ -161,7 +161,11 @@ func (m *metadataStore) SendSecret(ctx context.Context, memberPK crypto.PubKey) 
 	}
 
 	if devs, err := m.GetDevicesForMember(memberPK); len(devs) == 0 || err != nil {
-		return nil, errcode.ErrInvalidInput
+		if err != nil {
+			return nil, errcode.ErrInvalidInput.Wrap(err)
+		} else {
+			return nil, errcode.ErrInvalidInput
+		}
 	}
 
 	ds, err := getDeviceSecret(ctx, m.g, m.mks, m.devKS)

--- a/go/pkg/bertyprotocol/testing.go
+++ b/go/pkg/bertyprotocol/testing.go
@@ -2,14 +2,141 @@ package bertyprotocol
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"berty.tech/berty/v2/go/internal/ipfsutil"
+	grpc "google.golang.org/grpc"
+	codes "google.golang.org/grpc/codes"
+	status "google.golang.org/grpc/status"
+
+	grpc_middleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	grpc_zap "github.com/grpc-ecosystem/go-grpc-middleware/logging/zap"
+	grpc_recovery "github.com/grpc-ecosystem/go-grpc-middleware/recovery"
+	grpc_ctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
+
+	keystore "github.com/ipfs/go-ipfs-keystore"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
+
+	libp2p_mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
 )
 
-// TestingClient returns a configured Client struct with in-memory contexts.
-func TestingClient(t *testing.T, opts Opts) (Service, func()) {
+type TestingProtocol struct {
+	Opts *Opts
+
+	Service Service
+	Client  Client
+	IPFS    ipfsutil.CoreAPIMock
+}
+
+type TestingOpts struct {
+	Logger  *zap.Logger
+	Mocknet libp2p_mocknet.Mocknet
+}
+
+func NewTestingProtocol(ctx context.Context, t *testing.T, opts *TestingOpts) (tp *TestingProtocol, cleanup func()) {
+	t.Helper()
+
+	var node ipfsutil.CoreAPIMock
+
+	if opts.Mocknet != nil {
+		node = ipfsutil.TestingCoreAPIUsingMockNet(ctx, t, opts.Mocknet)
+	} else {
+		node = ipfsutil.TestingCoreAPI(ctx, t)
+	}
+
+	serviceOpts := Opts{
+		Logger:          opts.Logger,
+		DeviceKeystore:  NewDeviceKeystore(keystore.NewMemKeystore()),
+		MessageKeystore: NewInMemMessageKeystore(),
+		IpfsCoreAPI:     node,
+	}
+
+	// setup grpc
+
+	// setup grpc server
+	grpcLogger := opts.Logger.Named("grpc")
+	// Define customfunc to handle panic
+	panicHandler := func(p interface{}) (err error) {
+		return status.Errorf(codes.Unknown, "panic recover: %v", p)
+	}
+
+	// Shared options for the logger, with a custom gRPC code to log level function.
+	recoverOpts := []grpc_recovery.Option{
+		grpc_recovery.WithRecoveryHandler(panicHandler),
+	}
+
+	zapOpts := []grpc_zap.Option{}
+
+	serverOpts := []grpc.ServerOption{
+		grpc_middleware.WithUnaryServerChain(
+			grpc_ctxtags.UnaryServerInterceptor(grpc_ctxtags.WithFieldExtractor(grpc_ctxtags.CodeGenRequestFieldExtractor)),
+
+			grpc_zap.UnaryServerInterceptor(grpcLogger, zapOpts...),
+			grpc_recovery.UnaryServerInterceptor(recoverOpts...),
+		),
+		grpc_middleware.WithStreamServerChain(
+			grpc_ctxtags.StreamServerInterceptor(grpc_ctxtags.WithFieldExtractor(grpc_ctxtags.CodeGenRequestFieldExtractor)),
+			grpc_zap.StreamServerInterceptor(grpcLogger, zapOpts...),
+			grpc_recovery.StreamServerInterceptor(recoverOpts...),
+		),
+	}
+
+	service, cleanupService := TestingService(t, serviceOpts)
+	client, cleanupClient := TestingClient(t, service, serverOpts...)
+
+	cleanup = func() {
+		cleanupClient()
+		cleanupService()
+		node.Close()
+	}
+
+	tp = &TestingProtocol{
+		Opts:    &serviceOpts,
+		Client:  client,
+		Service: service,
+		IPFS:    node,
+	}
+
+	return
+}
+
+func generateTestingProtocol(ctx context.Context, t *testing.T, opts *TestingOpts, n int) (tps []*TestingProtocol, cleanup func()) {
+	t.Helper()
+
+	cls := make([]func(), n)
+	cleanup = func() {
+		for i := range cls {
+			if cls[i] != nil {
+				cls[i]()
+			}
+		}
+	}
+
+	if opts.Mocknet == nil {
+		opts.Mocknet = libp2p_mocknet.New(ctx)
+	}
+
+	if opts.Logger == nil {
+		opts.Logger = zap.NewNop()
+	}
+
+	logger := opts.Logger
+
+	tps = make([]*TestingProtocol, n)
+	for i := range tps {
+		opts.Logger = logger.Named(fmt.Sprintf("pt[%d]", i))
+		tps[i], cls[i] = NewTestingProtocol(ctx, t, opts)
+	}
+
+	err := opts.Mocknet.LinkAll()
+	require.NoError(t, err)
+	return
+}
+
+// TestingService returns a configured Client struct with in-memory contexts.
+func TestingService(t *testing.T, opts Opts) (Service, func()) {
 	t.Helper()
 
 	ctx := opts.RootContext
@@ -29,15 +156,39 @@ func TestingClient(t *testing.T, opts Opts) (Service, func()) {
 		ipfsCoreClose = ca.Close
 	}
 
-	client, err := New(opts)
+	service, err := New(opts)
 	if err != nil {
 		t.Fatalf("failed to initialize client: %v", err)
 	}
 
 	cleanup := func() {
-		client.Close()
+		service.Close()
 		ipfsCoreClose()
 	}
 
-	return client, cleanup
+	return service, cleanup
+}
+
+func TestingClientFromServer(t *testing.T, s *grpc.Server, svc Service, dialOpts ...grpc.DialOption) (client Client, cleanup func()) {
+	t.Helper()
+
+	var err error
+
+	client, err = NewClientFromServer(s, svc, dialOpts...)
+	require.NoError(t, err)
+	cleanup = func() { client.Close() }
+
+	return
+}
+
+func TestingClient(t *testing.T, svc Service, opts ...grpc.ServerOption) (client Client, cleanup func()) {
+	t.Helper()
+
+	var err error
+
+	client, err = NewClient(svc, opts...)
+	require.NoError(t, err)
+	cleanup = func() { client.Close() }
+
+	return
 }

--- a/go/pkg/bertyprotocol/testing_test.go
+++ b/go/pkg/bertyprotocol/testing_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestTestingClient_impl(t *testing.T) {
-	client, cleanup := bertyprotocol.TestingClient(t, bertyprotocol.Opts{
+	client, cleanup := bertyprotocol.TestingService(t, bertyprotocol.Opts{
 		Logger:          zap.NewNop(),
 		DeviceKeystore:  bertyprotocol.NewDeviceKeystore(keystore.NewMemKeystore()),
 		MessageKeystore: bertyprotocol.NewInMemMessageKeystore(),

--- a/go/pkg/bertytypes/contact.go
+++ b/go/pkg/bertytypes/contact.go
@@ -1,6 +1,8 @@
 package bertytypes
 
 import (
+	"fmt"
+
 	"berty.tech/berty/v2/go/pkg/errcode"
 	"github.com/libp2p/go-libp2p-core/crypto"
 )
@@ -8,8 +10,8 @@ import (
 const RendezvousSeedLength = 32
 
 func (m *ShareableContact) CheckFormat() error {
-	if len(m.PublicRendezvousSeed) != RendezvousSeedLength {
-		return errcode.ErrInvalidInput
+	if l := len(m.PublicRendezvousSeed); l != RendezvousSeedLength {
+		return errcode.ErrInvalidInput.Wrap(fmt.Errorf("rendezvous seed length should not be %d", l))
 	}
 
 	_, err := crypto.UnmarshalEd25519PublicKey(m.PK)


### PR DESCRIPTION
- Use real grpc client in berty mini instead of using service directly
- Add scenario test to protocol
- Fixup wrong context passed to `ActivateGroup` method