### PR TITLE
Fix typos

### DIFF
--- a/bazel.make
+++ b/bazel.make
@@ -21,7 +21,7 @@ check-program = $(foreach exec,$(1),$(if $(shell PATH="$(PATH)" which $(exec)),,
 
 
 SAMPLE_GAZELLE_GENERATED_FILE ?= pkg/bertyprotocol/BUILD.bazel # should be the path of a git-ignored bazel-generated file
-VENDOR_BAZEL_OVERRIDEN_FILES = vendor/github.com/libp2p/go-openssl/BUILD.bazel
+VENDOR_BAZEL_OVERRIDDEN_FILES = vendor/github.com/libp2p/go-openssl/BUILD.bazel
 
 ##
 ## Main
@@ -102,7 +102,7 @@ ibazel.unittest: bazel.generate
 vendor/github.com/libp2p/go-openssl/BUILD.bazel: build/bazel/com_github_libp2p_go_openssl.BUILD.bzl vendor
 	cp $< $@
 
-$(SAMPLE_GAZELLE_GENERATED_FILE): WORKSPACE vendor $(VENDOR_BAZEL_OVERRIDEN_FILES)
+$(SAMPLE_GAZELLE_GENERATED_FILE): WORKSPACE vendor $(VENDOR_BAZEL_OVERRIDDEN_FILES)
 	$(call check-program, $(BAZEL))
 	$(BAZEL) $(BAZEL_ARGS) run $(BAZEL_CMD_ARGS) //:gazelle
 

--- a/go/third_party/io_bazel_rules_go/PR-2181-rebase-0.20.1.patch
+++ b/go/third_party/io_bazel_rules_go/PR-2181-rebase-0.20.1.patch
@@ -28,7 +28,7 @@ diff --git a/go/core.rst b/go/core.rst
 index 0bd0d242..e5ed564d 100644
 --- a/go/core.rst
 +++ b/go/core.rst
-@@ -61,7 +61,7 @@ These mappings are collected up across the entire transitive dependancies of a
+@@ -61,7 +61,7 @@ These mappings are collected up across the entire transitive dependencies of a
  binary. This means you can set a value using :param:`x_defs` in a
  ``go_library``, and any binary that links that library will be stamped with that
  value. You can also override stamp values from libraries using :param:`x_defs`

--- a/go/third_party/io_bazel_rules_go/PR-2181-rebase-master.patch
+++ b/go/third_party/io_bazel_rules_go/PR-2181-rebase-master.patch
@@ -28,7 +28,7 @@ diff --git a/go/core.rst b/go/core.rst
 index 0bd0d242..e5ed564d 100644
 --- a/go/core.rst
 +++ b/go/core.rst
-@@ -61,7 +61,7 @@ These mappings are collected up across the entire transitive dependancies of a
+@@ -61,7 +61,7 @@ These mappings are collected up across the entire transitive dependencies of a
  binary. This means you can set a value using :param:`x_defs` in a
  ``go_library``, and any binary that links that library will be stamped with that
  value. You can also override stamp values from libraries using :param:`x_defs`

--- a/js/packages/components/Onboarding.tsx
+++ b/js/packages/components/Onboarding.tsx
@@ -298,11 +298,11 @@ const NodeConfigInput: React.FC<{
 				<View style={{ flexDirection: 'row', alignItems: 'center' }}>
 					<Text>Persist: </Text>
 					<Switch
-						value={config.opts.persistance}
+						value={config.opts.persistence}
 						onValueChange={() =>
 							onConfigChange({
 								...config,
-								opts: { ...config.opts, persistance: !config.opts.persistance },
+								opts: { ...config.opts, persistence: !config.opts.persistence },
 							})
 						}
 					/>

--- a/js/packages/components/shared-components/CircleAvatar.tsx
+++ b/js/packages/components/shared-components/CircleAvatar.tsx
@@ -18,7 +18,7 @@ type CircleAvatarProps = {
 	state?: {
 		icon: string
 		iconColor?: string
-	} // when group is created, members have a state for know if the memeber accept, is pending or refuse
+	} // when group is created, members have a state for know if the member accept, is pending or refuse
 	style?: StyleProp<any>
 }
 

--- a/js/packages/components/shared-components/FingerprintContent.tsx
+++ b/js/packages/components/shared-components/FingerprintContent.tsx
@@ -5,7 +5,7 @@ import { useStyles } from '@berty-tech/styles'
 import { SHA3 } from 'sha3'
 
 //
-// FingerprintContent => Generally on TabBar there is a TabItem Fingerpint that show this component
+// FingerprintContent => Generally on TabBar there is a TabItem Fingerprint that show this component
 //
 
 // Types

--- a/js/packages/components/shared-components/ProceduralCircleAvatar.tsx
+++ b/js/packages/components/shared-components/ProceduralCircleAvatar.tsx
@@ -19,7 +19,7 @@ type ProceduralCircleAvatarProps = {
 	state?: {
 		icon: string
 		iconColor?: string
-	} // when group is created, members have a state for know if the memeber accept, is pending or refuse
+	} // when group is created, members have a state for know if the member accept, is pending or refuse
 	style?: StyleProp<any>
 }
 

--- a/js/packages/components/shared-components/Request.tsx
+++ b/js/packages/components/shared-components/Request.tsx
@@ -165,7 +165,7 @@ export const MarkAsVerified: React.FC<{}> = () => {
 				style={[text.color.grey, margin.top.medium, text.bold.medium, _styles.markAsVerifiedText]}
 			>
 				Compare the fingerprint displayed above with the one on Caterpillar’s phone. If they are
-				identical, end-to-end encryption is guaranted on you can mark this contact as verified.
+				identical, end-to-end encryption is guaranteed on you can mark this contact as verified.
 			</Text>
 		</View>
 	)

--- a/js/packages/go-bridge/ios/GoBridge.swift
+++ b/js/packages/go-bridge/ios/GoBridge.swift
@@ -30,7 +30,7 @@ class GoBridge: NSObject {
     }
 
     override init() {
-        // set berty dir for persistance
+        // set berty dir for persistence
         let absUserUrl = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
         self.rootdir = absUserUrl.appendingPathComponent("berty", isDirectory: true)
 
@@ -74,7 +74,7 @@ class GoBridge: NSObject {
             }
 
             // gather opts
-            let optPersistance = opts.get(bool: "persistance")
+            let optPersistence = opts.get(bool: "persistence")
             let optLog = opts.get(string: "logLevel", defaultValue: "info")
             let optPOIDebug = opts.get(bool: "poiDebug")
             let optGrpcListeners = opts.get(array: "grpcListeners", defaultValue: ["/ip4/127.0.0.1/tcp/0/grpcws"])
@@ -112,8 +112,8 @@ class GoBridge: NSObject {
                 config.addSwarmListener(listener)
             }
 
-            // set persistance if needed
-            if optPersistance {
+            // set persistence if needed
+            if optPersistence {
                 var isDirectory: ObjCBool = true
                 let exist = FileManager.default.fileExists(atPath: self.rootdir.path, isDirectory: &isDirectory)
                 if !exist {

--- a/js/packages/go-bridge/types.ts
+++ b/js/packages/go-bridge/types.ts
@@ -8,7 +8,7 @@ export enum GoLogLevel {
 export type GoBridgeOpts = {
 	swarmListeners?: string[]
 	grpcListeners?: string[]
-	persistance?: boolean
+	persistence?: boolean
 	logLevel?: GoLogLevel
 	tracing?: boolean
 	tracingPrefix?: string

--- a/js/packages/store/protocol/client.ts
+++ b/js/packages/store/protocol/client.ts
@@ -302,7 +302,7 @@ export const defaultBridgeOpts: GoBridgeOpts = {
 	grpcListeners: ['/ip4/127.0.0.1/tcp/0/grpcws'],
 	logLevel: GoLogLevel.debug,
 	poiDebug: true,
-	persistance: true,
+	persistence: true,
 	tracing: true,
 	tracingPrefix: '',
 	localDiscovery: true,

--- a/js/packages/store/settings/main.ts
+++ b/js/packages/store/settings/main.ts
@@ -90,7 +90,7 @@ const eventHandler = createSlice<State, Events>({
 			state[payload.id].systemInfo = payload.info
 			return state
 		},
-		// put reducer implementaion here
+		// put reducer implementation here
 	},
 })
 


### PR DESCRIPTION
Fixed files

```
berty/bazel.make:24:13: "OVERRIDEN" is a misspelling of "OVERRIDDEN"
berty/bazel.make:105:66: "OVERRIDEN" is a misspelling of "OVERRIDDEN"
berty/go/third_party/io_bazel_rules_go/PR-2181-rebase-0.20.1.patch:31:79: "dependancies" is a misspelling of "dependencies"
berty/go/third_party/io_bazel_rules_go/PR-2181-rebase-master.patch:31:79: "dependancies" is a misspelling of "dependencies"
berty/js/packages/components/Onboarding.tsx:305:32: "persistance" is a misspelling of "persistence"
berty/js/packages/components/shared-components/CircleAvatar.tsx:21:66: "memeber" is a misspelling of "member"
berty/js/packages/components/shared-components/FingerprintContent.tsx:8:64: "Fingerpint" is a misspelling of "Fingerprint"
berty/js/packages/components/shared-components/ProceduralCircleAvatar.tsx:22:66: "memeber" is a misspelling of "member"
berty/js/packages/components/shared-components/Request.tsx:168:40: "guaranted" is a misspelling of "guaranteed"
berty/js/packages/go-bridge/ios/GoBridge.swift:33:29: "persistance" is a misspelling of "persistence"
berty/js/packages/go-bridge/ios/GoBridge.swift:77:49: "persistance" is a misspelling of "persistence"
berty/js/packages/go-bridge/ios/GoBridge.swift:115:19: "persistance" is a misspelling of "persistence"
berty/js/packages/go-bridge/types.ts:11:1: "persistance" is a misspelling of "persistence"
berty/js/packages/store/protocol/client.ts:305:1: "persistance" is a misspelling of "persistence"
berty/js/packages/store/settings/main.ts:93:17: "implementaion" is a misspelling of "implementation"
```