### PR TITLE
chore: set up release not preview on PR

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,0 +1,22 @@
+name: PR
+
+on:
+  pull_request:
+    branches: [ master ]
+  issue_comment:
+    types: [ edited ]
+
+jobs:
+  preview:
+    name: Release Note Preview
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - run: |
+        git fetch --prune --unshallow --tags
+    - uses: snyk/release-notes-preview@v1.6.1
+      with:
+        releaseBranch: master
+      env:
+        GITHUB_PR_USERNAME: ${{ github.actor }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
set up this: https://github.com/marketplace/actions/release-notes-preview