### PR TITLE
feat(front): add basic message body search to store

### DIFF
--- a/js/packages/hooks/message.ts
+++ b/js/packages/hooks/message.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { useMemo } from 'react'
 import { useDispatch, useSelector } from 'react-redux'
 import { messenger } from '@berty-tech/store'
@@ -66,4 +67,24 @@ export const useGetDateLastContactMessage = (id: string) => {
 			}
 		})
 	return lastDate || null
+}
+
+export const useMessageSearchResults = (searchText: string): any[] => {
+	const selectorMessageIds = (state: messenger.conversation.GlobalState): string[] => {
+		return messenger.conversation.queries
+			.list(state)
+			.filter((conv) => conv?.accountId !== 'fake' && conv.messages.length)
+			.map((conv) => conv.messages)
+			.reduce((acc, conv) => [...acc, ...conv], [])
+	}
+
+	const list = useSelector(selectorMessageIds)
+	const selectorMessageResults = useMemo(
+		() => (state: messenger.message.GlobalState) =>
+			messenger.message.queries.search(state, { searchText, list }),
+		[searchText, list],
+	)
+
+	const matchingMessages = useSelector(selectorMessageResults)
+	return matchingMessages
 }

--- a/js/packages/store/messenger/message.ts
+++ b/js/packages/store/messenger/message.ts
@@ -48,6 +48,7 @@ export namespace Query {
 	export type Get = { id: string }
 	export type GetLength = void
 	export type GetList = { list: Entity['id'][] }
+	export type Search = { searchText: string; list: Entity['id'][] }
 }
 
 export namespace Event {
@@ -99,6 +100,7 @@ export type QueryReducer = {
 	get: (state: GlobalState, query: Query.Get) => Entity | undefined
 	getLength: (state: GlobalState) => number
 	getList: (state: GlobalState, query: Query.GetList) => Entity[]
+	search: (state: GlobalState, query: Query.Search) => Entity[]
 }
 
 export type EventsReducer = {
@@ -212,6 +214,14 @@ export const queries: QueryReducer = {
 			return ret
 		})
 		return messages as Entity[]
+	},
+	search: (state, { searchText, list }) => {
+		const messages = list
+			.map((id) => state.messenger.message.aggregates[id])
+			.filter(
+				(message) => message?.body && message.body.toLowerCase().includes(searchText.toLowerCase()),
+			)
+		return !searchText ? [] : messages
 	},
 }
 

--- a/js/packages/web-dev-app/src/App.tsx
+++ b/js/packages/web-dev-app/src/App.tsx
@@ -358,17 +358,7 @@ const Search: React.FC = () => {
 	)
 }
 
-type TabsDef = {
-	Account: typeof Account
-	Contacts: typeof Contacts
-	Requests: typeof Requests
-	Conversations: typeof Conversations
-	Groups: typeof Groups
-	Tools: typeof Tools
-	Search: typeof Search
-}
-
-const TABS: TabsDef = {
+const TABS = {
 	Account: Account,
 	Contacts: Contacts,
 	Requests: Requests,

--- a/js/packages/web-dev-app/src/App.tsx
+++ b/js/packages/web-dev-app/src/App.tsx
@@ -7,6 +7,10 @@ import { AppMessageType } from '@berty-tech/store/messenger/AppMessage'
 import ProtocolServiceClient from '@berty-tech/store/protocol/ProtocolServiceClient.gen'
 import './App.css'
 import storage from 'redux-persist/lib/storage'
+import {
+	useAccountContactSearchResults,
+	useMessageSearchResults,
+} from '@berty-tech/hooks/Messenger'
 
 const CreateAccount: React.FC = () => {
 	const [name, setName] = useState('')
@@ -85,6 +89,27 @@ const AddContact: React.FC = () => {
 const JSONed: React.FC<{ value: any }> = ({ value }) => (
 	<div style={{ whiteSpace: 'pre-wrap', textAlign: 'left' }}>{JSON.stringify(value, null, 4)}</div>
 )
+
+const SearchContacts: React.FC = () => {
+	const [searchText, setSearchText] = useState('')
+	const contactSearchResults = useAccountContactSearchResults(searchText)
+	return (
+		<>
+			<input
+				type='text'
+				placeholder='Search contacts'
+				value={searchText}
+				onChange={(e) => setSearchText(e.target.value.replace(/^\s+/g, ''))}
+			/>
+			<div>
+				{contactSearchResults &&
+					contactSearchResults.map((contact, i) => {
+						return <JSONed value={contact} key={i} />
+					})}
+			</div>
+		</>
+	)
+}
 
 const Contacts: React.FC = () => {
 	const contacts = Messenger.useAccountContacts()
@@ -169,6 +194,27 @@ const Conversation: React.FC<{ convId: string }> = ({ convId }) => {
 				<JSONed value={conv} />
 			</>
 		)
+	)
+}
+
+const SearchMessages: React.FC = () => {
+	const [searchText, setSearchText] = useState('')
+	const messageSearchResults = useMessageSearchResults(searchText)
+	return (
+		<>
+			<input
+				type='text'
+				placeholder='Search messages'
+				value={searchText}
+				onChange={(e) => setSearchText(e.target.value.replace(/^\s+/g, ''))}
+			/>
+			<div>
+				{messageSearchResults &&
+					messageSearchResults.map((message, i) => {
+						return <JSONed value={message} key={i} />
+					})}
+			</div>
+		</>
 	)
 }
 
@@ -301,13 +347,35 @@ const Tools: React.FC = () => {
 	)
 }
 
-const TABS = {
+const Search: React.FC = () => {
+	return (
+		<>
+			<h3>Search Contacts</h3>
+			<SearchContacts />
+			<h3>Search Messages</h3>
+			<SearchMessages />
+		</>
+	)
+}
+
+type TabsDef = {
+	Account: typeof Account
+	Contacts: typeof Contacts
+	Requests: typeof Requests
+	Conversations: typeof Conversations
+	Groups: typeof Groups
+	Tools: typeof Tools
+	Search: typeof Search
+}
+
+const TABS: TabsDef = {
 	Account: Account,
 	Contacts: Contacts,
 	Requests: Requests,
 	Conversations: Conversations,
 	Groups: Groups,
 	Tools: Tools,
+	Search: Search,
 }
 
 type TabKey = keyof typeof TABS


### PR DESCRIPTION
- Create hook and selector for searching body text of messages sent by humans
- Add a Search tab to web-dev-app to demo contact and message searching

nb
- Not tested for edge cases or very heavy data search volume

Closes #2043 