### PR TITLE
WIP: feat(messenger): basic search screen layout

### DIFF
--- a/js/packages/berty-navigation/stacks.tsx
+++ b/js/packages/berty-navigation/stacks.tsx
@@ -99,11 +99,11 @@ const SearchStack = createNativeStackNavigator()
 export const SearchNavigation: React.FC<BottomTabBarProps> = () => (
 	<SearchStack.Navigator screenOptions={{ headerShown: false }}>
 		<SearchStack.Screen name={Routes.Main.Search} component={Components.Main.Search} />
-		<SearchStack.Screen
+		{/* <SearchStack.Screen
 			name={'Modals'}
 			component={ModalsNavigation}
 			options={{ stackPresentation: 'transparentModal', stackAnimation: 'fade' }}
-		/>
+		/> */}
 	</SearchStack.Navigator>
 )
 

--- a/js/packages/components/main/Footer.tsx
+++ b/js/packages/components/main/Footer.tsx
@@ -10,9 +10,9 @@ export const Footer: React.FC<{ selected: string }> = ({ selected }) => {
 		<SharedFooter
 			left={{
 				icon: 'search-outline',
-				// onPress: navigate.main.search,
+				onPress: navigate.main.search,
 				selected: selected === Routes.Main.Search,
-				disabled: true,
+				disabled: false,
 			}}
 			center={
 				selected === Routes.Main.List

--- a/js/packages/components/main/Search.tsx
+++ b/js/packages/components/main/Search.tsx
@@ -1,121 +1,286 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+/* eslint-disable react-native/no-inline-styles */
 import React, { useState } from 'react'
-import { View, TouchableHighlight, StyleSheet, Dimensions, TextInput } from 'react-native'
+import {
+	View,
+	TouchableHighlight,
+	TextInput,
+	SectionList,
+	Keyboard,
+	ScrollView,
+} from 'react-native'
 import { Layout, Text, Icon } from 'react-native-ui-kitten'
 import { useStyles } from '@berty-tech/styles'
-import { SDTSModalComponent } from '../shared-components/SDTSModalComponent'
 import { CircleAvatar } from '../shared-components/CircleAvatar'
 import { Chat } from '@berty-tech/hooks'
 import { SafeAreaView } from 'react-native-safe-area-context'
-
-const Screen = Dimensions.get('window')
+import { useDimensions } from '@react-native-community/hooks'
 
 // Styles
+
+const _titleIconSize = 30
+
+const _landingIconSize = 90
+
+const _resultAvatarSize = 39
+
+const _fontSizeSearchComponent = 17 // trying to move away from in-house 'scale' (makes font too small in some devices)
+const _fontSizeSmall = 12
+
+const _searchComponentBorderRadius = 7
+const _searchBarIconSize = 25
+
+const _searchComponentMarginTopFactor = 0.02
+const _approxFooterHeight = 90
+
+const _maxWidthConversationsItemNameText = 120
+
 const useStylesSearch = () => {
-	const [{ text, width, maxWidth, height }] = useStyles()
+	const [{ text, background }] = useStyles()
+	const { height: windowHeight, width: windowWidth } = useDimensions().window
+	const isLandscape = () => windowHeight < windowWidth
+
 	return {
-		searchComponentText: [text.color.light.yellow, text.size.scale(17), width(200)],
-		conversationsItemMsgText: maxWidth(240),
-		conversationsItemNameText: maxWidth(120),
-		messages: height(400),
+		searchResultHighlightText: [text.color.yellow, background.light.yellow, text.bold.medium],
+		windowHeight,
+		windowWidth,
+		isLandscape,
 	}
 }
 
-const _stylesSearch = StyleSheet.create({
-	searchComponent: {
-		borderRadius: 7,
-		top: -395,
-	},
-	searchComponentBody: {
-		top: -290,
-	},
-})
-
-const initialSearchText = ''
-
-const SearchBar: React.FC<{ onChange?: (text: string) => void; searchText: string }> = ({
-	onChange,
-	searchText,
-}) => {
-	const [{ row, color, margin }] = useStyles()
-
+const SearchTitle: React.FC<{}> = () => {
+	const [{ text, color }] = useStyles()
 	return (
-		<View>
-			<View style={[row.fill]}>
-				<View style={[row.center]}>
-					<Icon name='search' width={25} height={25} fill={color.yellow} />
-					<TextInput
-						onChangeText={onChange}
-						placeholder='Search'
-						placeholderTextColor={color.yellow}
-						style={[
-							margin.left.medium,
-							{ color: color.yellow, backgroundColor: color.light.yellow },
-						]}
-					/>
-				</View>
-				{searchText.length > 0 && (
-					<Icon name='close-circle-outline' width={25} height={25} fill={color.yellow} />
-				)}
-			</View>
+		<View
+			style={[
+				{
+					flexDirection: 'row',
+					justifyContent: 'center',
+					alignItems: 'center',
+					marginLeft: _titleIconSize,
+				},
+			]}
+		>
+			<Text
+				style={[
+					text.size.big,
+					text.bold.medium,
+					text.color.white,
+					text.align.center,
+					{
+						flexShrink: 0,
+						alignItems: 'center',
+						justifyContent: 'center',
+						flexGrow: 1,
+					},
+				]}
+			>
+				Search
+			</Text>
+			<Icon
+				style={[
+					{
+						flexShrink: 0,
+						flexGrow: 0,
+					},
+				]}
+				name='arrow-forward-outline'
+				width={_titleIconSize}
+				height={_titleIconSize}
+				fill={color.white}
+			/>
 		</View>
 	)
 }
 
-const SearchHint = () => {
-	const [{ row, color, text, margin }] = useStyles()
-	const _styles = useStylesSearch()
+const initialSearchText = ''
+
+const SearchBar: React.FC<{
+	onChange: (text: string) => void
+	searchText: string
+}> = ({ onChange, searchText }) => {
+	const [{ row, color, background, text }] = useStyles()
+	const onClear = (): void => {
+		onChange('')
+		Keyboard.dismiss()
+	}
+
 	return (
-		<>
+		<ScrollView contentContainerStyle={[row.left]} keyboardShouldPersistTaps='handled'>
 			<Icon
 				name='search'
-				width={90}
-				height={90}
+				width={_searchBarIconSize}
+				height={_searchBarIconSize}
+				fill={color.yellow}
+			/>
+			<TextInput
+				onChangeText={onChange}
+				placeholder='Search'
+				placeholderTextColor={color.yellow}
+				style={[
+					{ marginLeft: 15, padding: 4, flex: 2 },
+					background.light.yellow,
+					text.color.yellow,
+				]}
+				autoCorrect={false}
+				autoCapitalize='none'
+				value={searchText}
+			/>
+			{searchText.length > 0 && (
+				<Icon
+					name='close-circle-outline'
+					width={_searchBarIconSize}
+					height={_searchBarIconSize}
+					fill={color.yellow}
+					onPress={onClear}
+					style={[{ marginLeft: 'auto' }]}
+				/>
+			)}
+		</ScrollView>
+	)
+}
+
+const SearchHint: React.FC<{ hintText: string }> = ({
+	hintText = 'Search messages, contacts, or groups...',
+}) => {
+	const [{ row, color, text, margin, column }] = useStyles()
+	const { windowWidth } = useStylesSearch()
+	return (
+		<View style={[column.top, { marginBottom: _approxFooterHeight }]}>
+			<Icon
+				name='search'
+				width={_landingIconSize}
+				height={_landingIconSize}
 				fill={color.light.yellow}
-				style={row.item.justify}
+				style={[row.item.justify, { opacity: 0.8 }]}
 			/>
 			<Text
-				style={[text.align.center, margin.top.big, row.item.justify, _styles.searchComponentText]}
+				style={[
+					text.align.center,
+					margin.top.small,
+					row.item.justify,
+					text.color.light.yellow,
+					text.size.medium,
+					{ width: windowWidth * 0.5, fontSize: _fontSizeSearchComponent, opacity: 0.8 },
+				]}
 			>
-				Search messages, contacts, or groups...
+				{hintText}
 			</Text>
-		</>
+		</View>
 	)
 }
 
 const SearchComponent: React.FC<{}> = () => {
 	const [searchText, setSearchText] = useState(initialSearchText)
 	const contacts = Chat.useAccountContactSearchResults(searchText)
-	const [{ padding, column, background }] = useStyles()
+	const [{ padding, margin, background, text, flex }] = useStyles()
+	const { windowHeight, windowWidth } = useStylesSearch()
+
+	const hintText = () =>
+		searchText && !contacts.length ? 'No results found' : 'Search messages, contacts, or groups...'
+
+	const fakeMessages: any = !searchText
+		? []
+		: [
+				{ name: contacts[0]?.name, message: 'So cool 😎' },
+				{
+					name: contacts[0]?.name,
+					message:
+						"Nobody's gonna hurt anybody. We're all gonna be like three little Fonzies here. And what's Fonzie like? Come on Yolanda, what's Fonzie like?",
+				},
+				{ name: contacts[0]?.name, message: 'k' },
+				{ name: contacts[0]?.name, message: '...' },
+				{ name: contacts[0]?.name, message: ' ' },
+				{
+					name: contacts[0]?.name,
+					message:
+						"I recognize the council has made a decision, but given that it's a stupid-ass decision, I've elected to ignore it.",
+				},
+				{
+					name: contacts[0]?.name,
+					message: "Well, there's this passage I've got memorized — sort of fits the occasion. ",
+				},
+				{ name: contacts[0]?.name, message: 'à é ü ê î' },
+				{ name: contacts[0]?.name, message: 'the THE The' },
+		  ]
+	const sections = [
+		{ title: 'Contacts', data: [...contacts] },
+		{ title: 'Messages', data: [...fakeMessages] },
+	]
 
 	return (
-		<View style={[{ height: Screen.height, justifyContent: 'center' }]}>
-			<View style={[padding.small, background.light.yellow, _stylesSearch.searchComponent]}>
+		<View style={[flex.tiny]}>
+			{/* Title */}
+			<View
+				style={[
+					padding.small,
+					margin.medium,
+					margin.top.huge,
+					{
+						flexShrink: 0,
+						marginTop: windowHeight * _searchComponentMarginTopFactor,
+					},
+				]}
+			>
+				<SearchTitle />
+			</View>
+			{/* SearchBar */}
+			<View
+				style={[
+					padding.small,
+					margin.horizontal.medium,
+					margin.bottom.medium,
+					{
+						flexShrink: 0,
+						flexGrow: 0,
+						borderRadius: _searchComponentBorderRadius,
+					},
+					background.light.yellow,
+				]}
+			>
 				<SearchBar searchText={searchText} onChange={setSearchText} />
 			</View>
-			<View style={[column.justify, _stylesSearch.searchComponentBody]}>
+			{/* Results or Landing */}
+			<View
+				style={[
+					margin.top.small,
+					{
+						flexShrink: 1,
+						flexGrow: 1,
+						justifyContent: 'center',
+					},
+				]}
+			>
 				{contacts.length > 0 ? (
-					<SDTSModalComponent
-						rows={[
-							{
-								toggledPoint: 50,
-								notToggledPoint: 50,
-								title: 'Contacts',
-								maxHeight: Screen.height,
-							},
-						]}
-					>
-						<View>
-							{contacts.map((contact) => (
-								<SearchItem
-									avatarUri={'https://s3.amazonaws.com/uifaces/faces/twitter/msveet/128.jpg'}
-									name={contact.name}
-									message='Coiuc bfei  bb dehbde dbehbe dhbed edeh d'
-								/>
-							))}
-						</View>
-					</SDTSModalComponent>
+					<SectionList
+						style={[background.white]} // todo: Needs to fill insets from SafeAreaView on Landscape
+						keyExtractor={(item, index) => item.name + index}
+						sections={sections}
+						renderSectionHeader={({ section: { title } }) => {
+							return (
+								// TODO: Fix this condition (just using it for UI demo)
+								(contacts.length > 1 || fakeMessages.length > 1) && (
+									<Text style={[text.size.large, padding.medium, background.white]}>{title}</Text>
+								)
+							)
+						}}
+						renderItem={({ item }) => (
+							<SearchItemTmp
+								avatarUri={'https://s3.amazonaws.com/uifaces/faces/twitter/msveet/128.jpg'}
+								name={item.name}
+								message={item.message || 'The quick brown fox jumps over the lazy dog.'}
+								subString={searchText}
+								searchTextKey={item.id ? 'name' : 'message'}
+							/>
+						)}
+						ListFooterComponent={() => (
+							// Workaround to make sure nothing is hidden behind footer;
+							// adding padding/margin to this or a wrapping parent doesn't work
+							<View style={[{ height: _approxFooterHeight }, background.white]} />
+						)}
+					/>
 				) : (
-					<SearchHint />
+					<SearchHint hintText={hintText()} />
 				)}
 			</View>
 		</View>
@@ -123,27 +288,13 @@ const SearchComponent: React.FC<{}> = () => {
 }
 
 export const Search: React.FC<{}> = () => {
-	const firstNotToggledPoint = Screen.height - 120
-	const firstToggledPoint = 20
 	const [{ flex, color }] = useStyles()
 
 	return (
-		<Layout style={[flex.tiny]}>
-			<SafeAreaView style={[flex.tiny]}>
-				<SDTSModalComponent
-					rows={[
-						{
-							toggledPoint: firstToggledPoint,
-							notToggledPoint: firstNotToggledPoint,
-							initialPoint: firstToggledPoint,
-							header: false,
-							maxHeight: Screen.height - 90,
-							bgColor: color.yellow,
-						},
-					]}
-				>
-					<SearchComponent />
-				</SDTSModalComponent>
+		<Layout style={[flex.tiny, { backgroundColor: color.yellow }]}>
+			{/* // TODO: SAV seems to not respect edges on landscape (even if dynamically changed on orientation change) */}
+			<SafeAreaView style={[flex.tiny]} {...{ edges: ['right', 'top', 'left'] }}>
+				<SearchComponent />
 			</SafeAreaView>
 		</Layout>
 	)
@@ -155,28 +306,73 @@ type SearchItemProps = {
 	avatarUri: string
 	name: string
 	message: string
+	searchTextKey: 'name' | 'message'
+	subString: string
 }
 
-const SearchItem: React.FC<SearchItemProps> = ({ avatarUri, name, message }) => {
+// 🚧 The parsing and logic in this function is a placeholder for UI demo
+const SearchItemTmp: React.FC<SearchItemProps> = ({
+	avatarUri,
+	name,
+	message,
+	searchTextKey,
+	subString,
+}) => {
 	const _styles = useStylesSearch()
-	const [{ color, row, border, padding, flex, column, text, margin }] = useStyles()
+	const [{ color, row, padding, flex, column, text, margin }] = useStyles()
+
+	const Name = () => {
+		const highlightName = searchTextKey === 'name'
+		return (
+			<Text
+				numberOfLines={1}
+				style={[
+					{ maxWidth: _maxWidthConversationsItemNameText },
+					highlightName && text.bold.medium,
+				]}
+			>
+				{name}
+			</Text>
+		)
+	}
+
+	const Message = () => {
+		const highlightMessage = searchTextKey === 'message'
+		const subStringLocation = !highlightMessage ? -1 : message.indexOf(subString)
+		return !highlightMessage ? (
+			<Text numberOfLines={1} style={[{ fontSize: _fontSizeSmall }, text.color.grey]}>
+				{message}
+			</Text>
+		) : (
+			<Text numberOfLines={1}>
+				<Text style={[{ fontSize: _fontSizeSmall }, text.color.grey]}>
+					{message.slice(0, subStringLocation)}
+				</Text>
+				<Text style={{ ..._styles.searchResultHighlightText, fontSize: _fontSizeSmall }}>
+					{message.slice(subStringLocation, subStringLocation + subString.length)}
+				</Text>
+				<Text style={[{ fontSize: _fontSizeSmall }, text.color.grey]}>
+					{message.slice(subStringLocation + subString.length)}
+				</Text>
+			</Text>
+		)
+	}
+
 	return (
 		<TouchableHighlight underlayColor={color.light.grey}>
-			<View style={[row.center, border.bottom.big, padding.medium]}>
-				<CircleAvatar avatarUri={avatarUri} size={39} withCircle={false} />
+			<View
+				style={[
+					row.center,
+					padding.medium,
+					{ borderBottomWidth: 1, borderBottomColor: color.light.grey },
+				]}
+			>
+				<CircleAvatar avatarUri={avatarUri} size={_resultAvatarSize} withCircle={false} />
 				<View style={[flex.medium, column.justify, padding.left.medium]}>
-					<View style={[row.center, { alignItems: 'center' }]}>
-						<Text numberOfLines={1} style={_styles.conversationsItemNameText}>
-							{name}
-						</Text>
-					</View>
+					<View style={[{ flexDirection: 'row', alignItems: 'center' }]} />
 					<View style={[margin.right.big]}>
-						<Text
-							numberOfLines={1}
-							style={[text.size.small, text.color.grey, _styles.conversationsItemMsgText]}
-						>
-							{message}
-						</Text>
+						<Name />
+						<Message />
 					</View>
 				</View>
 			</View>


### PR DESCRIPTION
! Do not merge, this contains fake data !

To test: Should work immediately upon building; search button in footer is enabled.

Implements the following from #2042 

(*landing === user hasn't initiated a search)

- [X] Apply styles for landing* (background, searchbar)
- [X] Apply styles for landing* for interaction (typing, clicking)
- [x] Apply styles for no results found
- [ ] Apply styles if only 1 result found (remove result type header) (done but not visible in this pr because of fake data structure, sorry)
- [X] Handle keyboard visibility (if necessary)
- [ ] Apply styles for pending search, if any (disabled inputs, spinner, etc)
- [X] Apply styles for Contact + Message list header(s)
- [X] Apply styles for search result items (highlighting, avatars, etc)
- [X] Handle scrolling UI in result list (keep header visible; no fade for now)

**Known issue:**
- On resizing content (when rotating to landscape), I can't get SafeAreaView to change which edges it wants to cover, so horizontal iPhone 11 results list will have yellow margins.