### PR TITLE
chore: run go-build on a dedicated queue so it can only be run once per host in parallel

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -60,8 +60,9 @@ steps:
       - cd go
       - touch gen.sum # avoid triggering make generate
       - make go.install
-      - SKIP_SLOW_TESTS=1 make go.unittest GO_TEST_OPTS="-v -test.timeout=1000s -count 10"
-      - SKIP_SLOW_TESTS=0 make go.unittest GO_TEST_OPTS="-v -test.timeout=1000s -count 2"
+      - SKIP_SLOW_TESTS=1 make go.unittest GO_TEST_OPTS="-v -test.timeout=600s -count 5"
+      - SKIP_SLOW_TESTS=0 make go.unittest GO_TEST_OPTS="-v -test.timeout=600s -count 1"
+      - SKIP_SLOW_TESTS=0 make go.unittest GO_TEST_OPTS="-v -test.timeout=600s -count 1 -race -cover -coverprofile=coverage.txt -covermode=atomic"
       - cd ..
       - codecov -f ./go/coverage.txt
 

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -31,7 +31,7 @@ steps:
       automatic:
         limit: 3
     agents:
-      queue: "bigcores"
+      queue: "berty-go-build" # a dedicated queue that should only be made available once per agent host
     plugins:
       - n0izn0iz/docker#v3.5.4:
           image: bertytech/build-go:v4

--- a/go/Makefile
+++ b/go/Makefile
@@ -3,7 +3,7 @@
 ##
 
 GO ?= go
-GO_TEST_OPTS ?= -test.timeout=180s
+GO_TEST_OPTS ?= -test.timeout=180s -race -cover -coverprofile=coverage.txt -covermode=atomic
 GOPATH ?= $(HOME)/go
 
 ##
@@ -67,7 +67,7 @@ go.lint: pb.generate
 go.unittest: GO_TEST_PATH ?= ./...
 go.unittest: pb.generate
 	$(call check-program, $(GO))
-	GO111MODULE=on $(GO) test $(GO_TEST_OPTS) -cover -coverprofile=coverage.txt -covermode=atomic -race $(GO_TEST_PATH)
+	GO111MODULE=on $(GO) test $(GO_TEST_OPTS) $(GO_TEST_PATH)
 
 .PHONY: go.unittest.watch
 go.unittest: GO_TEST_PATH ?= ./...

--- a/go/gen.sum
+++ b/go/gen.sum
@@ -3,4 +3,4 @@ a6b1965b41d41869f43fc31d65350fccd9fc2908  ../api/bertyprotocol.proto
 9a50d810a6ef389b746a3714382c44e059205297  ../api/bertytypes.proto
 0c750308ca695ad24d22caa368e197f0fbc3d9e7  ../api/errcode.proto
 5589d560e33f2da4a466ad965eb9c8bd3d7612cd  ../api/go-internal/handshake.proto
-539e95558861507840bdad3edbb49b4b7e0615f2  Makefile
+a4c78ad0a0c10f7ac335695d04fb964e2a959527  Makefile


### PR DESCRIPTION
the `bigcores` queue can be run multiple times per host

this queue can only be deployed once per host