### PR TITLE
chore(js): add 'make bridge.start.docker' rule

### DIFF
--- a/js/Makefile
+++ b/js/Makefile
@@ -36,23 +36,24 @@ clisim := packages/berty-app/node_modules/.bin/clisim
 
 .PHONY: help
 help:
-	@echo "User commands                                                env options"
-	@echo "  android.run        "
-	@echo "  android.storybook  "
-	@echo "  bridge.start                                               BERTY_BRIDGE_PORT=1337"
-	@echo "  clean              clear cache"
-	@echo "  deps.update        "
-	@echo "  generate           use protobuf to generate files"
-	@echo "  ios.run                                                    IOS_DEVICE='iPhone 11'"
-	@echo "  ios.storybook      "
-	@echo "  lint               "
-	@echo "  lint.fix           "
-	@echo "  lint.quick         lint without verifying deps"
-	@echo "  metro.start        "
-	@echo "  regenerate         "
-	@echo "  test               run tests"
-	@echo "  test.quick         run tests without verifying deps"
-	@echo "  web.storybook      "
+	@echo "User commands          Description                             Main env options"
+	@echo "  android.run"
+	@echo "  android.storybook"
+	@echo "  bridge.start                                                 BERTY_BRIDGE_PORT=1337"
+	@echo "  bridge.start.docker                                          BERTY_BRIDGE_PORT=1337"
+	@echo "  clean                clear cache"
+	@echo "  deps.update"
+	@echo "  generate             use protobuf to generate files"
+	@echo "  ios.run                                                      IOS_DEVICE='iPhone 11'"
+	@echo "  ios.storybook"
+	@echo "  lint"
+	@echo "  lint.fix"
+	@echo "  lint.quick           lint without verifying deps"
+	@echo "  metro.start"
+	@echo "  regenerate"
+	@echo "  test                 run tests"
+	@echo "  test.quick           run tests without verifying deps"
+	@echo "  web.storybook"
 
 .PHONY: test
 test: deps
@@ -231,8 +232,12 @@ bridge.start:
 	cd ../go && $(MAKE) install
 	$(GOPATH)/bin/berty daemon -l /ip4/127.0.0.1/tcp/$(BERTY_BRIDGE_PORT)/grpcws
 
+.PHONY: bridge.start.docker
+bridge.start.docker:
+	$(call check-program, docker)
+	docker run -it --rm -p $(BERTY_BRIDGE_PORT):$(BERTY_BRIDGE_PORT) bertytech/berty daemon -l /ip4/0.0.0.0/tcp/$(BERTY_BRIDGE_PORT)/grpcws
+
 ### gen
-### TODO: consider putting all the generation deps in bertytech/protoc docker image and remove the `deps` rule dep to only require docker
 
 #### pbhbs based code generation
 

--- a/js/gen.sum
+++ b/js/gen.sum
@@ -1,12 +1,12 @@
 0c5c61ea1fed8180ad37c5e261fda0dbe15f439f  packages/store/protocol/ProtocolServiceClient.gen.ts.hbs
 109c92178d930d49161d85a08dbf50ecb62efc99  packages/components/faker.gen.tsx.hbs
 23bcfc76c7967f804ae23af8d7c65b0e8ce17740  packages/store/protocol/client.gen.ts.hbs
+2d133bba134fef4f23b3087a76907783bbd4f460  Makefile
 4989b51bf6dfc52cd195cc46db1732a81090191f  ../api/bertyprotocol.proto
 4c0fa735ab710727c465ed1444dc6db1c748dc45  ../vendor/github.com/gogo/protobuf/gogoproto/gogo.proto
 79cc69e3078dc058c0f82cb852e8dd54871af7e2  packages/store/messenger/client.gen.ts.hbs
 805aee6ffe307df914ec45a89d6bb05dcbd5a33a  packages/store/types/events.gen.ts.hbs
 933afb5edbb7027e0dafd10e31601a10fc741b12  ../api/bertymessenger.proto
 cdcfd4235af64debca29d0553209a34df7899361  ../api/bertytypes.proto
-da7c5600ba2035ee97874b61d7c8aeede43396a3  Makefile
 e3fb6d1b91d746e062c3ceda2d8908108b4b791c  packages/store/protocol/ProtocolServiceSagaClient.gen.ts.hbs
 fff74e17f874124b181741e1f0271e10520159b6  packages/store/messenger/MessengerServiceSagaClient.gen.ts.hbs


### PR DESCRIPTION
* add a new `make bridge.start.docker` rule in `js/`
* tested with latest Docker for Mac
* cc @alexarsh

## Demo:

![Screenshot - Manfred 2020-07-03 at 20 59 42](https://user-images.githubusercontent.com/94029/86493075-65323f00-bd70-11ea-83a3-55f2985a796d.gif)

## How-to:

* `cd js; make bridge.start.docker` in a terminal
* `cd js; make metro.start` in another one
* `cd js; make ios.run` from a last one
* in the iOS simulator, let the default `External` toggle + `1337` port