### PR TITLE
chore: generate halfblock qrcodes on terminal to support smaller screens or splitted layouts

### DIFF
--- a/go/cmd/berty/main.go
+++ b/go/cmd/berty/main.go
@@ -489,7 +489,7 @@ func main() {
 				return errcode.TODO.Wrap(err)
 			}
 			if !shareInviteNoTerminal {
-				qrterminal.Generate(ret.DeepLink, qrterminal.L, os.Stdout) // FIXME: show deeplink
+				qrterminal.GenerateHalfBlock(ret.DeepLink, qrterminal.L, os.Stdout) // FIXME: show deeplink
 			}
 			fmt.Printf("deeplink: %s\n", ret.DeepLink)
 			fmt.Printf("html url: %s\n", ret.HTMLURL)

--- a/go/cmd/berty/mini/view_group_outgoing.go
+++ b/go/cmd/berty/mini/view_group_outgoing.go
@@ -13,7 +13,7 @@ import (
 	"berty.tech/berty/v2/go/pkg/bertymessenger"
 	"berty.tech/berty/v2/go/pkg/bertytypes"
 	"github.com/gogo/protobuf/proto"
-	"github.com/ipfs/go-cid"
+	cid "github.com/ipfs/go-cid"
 	qrterminal "github.com/mdp/qrterminal/v3"
 	"github.com/pkg/errors"
 )
@@ -471,11 +471,14 @@ func contactShareCommand(ctx context.Context, v *groupView, cmd string) error {
 	if cmd == "qr" || cmd == "qrcode" {
 		qrOut := new(bytes.Buffer)
 		qrterminal.GenerateWithConfig(res.DeepLink, qrterminal.Config{
-			Writer:    qrOut,
-			Level:     qrterminal.L,
-			BlackChar: qrterminal.BLACK_BLACK + qrterminal.BLACK_BLACK,
-			WhiteChar: qrterminal.WHITE_WHITE + qrterminal.WHITE_WHITE,
-			QuietZone: qrterminal.QUIET_ZONE,
+			Writer:         qrOut,
+			Level:          qrterminal.L,
+			HalfBlocks:     true,
+			BlackChar:      qrterminal.BLACK_BLACK,
+			WhiteBlackChar: qrterminal.WHITE_BLACK,
+			WhiteChar:      qrterminal.WHITE_WHITE,
+			BlackWhiteChar: qrterminal.BLACK_WHITE,
+			QuietZone:      qrterminal.QUIET_ZONE,
 		})
 
 		lines := strings.Split(qrOut.String(), "\n")


### PR DESCRIPTION
![Manfreds-iMac - Screen Shot 2020-06-09 at 13 37 49](https://user-images.githubusercontent.com/94029/84143181-6ebcd580-aa56-11ea-9972-ade2658fa640.png)