### PR TITLE
fix: broken golangci github action

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -51,7 +51,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v1
         with:
-          version: v1.27
+          version: v1.28
           working-directory: go
           args: --timeout=2m
           # only-new-issues: true


### PR DESCRIPTION
Last update on golangci-lint-action (https://github.com/golangci/golangci-lint-action/pull/34) requires having golangci-lint v1.28.3