### PR TITLE
chore: reduce CI failures on go build

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -53,6 +53,9 @@ steps:
 
   - label: go-build
     if: build.branch == "master" || (build.message !~ /\[skip go-build\]/ && build.message !~ /\[skip-ci\]/)
+    retry:
+      automatic:
+        limit: 3
     agents:
       queue: "bigcores"
     plugins:
@@ -83,8 +86,8 @@ steps:
       - cd go
       - touch gen.sum # avoid triggering make generate
       - make go.install
-      - SKIP_SLOW_TESTS=1 make go.unittest GO_TEST_OPTS="-v -test.timeout=600s -count 10"
-      - SKIP_SLOW_TESTS=0 make go.unittest GO_TEST_OPTS="-v -test.timeout=600s -count 2"
+      - SKIP_SLOW_TESTS=1 make go.unittest GO_TEST_OPTS="-v -test.timeout=1000s -count 10"
+      - SKIP_SLOW_TESTS=0 make go.unittest GO_TEST_OPTS="-v -test.timeout=1000s -count 2"
       - make tidy
       - make lint
       - cd ..


### PR DESCRIPTION
there is a plan to fix those issues at the root, but for now, we regularly have
annoying failures, mainly on CI which is probably just already allocating too
much CPU on other things

this PR should avoid getting to the admin to manually retry go-build