### PR TITLE
feat(messenger): add avatar and name to multimember conversation

### DIFF
--- a/js/packages/components/chat/ChatGroup.tsx
+++ b/js/packages/components/chat/ChatGroup.tsx
@@ -209,6 +209,10 @@ const MessageList: React.FC<{ id: string }> = ({ id }) => {
 	if (!conversation) {
 		return <CenteredActivityIndicator />
 	}
+	const getPreviousMessageId = (item = '', messageList: string[] = []): string => {
+		const messagePosition: number = !item ? -1 : messageList.indexOf(item)
+		return messagePosition < 1 ? '' : messageList[messagePosition - 1]
+	}
 	return (
 		<FlatList
 			keyboardDismissMode='on-drag'
@@ -217,7 +221,13 @@ const MessageList: React.FC<{ id: string }> = ({ id }) => {
 			inverted
 			ListFooterComponent={<InfosChatGroup {...conversation} />}
 			renderItem={({ item }) => (
-				<Message id={item} convKind='multi' key={item} membersNames={conversation.membersNames} />
+				<Message
+					id={item}
+					convKind='multi'
+					key={item}
+					membersNames={conversation.membersNames}
+					previousMessageId={getPreviousMessageId(item, conversation.messages)}
+				/>
 			)}
 		/>
 	)


### PR DESCRIPTION
Credit for this goes to 
- Adds avatar and username (already done by @clegirar or @n0izn0iz, I've just added it back)
- Puts username inside message body container
- Hides username, timestamp and avatar on follow-up messages (messages where previous message is from same non-self user and is more than 10 minutes time difference)

<img width="351" alt="image" src="https://user-images.githubusercontent.com/24300177/88291702-aa3df700-ccc6-11ea-8488-6297fe558f72.png">




Closes #2187