### PR TITLE
Don't create conversation until contact has accepted request

### DIFF
--- a/js/packages/hooks/Chat.tsx
+++ b/js/packages/hooks/Chat.tsx
@@ -238,8 +238,19 @@ export const useAccountContactSearchResults = (searchText: string): chat.contact
 
 // conversation queries
 export const useConversationList = () => {
+	const client = useClient()
+	// TODO: handle multiple devices
 	const list = useSelector((state: chat.conversation.GlobalState) =>
-		chat.conversation.queries.list(state),
+		client
+			? chat.conversation.queries
+					.list(state)
+					.filter(
+						(conv) =>
+							conv.kind === 'fake' ||
+							Object.values(conv.membersDevices).filter((m) => !m.includes(client.devicePk))
+								.length > 0,
+					)
+			: [],
 	)
 	return list
 }

--- a/js/packages/store/chat/conversation.ts
+++ b/js/packages/store/chat/conversation.ts
@@ -201,7 +201,7 @@ const eventHandler = createSlice<State, EventsReducer>({
 			const aggregateId = getAggregateId({ accountId, groupPk })
 			const conversation = state.aggregates[aggregateId]
 
-			if (conversation && conversation.kind === berty.chatmodel.Conversation.Kind.PrivateGroup) {
+			if (conversation) {
 				const memberPkStr = decodePublicKey(memberPk)
 				if (!conversation.membersDevices[memberPkStr]) {
 					conversation.membersDevices[memberPkStr] = []

--- a/js/packages/store/chat/conversation.ts
+++ b/js/packages/store/chat/conversation.ts
@@ -244,21 +244,14 @@ const FAKE_CONVERSATIONS: Entity[] = FAKE_CONVERSATIONS_CONFIG.map((fc, index) =
 })
 
 export const getAggregatesWithFakes = (state: GlobalState) => {
-	const list = Object.values(state.chat.conversation.aggregates).filter((v) => v)
-	const realCount = list.length
-	const toFakeCount = FAKE_CONVERSATIONS.length - realCount
-	if (toFakeCount > 0) {
-		const result: { [key: string]: Entity | FakeConversation } = {
-			...state.chat.conversation.aggregates,
-		}
-		for (let i = 0; i < toFakeCount; i++) {
-			const conv = FAKE_CONVERSATIONS[i]
-			result[conv.id] = conv
-		}
-		return result
-	} else {
-		return state.chat.conversation.aggregates
+	const result: { [key: string]: Entity | FakeConversation } = {
+		...state.chat.conversation.aggregates,
 	}
+	for (let i = 0; i < FAKE_CONVERSATIONS.length; i++) {
+		const conv = FAKE_CONVERSATIONS[i]
+		result[conv.id] = conv
+	}
+	return result
 }
 
 export const reducer = composeReducers(commandHandler.reducer, eventHandler.reducer)


### PR DESCRIPTION
Fixes #1854 

This also always show the sample conversations as requested by the ux team