### PR TITLE
chore: JS makefile: add env args and no-dep make targets

### DIFF
--- a/js/Makefile
+++ b/js/Makefile
@@ -36,24 +36,30 @@ clisim := packages/berty-app/node_modules/.bin/clisim
 
 .PHONY: help
 help:
-	@echo "User commands"
+	@echo "User commands                                                env options"
 	@echo "  android.run        "
 	@echo "  android.storybook  "
-	@echo "  bridge.start       "
+	@echo "  bridge.start                                               BERTY_BRIDGE_PORT=1337"
 	@echo "  clean              clear cache"
 	@echo "  deps.update        "
 	@echo "  generate           use protobuf to generate files"
-	@echo "  ios.run            "
+	@echo "  ios.run                                                    IOS_DEVICE='iPhone 11'"
 	@echo "  ios.storybook      "
 	@echo "  lint               "
 	@echo "  lint.fix           "
+	@echo "  lint.quick         lint without verifying deps"
 	@echo "  metro.start        "
 	@echo "  regenerate         "
 	@echo "  test               run tests"
+	@echo "  test.quick         run tests without verifying deps"
 	@echo "  web.storybook      "
 
 .PHONY: test
 test: deps
+	yarn test
+
+.PHONY: test.quick
+test.quick:
 	yarn test
 
 .PHONY: deps.update
@@ -128,6 +134,14 @@ lint: deps
 .PHONY: lint.fix
 lint.fix: deps
 	eslint --fix .
+
+.PHONY: lint.quick
+lint.quick:
+	cp .gitignore .eslintignore
+	echo "packages/store/protocol/grpc-web-gen/" >> .eslintignore
+	echo "*.pb.*" >> .eslintignore
+	echo "*.gen.*" >> .eslintignore
+	eslint --cache --quiet --ext=.js,.jsx,.ts,.tsx .
 
 print-%: ; @echo $* = $($*)
 

--- a/js/gen.sum
+++ b/js/gen.sum
@@ -1,5 +1,5 @@
 27b28bf3451192effed2411e86def7198ce72909  .tmp/stripped-api/bertymessenger.proto
 28771eef5d4bc14523168fac138590d6f93df365  .tmp/stripped-api/bertytypes.proto
-4643cb60c9372e911e7e72d0a3be5cf195028425  Makefile
 4c0fa735ab710727c465ed1444dc6db1c748dc45  ../vendor/github.com/gogo/protobuf/gogoproto/gogo.proto
+a36ea21ff9cbc97da609189bc3703a5eaa77d3f9  Makefile
 fa793842963c3aa65da2b94883687e029d9d8d8e  .tmp/stripped-api/bertyprotocol.proto


### PR DESCRIPTION
- Adds env variable options with defaults to some commands (not exhaustive)
- Adds `.quick` targets for `lint` and `test` (`deps` verification is currently too slow to use repeatedly)

<img width="573" alt="image" src="https://user-images.githubusercontent.com/24300177/86377840-26758980-bc89-11ea-8c8f-7df7b35a0af1.png">