### PR TITLE
fix: text input text is black in dark iOS mode

### DIFF
--- a/js/packages/components/Onboarding.tsx
+++ b/js/packages/components/Onboarding.tsx
@@ -284,6 +284,7 @@ const NodeConfigInput: React.FC<{
 						padding.medium,
 						text.size.large,
 						border.radius.small,
+						text.color.black,
 					]}
 					value={`${config.port}`}
 					onChangeText={(text) => onConfigChange({ ...config, port: parseInt(text, 10) })}

--- a/js/packages/components/modals/DeleteAccount.tsx
+++ b/js/packages/components/modals/DeleteAccount.tsx
@@ -134,6 +134,7 @@ const DeleteAccountContent: React.FC<{}> = () => {
 						text.size.large,
 						border.radius.small,
 						margin.medium,
+						text.color.black,
 					]}
 					value={deleteConfirmation}
 					onChangeText={setDeleteConfirmation}


### PR DESCRIPTION
Name input was already fixed; this adds 'Delete' confirmation field + port number input in dev onboarding

Closes #1928