### PR TITLE
fix(chat): responsive BertyId modal

### DIFF
--- a/js/gen.sum
+++ b/js/gen.sum
@@ -3,4 +3,4 @@ a6b1965b41d41869f43fc31d65350fccd9fc2908  ../api/bertyprotocol.proto
 4c0fa735ab710727c465ed1444dc6db1c748dc45  ../vendor/github.com/gogo/protobuf/gogoproto/gogo.proto
 4b8f24f346b0cf0494144b7f18b370315ba83f02  Makefile
 583c90ab3c0fa4298f354eaf54fed7a476ef7711  gen.make
-8bf3ee0f05ffe75b4963fd2ace50ac16aa577e5e  yarn.lock
+bd178693b644c28f6cbd2caeb8220d30ff341912  yarn.lock

--- a/js/package.json
+++ b/js/package.json
@@ -45,6 +45,7 @@
     ]
   },
   "dependencies": {
+    "@react-native-community/hooks": "^2.5.1",
     "@types/node": "^13.5.0",
     "babel-jest": "^24.9.0",
     "caser": "^0.1.1",

--- a/js/packages/components/settings/MyBertyId.tsx
+++ b/js/packages/components/settings/MyBertyId.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { View, TouchableOpacity, StyleSheet, ScrollView, Dimensions, Share } from 'react-native'
+import { View, TouchableOpacity, StyleSheet, ScrollView, Share } from 'react-native'
 import { Layout, Text, Icon } from 'react-native-ui-kitten'
 import { useStyles } from '@berty-tech/styles'
 import { TabBar } from '../shared-components/TabBar'
@@ -9,54 +9,56 @@ import { useNavigation } from '@berty-tech/berty-navigation'
 import QRCode from 'react-native-qrcode-svg'
 import { FingerprintContent } from '../shared-components/FingerprintContent'
 import { SafeAreaView } from 'react-native-safe-area-context'
-
+import { useDimensions } from '@react-native-community/hooks'
 //
 // Settings My Berty ID Vue
 //
 
-// Style
-const useStylesBertyId = () => {
-	const [{ margin, padding, maxHeight, minHeight }] = useStyles()
-	return {
-		bodyMarginTop: margin.top.scale(60),
-		bodyContent: [margin.bottom.scale(40), padding.top.scale(50)],
-		scrollViewMaxHeight: maxHeight(400),
-		contentMinHeight: minHeight(400),
-	}
-}
+// Styles
+const _bertyIdButtonSize = 60
+const _bertyIdContentScaleFactor = 0.66
+const _iconShareSize = 26
+const _iconArrowBackSize = 30
+const _iconIdSize = 45
+const _titleSize = 26
+const _requestAvatarSize = 90
+
 const _bertyIdStyles = StyleSheet.create({
-	headerToggleBar: {
-		borderWidth: 2.5,
-		width: '12%',
-		borderRadius: 4,
+	bertyIdButton: {
+		width: _bertyIdButtonSize,
+		height: _bertyIdButtonSize,
+		borderRadius: _bertyIdButtonSize / 2,
+		marginRight: _bertyIdButtonSize,
+		bottom: _bertyIdButtonSize / 2,
 	},
-	bertyLayout: { borderTopLeftRadius: 25, borderTopRightRadius: 25, height: '100%' },
-	bertyIdButton: { width: 60, height: 60, borderRadius: 60 / 2, marginRight: 60, bottom: 30 },
+	bertyIdContent: { paddingBottom: _bertyIdButtonSize / 2 + 10 },
 })
 
 const BertyIdContent: React.FC<{}> = ({ children }) => {
-	const _styles = useStylesBertyId()
-	const [{ padding, column }] = useStyles()
+	const [{ column }] = useStyles()
 
 	return (
-		<ScrollView
-			style={[_styles.scrollViewMaxHeight]}
-			contentContainerStyle={[padding.vertical.medium]}
-		>
-			<View style={[column.justify, { alignItems: 'center' }]}>{children}</View>
-		</ScrollView>
+		<View>
+			<View style={[column.item.center]}>{children}</View>
+		</View>
 	)
 }
 
 const ContactRequestQR = () => {
 	const contactRequestReference = Chat.useContactRequestReference()
 	const contactRequestEnabled = Chat.useContactRequestEnabled()
-	const [styles] = useStyles()
+	const [{ padding }] = useStyles()
+
+	const { height, width } = useDimensions().window
+
 	// I would like to use binary mode in QR but the scanner used seems to not support it, extended tests were done
 	if (contactRequestEnabled) {
 		return (
-			<View style={[styles.padding.top.big]}>
-				<QRCode size={Dimensions.get('window').width * 0.66} value={contactRequestReference} />
+			<View style={[padding.top.big]}>
+				<QRCode
+					size={_bertyIdContentScaleFactor * Math.min(height, width)}
+					value={contactRequestReference}
+				/>
 			</View>
 		)
 	} else {
@@ -66,12 +68,17 @@ const ContactRequestQR = () => {
 
 const Fingerprint: React.FC = () => {
 	const client = Chat.useClient()
-	const [styles] = useStyles()
+	const [{ padding }] = useStyles()
+
+	const { height, width } = useDimensions().window
+
 	if (!client) {
 		return <Text>Client not initialized</Text>
 	}
 	return (
-		<View style={[styles.padding.top.big, { width: '100%' }]}>
+		<View
+			style={[padding.top.big, { width: _bertyIdContentScaleFactor * Math.min(height, width) }]}
+		>
 			<FingerprintContent seed={client.accountPk} />
 		</View>
 	)
@@ -89,21 +96,22 @@ const SelectedContent: React.FC<{ contentName: string }> = ({ contentName }) => 
 }
 
 const BertIdBody: React.FC<{ user: any }> = ({ user }) => {
-	const _styles = useStylesBertyId()
 	const [{ background, border, margin, padding, opacity }] = useStyles()
 	const [selectedContent, setSelectedContent] = useState()
 	const client = Chat.useClient()
+
 	return (
 		<View
 			style={[
 				background.white,
 				border.radius.scale(30),
 				margin.horizontal.medium,
-				_styles.bodyMarginTop,
+				padding.top.large,
+				_bertyIdStyles.bertyIdContent,
 			]}
 		>
-			<RequestAvatar {...user} seed={client?.accountPk} size={90} />
-			<View style={[padding.horizontal.big, _styles.bodyContent]}>
+			<RequestAvatar {...user} seed={client?.accountPk} size={_requestAvatarSize} />
+			<View style={[padding.horizontal.big]}>
 				<TabBar
 					tabs={[
 						{ name: 'QR', icon: 'qr', iconPack: 'custom' },
@@ -154,8 +162,8 @@ const BertyIdShare: React.FC<{}> = () => {
 					style={row.item.justify}
 					name='share'
 					pack='custom'
-					width={26}
-					height={26}
+					width={_iconShareSize}
+					height={_iconShareSize}
 					fill={color.blue}
 				/>
 			</View>
@@ -163,32 +171,47 @@ const BertyIdShare: React.FC<{}> = () => {
 	)
 }
 
-const Screen = Dimensions.get('window')
-
 const MyBertyIdComponent: React.FC<{ user: any }> = ({ user }) => {
 	const { goBack } = useNavigation()
-	const [{ padding, color, margin }] = useStyles()
-	const titleSize = 26
+	const [{ padding, color }] = useStyles()
+	const { height } = useDimensions().window
+
 	return (
-		<View style={[{ height: Screen.height }, padding.medium]}>
+		<ScrollView style={[padding.medium]}>
 			<View
 				style={[
-					{ flexDirection: 'row', justifyContent: 'space-between', alignItems: 'center' },
-					margin.horizontal.medium,
+					{
+						flexDirection: 'row',
+						justifyContent: 'space-between',
+						alignItems: 'center',
+						marginBottom: height * 0.1,
+					},
 				]}
 			>
-				<View style={[{ flexDirection: 'row', alignItems: 'center' }]}>
+				<View
+					style={[
+						{
+							flexDirection: 'row',
+							alignItems: 'center',
+						},
+					]}
+				>
 					<TouchableOpacity
 						onPress={goBack}
 						style={{ alignItems: 'center', justifyContent: 'center' }}
 					>
-						<Icon name='arrow-back-outline' width={30} height={30} fill={color.white} />
+						<Icon
+							name='arrow-back-outline'
+							width={_iconArrowBackSize}
+							height={_iconArrowBackSize}
+							fill={color.white}
+						/>
 					</TouchableOpacity>
 					<Text
 						style={{
 							fontWeight: '700',
-							fontSize: titleSize,
-							lineHeight: 1.25 * titleSize,
+							fontSize: _titleSize,
+							lineHeight: 1.25 * _titleSize,
 							marginLeft: 10,
 							color: color.white,
 						}}
@@ -196,11 +219,11 @@ const MyBertyIdComponent: React.FC<{ user: any }> = ({ user }) => {
 						My Berty ID
 					</Text>
 				</View>
-				<Icon name='id' pack='custom' width={45} height={45} fill={color.white} />
+				<Icon name='id' pack='custom' width={_iconIdSize} height={_iconIdSize} fill={color.white} />
 			</View>
 			<BertIdBody user={user} />
 			<BertyIdShare />
-		</View>
+		</ScrollView>
 	)
 }
 

--- a/js/packages/components/shared-components/Request.tsx
+++ b/js/packages/components/shared-components/Request.tsx
@@ -97,7 +97,7 @@ export const RequestAvatar: React.FC<RequestAvatarProps> = ({
 }) => {
 	const [{ height, row, flex, text, margin, color }] = useStyles()
 	return (
-		<View style={[height(size), row.left, flex.tiny, { justifyContent: 'center' }, style]}>
+		<View style={[row.left, flex.tiny, { justifyContent: 'center' }, style]}>
 			<View style={[flex.tiny, row.item.bottom, row.center]}>
 				<Text category='h6' style={[text.align.center, text.color.black]}>
 					{name}

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -3621,6 +3621,11 @@
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@react-native-community/eslint-plugin/-/eslint-plugin-1.0.0.tgz#ae9a430f2c5795debca491f15a989fce86ea75a0"
 
+"@react-native-community/hooks@^2.5.1":
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/@react-native-community/hooks/-/hooks-2.5.1.tgz#545c76d1a6203532a8e776578bbaaa64bb754cf6"
+  integrity sha512-P9gwIUGpa/h8p5ASwY8QFTthXw/e/rt4mzZRfe3Xh5L13mTuOFXsYVwe9f8JAUx512cUKUsdTg6Dsg3/jTlxeg==
+
 "@react-native-community/masked-view@^0.1.7":
   version "0.1.7"
   resolved "https://registry.yarnpkg.com/@react-native-community/masked-view/-/masked-view-0.1.7.tgz#a65ce0702f55cb67fd777995de6fc7b3e5781903"


### PR DESCRIPTION
Makes the MyBertyId modal responsive (in this case, scrollable on landscape view, otherwise there should never be any overflow).

TODO:

- [x] test with RequstAvatar
- [X] test on physical device
- [x] fix Fingerprint

Relates to #1984
Closes #1998 