### PR TITLE
feat(js): add flex utils to style API

### DIFF
--- a/js/packages/components/main/Search.tsx
+++ b/js/packages/components/main/Search.tsx
@@ -58,15 +58,15 @@ const useStylesSearch = () => {
 }
 
 const SearchTitle: React.FC<{}> = () => {
-	const [{ text, color }] = useStyles()
+	const [{ text, color, flex }] = useStyles()
 	const { dispatch } = useNavigation()
 	return (
 		<View
 			style={[
+				flex.direction.row,
+				flex.justify.center,
+				flex.align.center,
 				{
-					flexDirection: 'row',
-					justifyContent: 'center',
-					alignItems: 'center',
 					marginLeft: _titleIconSize,
 				},
 			]}
@@ -77,10 +77,10 @@ const SearchTitle: React.FC<{}> = () => {
 					text.bold.medium,
 					text.color.white,
 					text.align.center,
+					flex.align.center,
+					flex.justify.center,
 					{
 						flexShrink: 0,
-						alignItems: 'center',
-						justifyContent: 'center',
 						flexGrow: 1,
 					},
 				]}
@@ -300,7 +300,7 @@ const SearchResultItem: React.FC<SearchItemProps> = ({ data, searchTextKey, sear
 					style={[padding.tiny, row.item.justify]}
 				/>
 				<View style={[flex.medium, column.justify, padding.left.medium]}>
-					<View style={[{ flexDirection: 'row', alignItems: 'center' }]} />
+					<View style={[flex.direction.row, flex.align.center]} />
 					<View style={[margin.right.big]}>
 						<Text numberOfLines={1} style={[text.bold.medium, !convId && text.color.grey]}>
 							{name}

--- a/js/packages/styles/map-declaration.ts
+++ b/js/packages/styles/map-declaration.ts
@@ -111,6 +111,25 @@ export const mapDeclaration = (decl: Declaration): Styles => {
 				big: { flex: 8 },
 				huge: { flex: 13 },
 			}),
+			direction: StyleSheet.create({
+				row: { flexDirection: 'row' },
+				column: { flexDirection: 'column' },
+			}),
+			align: StyleSheet.create({
+				baseline: { alignItems: 'baseline' },
+				center: { alignItems: 'center' },
+				end: { alignItems: 'flex-end' },
+				start: { alignItems: 'flex-start' },
+				stretch: { alignItems: 'stretch' },
+			}),
+			justify: StyleSheet.create({
+				center: { justifyContent: 'center' },
+				end: { justifyContent: 'flex-end' },
+				spaceAround: { justifyContent: 'space-around' },
+				spaceBetween: { justifyContent: 'space-between' },
+				spaceEvenly: { justifyContent: 'space-evenly' },
+				start: { justifyContent: 'flex-start' },
+			}),
 			scale: mem((size: number) => StyleSheet.create({ scale: { flex: size } }).scale),
 		},
 		absolute: {

--- a/js/packages/styles/types.ts
+++ b/js/packages/styles/types.ts
@@ -54,12 +54,13 @@ export type AlignHorizontal<T> = {
 	fill: T
 }
 
-export type AlignVerticalTypes = 'top' | 'bottom' | 'justify' | 'fill'
+export type AlignVerticalTypes = 'top' | 'bottom' | 'justify' | 'fill' | 'center'
 export type AlignVertical<T> = {
 	top: T
 	bottom: T
 	justify: T
 	fill: T
+	center?: T
 }
 
 export type AlignTypes = [AlignHorizontalTypes, AlignVerticalTypes]
@@ -109,6 +110,40 @@ export type Border<T> = Sizes<T> &
 		color: Colors<T> & ColorsBrightness<T>
 	}
 
+export type FlexJustifyTypes =
+	| 'center'
+	| 'flex-end'
+	| 'flex-start'
+	| 'space-around'
+	| 'space-between'
+	| 'space-evenly'
+export type FlexJustifyType = { justifyContent: FlexJustifyTypes }
+export type FlexJustify<FlexJustifyType> = {
+	center: FlexJustifyType
+	end: FlexJustifyType
+	spaceAround: FlexJustifyType
+	spaceBetween: FlexJustifyType
+	spaceEvenly: FlexJustifyType
+	start: FlexJustifyType
+}
+
+export type FlexAlignTypes = 'stretch' | 'center' | 'flex-start' | 'flex-end' | 'baseline'
+export type FlexAlignType = { alignItems: FlexAlignTypes }
+export type FlexAlign<FlexAlignType> = {
+	baseline: FlexAlignType
+	center: FlexAlignType
+	end: FlexAlignType
+	start: FlexAlignType
+	stretch: FlexAlignType
+}
+
+export type FlexDirectionTypes = 'row' | 'column'
+export type FlexDirectionType = { flexDirection: FlexDirectionTypes }
+export type FlexDirection<FlexDirectionType> = {
+	row: FlexDirectionType
+	column: FlexDirectionType
+}
+
 export type Declaration = {
 	colors: ColorsDeclaration
 	sides: SizesDeclaration<number>
@@ -134,7 +169,11 @@ export type Styles = {
 	row: AlignHorizontal<{}> & {
 		item: AlignVertical<{}>
 	}
-	flex: Sizes<{}>
+	flex: Sizes<{}> & {
+		align: FlexAlign<FlexAlignType>
+		justify: FlexJustify<FlexJustifyType>
+		direction: FlexDirection<FlexDirectionType>
+	}
 	width: (width: number) => {}
 	height: (height: number) => {}
 	maxWidth: (maxWidth: number) => {}


### PR DESCRIPTION
Adds non-abstract flex utils, so we can now use:
`flex.direction` (flexDirection), `flex.align` (alignItems), `flex.justify` (justifyContent)

The old flex abstractions are still possible to use (`row.left` for example)


Closes #2141