### PR TITLE
chore(front): Use dynamic UI scale values from styles API

### DIFF
--- a/js/packages/components/Onboarding.tsx
+++ b/js/packages/components/Onboarding.tsx
@@ -171,7 +171,7 @@ export const SelectMode: React.FC = () => {
 }
 
 const SwiperCard: React.FC<{
-	label?: 'required' | 'optional' | 'recommanded' | ''
+	label?: 'required' | 'optional' | 'recommended' | ''
 	header?: string
 	title: string
 	description: string
@@ -190,7 +190,7 @@ const SwiperCard: React.FC<{
 		case 'optional':
 			labelColor = 'yellow'
 			break
-		case 'recommanded':
+		case 'recommended':
 			labelColor = 'green'
 			break
 	}
@@ -439,7 +439,7 @@ const Notifications: React.FC<{
 		{(t) => (
 			<SwiperCard
 				header={t('onboarding.notifications.header')}
-				label={t('onboarding.notifications.recommanded')}
+				label={t('onboarding.notifications.recommended')}
 				title={t('onboarding.notifications.title')}
 				description={t('onboarding.notifications.desc')}
 				button={{
@@ -692,8 +692,10 @@ export const Privacy: React.FC<{}> = () => {
 						activeDotStyle={[background.white]}
 						scrollEnabled={false}
 					>
-						<CreateYourAccount next={next(2)} setClickedCreate={setClickedCreate} />
-						<SetupFinished />
+						{!clickedCreate && (
+							<CreateYourAccount next={next(2)} setClickedCreate={setClickedCreate} />
+						)}
+						{clickedCreate && <SetupFinished />}
 					</Swiper>
 				</KeyboardAvoidingView>
 			</View>

--- a/js/packages/components/chat/MultiMemberQR.tsx
+++ b/js/packages/components/chat/MultiMemberQR.tsx
@@ -2,11 +2,11 @@ import React from 'react'
 import QRCode from 'react-native-qrcode-svg'
 import { View } from 'react-native'
 import { Button } from 'react-native-ui-kitten'
-import { useDimensions } from '@react-native-community/hooks'
 import { SafeAreaConsumer } from 'react-native-safe-area-context'
 
 import { ScreenProps, useNavigation } from '@berty-tech/navigation'
 import { Messenger } from '@berty-tech/hooks'
+import { useStyles } from '@berty-tech/styles'
 
 const _contentScaleFactor = 0.66
 
@@ -15,7 +15,7 @@ export const MultiMemberQR: React.FC<ScreenProps.Chat.MultiMemberQR> = ({
 		params: { convId },
 	},
 }) => {
-	const { height, width } = useDimensions().window
+	const [, { windowHeight, windowWidth }] = useStyles()
 	const conv = Messenger.useGetConversation(convId)
 	const { goBack } = useNavigation()
 	if (!conv) {
@@ -35,7 +35,7 @@ export const MultiMemberQR: React.FC<ScreenProps.Chat.MultiMemberQR> = ({
 					]}
 				>
 					<QRCode
-						size={_contentScaleFactor * Math.min(height, width)}
+						size={_contentScaleFactor * Math.min(windowHeight, windowWidth)}
 						value={conv.shareableGroup}
 					/>
 					<Button style={[{ marginTop: 40 }]} onPress={goBack}>

--- a/js/packages/components/main/CreateGroupAddMembers.tsx
+++ b/js/packages/components/main/CreateGroupAddMembers.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 import { View, ScrollView, TouchableOpacity, TextInput, Text as TextNative } from 'react-native'
 import { Layout, Text, Icon, CheckBox } from 'react-native-ui-kitten'
 import { useStyles } from '@berty-tech/styles'
@@ -7,7 +7,6 @@ import { useNavigation } from '@berty-tech/navigation'
 import { Messenger } from '@berty-tech/hooks'
 import { messenger } from '@berty-tech/store'
 import { SafeAreaView } from 'react-native-safe-area-context'
-import { useDimensions } from '@react-native-community/hooks'
 import { FooterCreateGroup } from './CreateGroupFooter'
 import { Header } from './HomeModal'
 
@@ -113,12 +112,14 @@ const AddMembers: React.FC<AddMembersProps> = ({
 	members,
 	layout,
 }) => {
-	const [{ padding, background, row, color, height, text, margin, border }] = useStyles()
+	const [
+		{ padding, background, row, color, height, text, margin, border },
+		{ windowHeight },
+	] = useStyles()
 	const [searchText, setSearchText] = useState('')
 	const contacts = searchText.length
 		? Messenger.useAccountContactSearchResults(searchText)
 		: Messenger.useAccountContacts()
-	const dimensions = useDimensions().window
 
 	return (
 		<View>
@@ -138,7 +139,7 @@ const AddMembers: React.FC<AddMembersProps> = ({
 						autoCorrect={false}
 					/>
 				</View>
-				<View style={[height(dimensions.height - layout - 90)]}>
+				<View style={[height(windowHeight - layout - 90)]}>
 					<ScrollView
 						contentContainerStyle={[
 							padding.top.medium,

--- a/js/packages/components/main/CreateGroupFinalize.tsx
+++ b/js/packages/components/main/CreateGroupFinalize.tsx
@@ -1,13 +1,12 @@
 import { ButtonSettingItem } from '../shared-components/SettingsButtons'
 import React, { useState, useEffect } from 'react'
-import { View, TouchableOpacity, TextInput, Dimensions, StyleSheet, ScrollView } from 'react-native'
+import { View, TouchableOpacity, TextInput, StyleSheet, ScrollView } from 'react-native'
 import { Layout, Text, Icon } from 'react-native-ui-kitten'
 import { useStyles } from '@berty-tech/styles'
 import { useNavigation } from '@berty-tech/navigation'
 import { Messenger } from '@berty-tech/hooks'
 import { messenger } from '@berty-tech/store'
 import { SafeAreaView } from 'react-native-safe-area-context'
-import { useDimensions } from '@react-native-community/hooks'
 import { FooterCreateGroup } from './CreateGroupFooter'
 import { CreateGroupHeader } from './CreateGroupAddMembers'
 import { Header } from './HomeModal'
@@ -101,11 +100,10 @@ type GroupInfoProps = { onGroupNameChange: (name: string) => void; layout: numbe
 const GroupInfo: React.FC<GroupInfoProps> = ({ onGroupNameChange, layout }) => {
 	const [
 		{ row, background, column, margin, flex, height, border, padding, color, text },
-		{ scaleSize },
+		{ scaleSize, windowHeight },
 	] = useStyles()
 	const _styles = useStylesCreateGroup()
-	const dimensions = useDimensions().window
-	const restScreen = dimensions.height - layout - 400 * scaleSize // Rest of screen // 400 = size of the component (300) + header (90) + padding (10)
+	const restScreen = windowHeight - layout - 400 * scaleSize // Rest of screen // 400 = size of the component (300) + header (90) + padding (10)
 	const paddingBottom =
 		restScreen < 90 * scaleSize ? 90 * scaleSize - restScreen + 20 * scaleSize : 0 // Padding in scrollview if the rest of screen was smaller than footer // 90 = size of footer, 20 = padding
 

--- a/js/packages/components/main/HomeModal.tsx
+++ b/js/packages/components/main/HomeModal.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-native/no-inline-styles */
 import React from 'react'
 import {
 	View,
@@ -19,16 +18,13 @@ import { CommonActions } from '@react-navigation/core'
 import Interactable from 'react-native-interactable'
 import FromNow from '../shared-components/FromNow'
 import EmptyContact from './empty_contact.svg'
-import { useDimensions } from '@react-native-community/hooks'
 
 const useStylesList = () => {
 	const shortScreenMax = 640
-	const iPadShortEdge = 768
-	const iPadLongEdge = 1024
 	const [
-		{ absolute, margin, padding, width, height, border, background, row, column },
+		{ absolute, margin, padding, height, border, background, row, column },
+		{ windowHeight },
 	] = useStyles()
-	const { height: windowHeight, width: windowWidth } = useDimensions().window
 
 	return {
 		tinyAvatar: [absolute.scale({ top: -32.5 }), row.item.justify],
@@ -47,15 +43,7 @@ const useStylesList = () => {
 			border.radius.scale(6),
 			border.color.light.grey,
 		],
-		addContactItem: [height(115), width(150)],
-		addContactItemText: width(75),
-		windowHeight,
-		windowWidth,
-		isLandscape: windowHeight < windowWidth,
 		isShortWindow: windowHeight <= shortScreenMax,
-		isGteIpadSize:
-			Math.min(windowHeight, windowWidth) >= iPadShortEdge &&
-			Math.max(windowHeight, windowWidth) >= iPadLongEdge,
 	}
 }
 
@@ -134,7 +122,10 @@ export const Header: React.FC<{
 const RequestsItem: React.FC<messenger.contact.Entity> = ({ name, request, publicKey, id }) => {
 	const { dispatch } = useNavigation()
 	const _styles = useStylesList()
-	const [{ border, column, flex, row, padding, text, background, color }] = useStyles()
+	const [
+		{ border, column, flex, row, padding, text, background, color },
+		{ scaleSize },
+	] = useStyles()
 	const discardContactRequest = Messenger.useDiscardContactRequest()
 	const discard = () => discardContactRequest({ id })
 	if (request.type !== messenger.contact.ContactRequestType.Outgoing) {
@@ -175,7 +166,12 @@ const RequestsItem: React.FC<messenger.contact.Entity> = ({ name, request, publi
 					style={[_styles.tinyDiscardButton, border.scale(1), row.item.justify]}
 					onPress={discard}
 				>
-					<Icon name='close-outline' width={20} height={20} fill={color.grey} />
+					<Icon
+						name='close-outline'
+						width={20 * scaleSize}
+						height={20 * scaleSize}
+						fill={color.grey}
+					/>
 				</TouchableOpacity>
 				<TouchableOpacity
 					disabled={!(request.state === 'sent')}
@@ -184,8 +180,8 @@ const RequestsItem: React.FC<messenger.contact.Entity> = ({ name, request, publi
 					<View style={[row.item.justify, padding.right.scale(3)]}>
 						<Icon
 							name='paper-plane-outline'
-							width={17}
-							height={17}
+							width={17 * scaleSize}
+							height={17 * scaleSize}
 							fill={color.green}
 							style={column.justify}
 						/>
@@ -205,8 +201,11 @@ const EmptyTab: React.FC<{}> = ({ children }) => {
 }
 
 const Requests: React.FC<{}> = () => {
-	const [{ padding, background, column, text, opacity }, { scaleHeight }] = useStyles()
-	const { isLandscape, isShortWindow, isGteIpadSize } = useStylesList()
+	const [
+		{ padding, background, column, text, opacity },
+		{ scaleHeight, isGteIpadSize },
+	] = useStyles()
+	const { isShortWindow } = useStylesList()
 
 	const requests = Messenger.useAccountContactsWithOutgoingRequests().filter(
 		(contact) => !(contact.request.accepted || contact.request.discarded) && !contact.fake,
@@ -225,7 +224,10 @@ const Requests: React.FC<{}> = () => {
 	) : (
 		<EmptyTab>
 			<View
-				style={[column.justify, { height: isLandscape && !isGteIpadSize ? 0 : 200 * scaleHeight }]}
+				style={[
+					column.justify,
+					{ height: isShortWindow && !isGteIpadSize ? 0 : 200 * scaleHeight },
+				]}
 			>
 				{!isShortWindow && <EmptyContact width='75%' height='75%' style={[column.item.center]} />}
 				<Text style={[text.color.grey, opacity(0.4)]}>You don't have any pending requests</Text>
@@ -236,81 +238,104 @@ const Requests: React.FC<{}> = () => {
 
 const AddContact: React.FC<{}> = () => {
 	const navigation = useNavigation()
-	const _styles = useStylesList()
-	const [{ padding, row, column, border, background, color, text, flex, height }] = useStyles()
+	const [
+		{
+			padding,
+			row,
+			border,
+			background,
+			color,
+			text,
+			flex,
+			maxWidth,
+			height,
+			column,
+			margin,
+			width,
+		},
+		{ scaleSize },
+	] = useStyles()
+	const { isShortWindow } = useStylesList()
+
+	const addContactItemContainer = [
+		padding.medium,
+		border.radius.medium,
+		margin.bottom.small,
+		margin.horizontal.medium,
+		column.justify,
+		maxWidth(250),
+		{
+			flexBasis: 175 * scaleSize,
+			flexGrow: 1,
+			flexShrink: 0,
+		},
+		!isShortWindow && height(115),
+	]
+
+	const addContactItemText = [
+		text.color.white,
+		isShortWindow ? [{ width: '100%' }, text.align.center] : width(75),
+	]
+	const addContactItemIconWrapper = [
+		isShortWindow && { display: 'none' },
+		row.fill,
+		flex.justify.end,
+		flex.align.center,
+		padding.tiny,
+	]
 
 	return (
 		<View
-			style={[background.white, _styles.isShortWindow ? padding.bottom.medium : padding.bottom.big]}
+			style={[
+				background.white,
+				padding.bottom.medium,
+				row.center,
+				{
+					flexWrap: 'wrap',
+				},
+			]}
 		>
-			<View style={[row.center]}>
-				<TouchableOpacity
-					style={[
-						background.red,
-						padding.medium,
-						border.radius.medium,
-						column.justify,
-						!_styles.isShortWindow && _styles.addContactItem,
-					]}
-					onPress={() => navigation.navigate.main.scan()}
-				>
-					<View
-						style={[
-							row.fill,
-							!_styles.isShortWindow && height(45),
-							!_styles.isShortWindow ? flex.justify.end : flex.justify.center,
-							!_styles.isShortWindow ? flex.align.start : flex.align.center,
-						]}
-					>
-						{!_styles.isShortWindow && (
-							<Icon name='qr' pack='custom' width={38} height={38} fill={color.white} />
-						)}
-					</View>
-					<View style={[row.fill]}>
-						<Text numberOfLines={2} style={[text.color.white, _styles.addContactItemText]}>
-							Scan QR code
-						</Text>
-						<View />
-					</View>
-				</TouchableOpacity>
-				<TouchableOpacity
-					style={[
-						background.blue,
-						padding.medium,
-						border.radius.medium,
-						column.justify,
-						!_styles.isShortWindow && _styles.addContactItem,
-					]}
-					onPress={() => navigation.navigate.settings.myBertyId()}
-				>
-					<View
-						style={[
-							row.fill,
-							!_styles.isShortWindow && height(45),
-							!_styles.isShortWindow ? flex.justify.end : flex.justify.center,
-							!_styles.isShortWindow ? flex.align.start : flex.align.center,
-						]}
-					>
-						{!_styles.isShortWindow && (
-							<Icon name='id' pack='custom' width={40} height={40} fill={color.white} />
-						)}
-					</View>
-					<View style={[row.fill]}>
-						<Text numberOfLines={2} style={[text.color.white, _styles.addContactItemText]}>
-							Share my Berty ID
-						</Text>
-						<View />
-					</View>
-				</TouchableOpacity>
-			</View>
+			<TouchableOpacity
+				style={[background.red, addContactItemContainer]}
+				onPress={() => navigation.navigate.main.scan()}
+			>
+				<View style={[addContactItemIconWrapper]}>
+					<Icon
+						name='qr'
+						pack='custom'
+						width={38 * scaleSize}
+						height={38 * scaleSize}
+						fill={color.white}
+					/>
+				</View>
+				<Text numberOfLines={2} style={[addContactItemText]}>
+					Scan QR code
+				</Text>
+			</TouchableOpacity>
+			<TouchableOpacity
+				style={[background.blue, addContactItemContainer]}
+				onPress={() => navigation.navigate.settings.myBertyId()}
+			>
+				<View style={[addContactItemIconWrapper]}>
+					<Icon
+						name='id'
+						pack='custom'
+						width={40 * scaleSize}
+						height={40 * scaleSize}
+						fill={color.white}
+					/>
+				</View>
+				<Text numberOfLines={2} style={[addContactItemText]}>
+					Share my Berty ID
+				</Text>
+			</TouchableOpacity>
 		</View>
 	)
 }
 
 export const HomeModal: React.FC<{}> = () => {
 	const navigation = useNavigation()
-	const [{ absolute }] = useStyles()
-	const { windowHeight } = useStylesList()
+	const [{ absolute }, { windowHeight }] = useStyles()
 
 	const handleOnDrag = (e: Interactable.IDragEvent) => {
 		if (e.nativeEvent.y >= Math.min(250, windowHeight * 0.9)) {

--- a/js/packages/components/main/Scan.tsx
+++ b/js/packages/components/main/Scan.tsx
@@ -8,7 +8,6 @@ import { useNavigation } from '@react-navigation/native'
 import ScanTarget from './scan_target.svg'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import { Messenger } from '@berty-tech/hooks'
-import { useDimensions } from '@react-native-community/hooks'
 
 //
 // Scan => Scan QrCode of an other contact
@@ -22,20 +21,9 @@ type ScanInfosTextProps = {
 // Styles
 
 const useStylesScan = () => {
-	const [{ border, height, width }] = useStyles()
-	const { height: windowHeight, width: windowWidth } = useDimensions().window
-	const titleSize = 26
-	const iPadShortEdge = 768
-	const iPadLongEdge = 1024
+	const [{ border, height, width }, { fontScale }] = useStyles()
 	return {
-		titleSize,
-
-		windowHeight,
-		windowWidth,
-		isLandscape: windowHeight < windowWidth,
-		isGteIpadSize:
-			Math.min(windowHeight, windowWidth) >= iPadShortEdge &&
-			Math.max(windowHeight, windowWidth) >= iPadLongEdge,
+		titleSize: 26 * fontScale,
 		styles: {
 			infosPoint: [width(10), height(10), border.radius.scale(5)],
 		},
@@ -45,12 +33,16 @@ const useStylesScan = () => {
 const ScanBody: React.FC<{}> = () => {
 	const handleDeepLink = Messenger.useHandleDeepLink()
 	const navigation = useNavigation()
-	const [{ background, margin, flex, column }] = useStyles()
-	const { windowWidth, windowHeight, titleSize, isGteIpadSize } = useStylesScan()
+	const [
+		{ background, margin, flex, column, border },
+		{ windowHeight, windowWidth, isGteIpadSize },
+	] = useStyles()
+	const { titleSize } = useStylesScan()
 	const qrScanSize = isGteIpadSize
 		? Math.min(windowHeight, windowWidth) * 0.5
 		: Math.min(windowHeight * 0.8, windowWidth * 0.8) - 1.25 * titleSize
-	const borderRadius = 30
+	const borderRadius = border.radius.scale(30)
+
 	return (
 		<View
 			style={[
@@ -59,10 +51,10 @@ const ScanBody: React.FC<{}> = () => {
 				column.item.center,
 				flex.align.center,
 				flex.justify.center,
+				borderRadius,
 				{
 					height: qrScanSize,
 					aspectRatio: 1,
-					borderRadius,
 				},
 			]}
 		>
@@ -79,7 +71,7 @@ const ScanBody: React.FC<{}> = () => {
 					}
 				}}
 				cameraProps={{ captureAudio: false }}
-				containerStyle={{ width: '100%', height: '100%', overflow: 'hidden', borderRadius }}
+				containerStyle={[borderRadius, { width: '100%', height: '100%', overflow: 'hidden' }]}
 				cameraStyle={{ width: '100%', height: '100%', aspectRatio: 1 }}
 				// flashMode={RNCamera.Constants.FlashMode.torch}
 			/>

--- a/js/packages/components/main/Search.tsx
+++ b/js/packages/components/main/Search.tsx
@@ -1,10 +1,8 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
 import { Messenger } from '@berty-tech/hooks'
 import { useFirstConversationWithContact, useGetMessage } from '@berty-tech/hooks/Messenger'
 import { Routes, useNavigation } from '@berty-tech/navigation'
 import { messenger } from '@berty-tech/store'
 import { useStyles } from '@berty-tech/styles'
-import { useDimensions } from '@react-native-community/hooks'
 import { CommonActions } from '@react-navigation/core'
 import dayjs from 'dayjs'
 import { noop } from 'lodash'
@@ -29,31 +27,21 @@ const _landingIconSize = 90
 
 const _resultAvatarSize = 45
 
-const _fontSizeSearchComponent = 17 // trying to move away from in-house 'scale' (makes font too small in some devices)
-const _fontSizeSmall = 12
-
-const _searchComponentBorderRadius = 7
 const _searchBarIconSize = 25
 
-const _searchComponentMarginTopFactor = 0.02
 const _approxFooterHeight = 90
 
 const useStylesSearch = () => {
 	const [{ text, background }] = useStyles()
-	const { height: windowHeight, width: windowWidth } = useDimensions().window
-	const isLandscape = () => windowHeight < windowWidth
 
 	return {
 		searchResultHighlightText: [
-			{ fontSize: _fontSizeSmall },
+			text.size.small,
 			text.color.yellow,
 			background.light.yellow,
 			text.bold.medium,
 		],
-		plainMessageText: [{ fontSize: _fontSizeSmall }, text.color.grey],
-		windowHeight,
-		windowWidth,
-		isLandscape,
+		plainMessageText: [text.size.small, text.color.grey],
 	}
 }
 
@@ -80,7 +68,7 @@ const formatTimestamp = (date: Date) => {
 //
 
 const SearchTitle: React.FC<{}> = () => {
-	const [{ text, color, flex }] = useStyles()
+	const [{ text, color, flex, margin }, { scaleSize }] = useStyles()
 	const { dispatch } = useNavigation()
 	return (
 		<View
@@ -88,9 +76,8 @@ const SearchTitle: React.FC<{}> = () => {
 				flex.direction.row,
 				flex.justify.center,
 				flex.align.center,
-				{
-					marginLeft: _titleIconSize,
-				},
+				margin.left.scale(_titleIconSize),
+				margin.top.medium,
 			]}
 		>
 			<Text
@@ -117,8 +104,8 @@ const SearchTitle: React.FC<{}> = () => {
 					},
 				]}
 				name='arrow-forward-outline'
-				width={_titleIconSize}
-				height={_titleIconSize}
+				width={_titleIconSize * scaleSize}
+				height={_titleIconSize * scaleSize}
 				fill={color.white}
 				onPress={() => dispatch(CommonActions.navigate(Routes.Main.Home))}
 			/>
@@ -132,18 +119,21 @@ const SearchBar: React.FC<{
 	onChange: (text: string) => void
 	searchText: string
 }> = ({ onChange, searchText }) => {
-	const [{ row, color, background, text }] = useStyles()
+	const [{ row, color, background, text, margin, padding }, { scaleSize }] = useStyles()
 	const onClear = (): void => {
 		onChange('')
 		Keyboard.dismiss()
 	}
 
 	return (
-		<ScrollView contentContainerStyle={[row.left]} keyboardShouldPersistTaps='handled'>
+		<ScrollView
+			contentContainerStyle={[row.left, { alignItems: 'center' }]}
+			keyboardShouldPersistTaps='handled'
+		>
 			<Icon
 				name='search'
-				width={_searchBarIconSize}
-				height={_searchBarIconSize}
+				width={_searchBarIconSize * scaleSize}
+				height={_searchBarIconSize * scaleSize}
 				fill={color.yellow}
 			/>
 			<TextInput
@@ -151,7 +141,9 @@ const SearchBar: React.FC<{
 				placeholder='Search'
 				placeholderTextColor={color.yellow}
 				style={[
-					{ marginLeft: 15, padding: 4, flex: 2 },
+					{ flex: 2 },
+					padding.scale(4),
+					margin.left.scale(10),
 					background.light.yellow,
 					text.color.yellow,
 				]}
@@ -162,8 +154,8 @@ const SearchBar: React.FC<{
 			{searchText.length > 0 && (
 				<Icon
 					name='close-circle-outline'
-					width={_searchBarIconSize}
-					height={_searchBarIconSize}
+					width={_searchBarIconSize * scaleSize}
+					height={_searchBarIconSize * scaleSize}
 					fill={color.yellow}
 					onPress={onClear}
 					style={[{ marginLeft: 'auto' }]}
@@ -176,16 +168,18 @@ const SearchBar: React.FC<{
 const SearchHint: React.FC<{
 	hintText: string
 }> = ({ hintText = 'Search messages, contacts, or groups...' }) => {
-	const [{ row, color, text, margin, column, padding }] = useStyles()
-	const { windowWidth } = useStylesSearch()
+	const [
+		{ row, color, text, margin, column, padding, width, opacity },
+		{ windowWidth, scaleSize },
+	] = useStyles()
 	return (
-		<View style={[column.top, padding.small, { marginBottom: _approxFooterHeight }]}>
+		<View style={[column.top, padding.small, margin.bottom.scale(_approxFooterHeight)]}>
 			<Icon
 				name='search'
-				width={_landingIconSize}
-				height={_landingIconSize}
+				width={_landingIconSize * scaleSize}
+				height={_landingIconSize * scaleSize}
 				fill={color.light.yellow}
-				style={[row.item.justify, { opacity: 0.8 }]}
+				style={[row.item.justify, opacity(0.8)]}
 			/>
 			<Text
 				style={[
@@ -193,8 +187,9 @@ const SearchHint: React.FC<{
 					margin.top.small,
 					row.item.justify,
 					text.color.light.yellow,
-					text.size.medium,
-					{ width: windowWidth * 0.5, fontSize: _fontSizeSearchComponent, opacity: 0.8 },
+					text.size.large,
+					width(windowWidth * 0.66),
+					opacity(0.8),
 				]}
 			>
 				{hintText}
@@ -355,7 +350,7 @@ const SearchResultItem: React.FC<SearchItemProps> = ({ data, searchTextKey, sear
 					</View>
 				</View>
 
-				<View style={{ marginLeft: 'auto', display: 'flex', alignSelf: 'center' }}>
+				<View style={[{ marginLeft: 'auto' }, row.item.center]}>
 					{receivedDate > 0 && searchTextKey === 'message' ? <TimeStamp /> : null}
 				</View>
 			</View>
@@ -391,8 +386,7 @@ const SearchComponent: React.FC<{
 	const [searchText, setSearchText] = useState(initialSearchText)
 	const contacts = Messenger.useAccountContactSearchResults(searchText)
 	const messages = Messenger.useGetMessageSearchResultWithMetadata(searchText)
-	const [{ padding, margin, background, text, flex }] = useStyles()
-	const { windowHeight } = useStylesSearch()
+	const [{ padding, margin, background, text, flex, border, height }] = useStyles()
 	const sections = useMemo(() => createSections(contacts, messages, searchText), [
 		messages,
 		contacts,
@@ -421,18 +415,17 @@ const SearchComponent: React.FC<{
 		searchText && !contacts.length ? 'No results found' : 'Search messages, contacts, or groups...'
 
 	return (
-		<View style={[flex.tiny, { ...paddingVertical }]}>
+		<View style={[flex.tiny, paddingVertical]}>
 			{/* Title */}
 			<View
 				style={[
 					padding.small,
 					margin.medium,
-					margin.top.huge,
+					margin.top.large,
 					{
 						flexShrink: 0,
-						marginTop: windowHeight * _searchComponentMarginTopFactor,
-						marginLeft: Math.max(validInsets.left, 16), // TODO: Add way to destructure styles API values
-						marginRight: Math.max(validInsets.right, 16), // TODO: Add way to destructure styles API values
+						marginLeft: Math.max(validInsets.left, 16),
+						marginRight: Math.max(validInsets.right, 16),
 					},
 				]}
 			>
@@ -445,12 +438,12 @@ const SearchComponent: React.FC<{
 					margin.horizontal.medium,
 					margin.bottom.medium,
 					background.light.yellow,
+					border.radius.small,
 					{
-						marginLeft: Math.max(validInsets.left, 16), // TODO: Add way to destructure styles API values
-						marginRight: Math.max(validInsets.right, 16), // TODO: Add way to destructure styles API values
-						flexShrink: 0, // TODO: Add to API
+						marginLeft: Math.max(validInsets.left, 16),
+						marginRight: Math.max(validInsets.right, 16),
+						flexShrink: 0,
 						flexGrow: 0,
-						borderRadius: _searchComponentBorderRadius,
 					},
 				]}
 			>
@@ -461,19 +454,19 @@ const SearchComponent: React.FC<{
 				style={[
 					margin.top.small,
 					flex.justify.center,
+					mainBackgroundColor,
 					{
 						flexShrink: 1,
 						flexGrow: 1,
 						paddingHorizontal: 0,
-						...mainBackgroundColor,
 					},
 				]}
 			>
 				{contacts.length + messages.length > 0 ? (
 					<SectionList
 						style={{
-							marginLeft: Math.max(validInsets.left, 16), // TODO: Add way to destructure styles API values
-							marginRight: Math.max(validInsets.right, 16), // TODO: Add way to destructure styles API values
+							marginLeft: Math.max(validInsets.left, 16),
+							marginRight: Math.max(validInsets.right, 16),
 						}}
 						stickySectionHeadersEnabled={false}
 						bounces={false}
@@ -489,7 +482,7 @@ const SearchComponent: React.FC<{
 
 							// Workaround to make sure nothing is hidden behind footer;
 							// adding padding/margin to this or a wrapping parent doesn't work
-							<View style={[{ height: _approxFooterHeight }, background.white]} />
+							<View style={[height(_approxFooterHeight), background.white]} />
 						)}
 					/>
 				) : (

--- a/js/packages/components/settings/EditProfile.tsx
+++ b/js/packages/components/settings/EditProfile.tsx
@@ -1,8 +1,8 @@
 import React from 'react'
-import { SafeAreaView, View, TouchableOpacity, Dimensions, StyleSheet } from 'react-native'
+import { SafeAreaView, View, TouchableOpacity, StyleSheet } from 'react-native'
 import { Icon, Input, Text } from 'react-native-ui-kitten'
 import { useStyles } from '@berty-tech/styles'
-import { ScreenProps, useNavigation } from '@berty-tech/navigation'
+import { ScreenProps } from '@berty-tech/navigation'
 import { BlurView } from '@react-native-community/blur'
 import { SDTSModalComponent } from '../shared-components/SDTSModalComponent'
 
@@ -128,15 +128,13 @@ const ResetMyQrCode: React.FC<{}> = () => {
 	)
 }
 
-const Screen = Dimensions.get('window')
-
 export const EditProfile: React.FC<ScreenProps.Settings.EditProfile> = () => {
-	const firstNotToggledPoint = Screen.height - 110 // 90 = header height component // 20 = padding // 10 = safeAreaview // 497 = height of the third component
+	const [{ flex, color }, { windowHeight }] = useStyles()
+	const firstNotToggledPoint = windowHeight - 110 // 90 = header height component // 20 = padding // 10 = safeAreaview // 497 = height of the third component
 	const firstToggledPoint = firstNotToggledPoint - 370 // 379.5 = height of first component / 10 = padding
 
 	const secondNotToggledPoint = firstToggledPoint - 190
 	const secondToggledPoint = secondNotToggledPoint - 300
-	const [{ flex, color }] = useStyles()
 
 	return (
 		<>

--- a/js/packages/components/settings/Home.tsx
+++ b/js/packages/components/settings/Home.tsx
@@ -63,18 +63,18 @@ const HomeHeaderGroupButton: React.FC = () => {
 }
 const HomeHeaderAvatar: React.FC = () => {
 	const _styles = useStylesHome()
-	const [{ row, margin, background, border, color }] = useStyles()
+	const [{ row, margin, background, border, color, padding }, { scaleSize }] = useStyles()
 	const client = Messenger.useClient()
 	const account = Messenger.useAccount()
 	const navigation = useNavigation()
 	return (
 		<View style={[row.center, margin.top.scale(50)]}>
 			<TouchableOpacity
-				style={[background.white, border.radius.medium, { padding: 20 }, { paddingTop: 40 }]}
+				style={[background.white, border.radius.medium, padding.scale(20), padding.top.scale(40)]}
 				onPress={() => navigation.navigate.settings.myBertyId()}
 			>
 				<View style={[{ alignItems: 'center' }]}>
-					<View style={{ position: 'absolute', top: -80 }}>
+					<View style={{ position: 'absolute', top: -80 * scaleSize }}>
 						<ProceduralCircleAvatar
 							seed={client?.accountPk}
 							size={80}
@@ -83,8 +83,20 @@ const HomeHeaderAvatar: React.FC = () => {
 						/>
 					</View>
 					<Text style={[_styles.headerNameText]}>{account?.name || ''}</Text>
-					<View style={{ paddingLeft: 12, paddingTop: 20 }}>
-						<Icon name='qr' pack='custom' width={140} height={140} fill={color.blue} />
+					<View
+						style={[
+							// { paddingLeft: 12, paddingTop: 20 },
+							padding.left.scale(12),
+							padding.top.scale(20),
+						]}
+					>
+						<Icon
+							name='qr'
+							pack='custom'
+							width={140 * scaleSize}
+							height={140 * scaleSize}
+							fill={color.blue}
+						/>
 					</View>
 				</View>
 			</TouchableOpacity>

--- a/js/packages/components/settings/MyBertyId.tsx
+++ b/js/packages/components/settings/MyBertyId.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react'
-import { View, TouchableOpacity, StyleSheet, ScrollView, Share } from 'react-native'
+import { View, TouchableOpacity, ScrollView, Share } from 'react-native'
 import { Layout, Text, Icon } from 'react-native-ui-kitten'
 import { useStyles } from '@berty-tech/styles'
 import { TabBar } from '../shared-components/TabBar'
@@ -9,8 +9,7 @@ import { useNavigation } from '@berty-tech/navigation'
 import QRCode from 'react-native-qrcode-svg'
 import { FingerprintContent } from '../shared-components/FingerprintContent'
 import { SafeAreaView } from 'react-native-safe-area-context'
-import { useDimensions } from '@react-native-community/hooks'
-import { scaleSize } from '@berty-tech/styles/constant'
+
 //
 // Settings My Berty ID Vue
 //
@@ -18,38 +17,30 @@ import { scaleSize } from '@berty-tech/styles/constant'
 // Styles
 
 const useStylesBertyId = () => {
-	const { height: windowHeight, width: windowWidth } = useDimensions().window
-	const iPadShortEdge = 768
-	const iPadLongEdge = 1024
-	const bertyIdButtonSize = 60
+	const _iconArrowBackSize = 30
+	const _iconIdSize = 45
+	const _iconShareSize = 26
+	const _titleSize = 26
 	const bertyIdContentScaleFactor = 0.66
-	const iconShareSize = 26
-	const iconArrowBackSize = 30
-	const iconIdSize = 45
-	const titleSize = 26
 	const requestAvatarSize = 90
+
+	const [, { fontScale, scaleSize }] = useStyles()
+	const _bertyIdButtonSize = 60 * scaleSize
 	return {
-		windowHeight,
-		windowWidth,
-		isLandscape: windowHeight < windowWidth,
-		isGteIpadSize:
-			Math.min(windowHeight, windowWidth) >= iPadShortEdge &&
-			Math.max(windowHeight, windowWidth) >= iPadLongEdge,
-		bertyIdButtonSize,
 		bertyIdContentScaleFactor,
-		iconShareSize,
-		iconArrowBackSize,
-		iconIdSize,
-		titleSize,
+		iconShareSize: _iconShareSize * scaleSize,
+		iconArrowBackSize: _iconArrowBackSize * scaleSize,
+		iconIdSize: _iconIdSize * scaleSize,
+		titleSize: _titleSize * fontScale,
 		requestAvatarSize,
 		styleBertyIdButton: {
-			width: bertyIdButtonSize,
-			height: bertyIdButtonSize,
-			borderRadius: bertyIdButtonSize / 2,
-			marginRight: bertyIdButtonSize,
-			bottom: bertyIdButtonSize / 2,
+			width: _bertyIdButtonSize,
+			height: _bertyIdButtonSize,
+			borderRadius: _bertyIdButtonSize / 2,
+			marginRight: _bertyIdButtonSize,
+			bottom: _bertyIdButtonSize / 2,
 		},
-		styleBertyIdContent: { paddingBottom: bertyIdButtonSize / 2 + 10 },
+		styleBertyIdContent: { paddingBottom: _bertyIdButtonSize / 2 + 10 },
 	}
 }
 
@@ -65,22 +56,18 @@ const BertyIdContent: React.FC<{}> = ({ children }) => {
 
 const ContactRequestQR = () => {
 	const client = Messenger.useClient()
-	const [{ padding }] = useStyles()
-	const {
-		isGteIpadSize,
-		windowHeight,
-		windowWidth,
-		titleSize,
-		bertyIdContentScaleFactor,
-	} = useStylesBertyId()
-	const qrCodeSize = isGteIpadSize
-		? Math.min(windowHeight, windowWidth) * 0.5
-		: Math.min(windowHeight * bertyIdContentScaleFactor, windowWidth * bertyIdContentScaleFactor) -
-		  1.25 * titleSize
+	const [{ padding }, { windowHeight, windowWidth, isGteIpadSize }] = useStyles()
+	const { titleSize, bertyIdContentScaleFactor } = useStylesBertyId()
 
 	if (!client?.deepLink) {
 		return <Text>Internal error</Text>
 	}
+
+	// Make sure we can always see the whole QR code on the screen, even if need to scroll
+	const qrCodeSize = isGteIpadSize
+		? Math.min(windowHeight, windowWidth) * 0.5
+		: Math.min(windowHeight * bertyIdContentScaleFactor, windowWidth * bertyIdContentScaleFactor) -
+		  1.25 * titleSize
 
 	// I would like to use binary mode in QR but the scanner used seems to not support it, extended tests were done
 	return (
@@ -92,8 +79,8 @@ const ContactRequestQR = () => {
 
 const Fingerprint: React.FC = () => {
 	const client = Messenger.useClient()
-	const [{ padding }] = useStyles()
-	const { bertyIdContentScaleFactor, windowHeight, windowWidth } = useStylesBertyId()
+	const [{ padding }, { windowHeight, windowWidth, isGteIpadSize }] = useStyles()
+	const { bertyIdContentScaleFactor } = useStylesBertyId()
 
 	if (!client) {
 		return <Text>Client not initialized</Text>
@@ -102,7 +89,12 @@ const Fingerprint: React.FC = () => {
 		<View
 			style={[
 				padding.top.big,
-				{ width: bertyIdContentScaleFactor * Math.min(windowHeight, windowWidth) },
+				{
+					// Make sure we can always see the whole Fingerprint on the screen, even if need to scroll
+					width: isGteIpadSize
+						? Math.min(windowHeight, windowWidth) * 0.5
+						: bertyIdContentScaleFactor * Math.min(windowHeight, windowWidth),
+				},
 			]}
 		>
 			<FingerprintContent seed={client.accountPk} />
@@ -197,9 +189,8 @@ const BertyIdShare: React.FC<{}> = () => {
 
 const MyBertyIdComponent: React.FC<{ user: any }> = ({ user }) => {
 	const { goBack } = useNavigation()
-	const [{ padding, color }] = useStyles()
-	const { iconArrowBackSize, titleSize, iconIdSize, iconShareSize } = useStylesBertyId()
-	const { height } = useDimensions().window
+	const [{ padding, color, margin }, { windowHeight }] = useStyles()
+	const { iconArrowBackSize, titleSize, iconIdSize } = useStylesBertyId()
 
 	return (
 		<ScrollView bounces={false} style={[padding.medium]}>
@@ -209,7 +200,7 @@ const MyBertyIdComponent: React.FC<{ user: any }> = ({ user }) => {
 						flexDirection: 'row',
 						justifyContent: 'space-between',
 						alignItems: 'center',
-						marginBottom: height * 0.1,
+						marginBottom: windowHeight * 0.1,
 					},
 				]}
 			>
@@ -233,13 +224,15 @@ const MyBertyIdComponent: React.FC<{ user: any }> = ({ user }) => {
 						/>
 					</TouchableOpacity>
 					<Text
-						style={{
-							fontWeight: '700',
-							fontSize: titleSize,
-							lineHeight: 1.25 * titleSize,
-							marginLeft: 10,
-							color: color.white,
-						}}
+						style={[
+							margin.left.scale(10),
+							{
+								fontWeight: '700',
+								fontSize: titleSize,
+								lineHeight: 1.25 * titleSize,
+								color: color.white,
+							},
+						]}
 					>
 						My Berty ID
 					</Text>

--- a/js/packages/components/shared-components/CircleAvatar.tsx
+++ b/js/packages/components/shared-components/CircleAvatar.tsx
@@ -31,7 +31,10 @@ export const CircleAvatar: React.FC<CircleAvatarProps> = ({
 	state = {},
 	style = null,
 }) => {
-	const [{ row, width, height, background, border, absolute, color: colorDecl }] = useStyles()
+	const [
+		{ row, width, height, background, border, absolute, color: colorDecl },
+		{ scaleSize },
+	] = useStyles()
 	const _circleStyle = [
 		row.center,
 		width(size),
@@ -55,8 +58,8 @@ export const CircleAvatar: React.FC<CircleAvatarProps> = ({
 				<View style={[_circleAvatarStyles]}>
 					<Icon
 						name={state.icon}
-						width={30}
-						height={30}
+						width={30 * scaleSize}
+						height={30 * scaleSize}
 						fill={state.iconColor ? state.iconColor : colorDecl[color]}
 					/>
 				</View>

--- a/js/packages/components/shared-components/ProceduralCircleAvatar.tsx
+++ b/js/packages/components/shared-components/ProceduralCircleAvatar.tsx
@@ -33,7 +33,10 @@ export const ProceduralCircleAvatar: React.FC<ProceduralCircleAvatarProps> = ({
 	style = null,
 }) => {
 	// for centering to work properly, size and diffsize must have the same oddness (pair or odd)
-	const [{ row, width, height, background, border, absolute, color: colorDecl }] = useStyles()
+	const [
+		{ row, width, height, background, border, absolute, color: colorDecl },
+		{ scaleSize },
+	] = useStyles()
 	const _circleStyle = [
 		row.center,
 		width(size),
@@ -47,14 +50,14 @@ export const ProceduralCircleAvatar: React.FC<ProceduralCircleAvatarProps> = ({
 			<View
 				style={[_circleStyle, { display: 'flex', alignItems: 'center', justifyContent: 'center' }]}
 			>
-				<Jdenticon value={seed} size={size - diffSize} style={{}} />
+				<Jdenticon value={seed} size={(size - diffSize) * scaleSize} style={{}} />
 			</View>
 			{state && state.icon ? (
 				<View style={[_circleAvatarStyles]}>
 					<Icon
 						name={state.icon}
-						width={30}
-						height={30}
+						width={30 * scaleSize}
+						height={30 * scaleSize}
 						fill={state.iconColor ? state.iconColor : colorDecl[color]}
 					/>
 				</View>

--- a/js/packages/eslint-config/index.js
+++ b/js/packages/eslint-config/index.js
@@ -75,6 +75,7 @@ module.exports = {
 				'@typescript-eslint/explicit-function-return-type': 0,
 				'@typescript-eslint/no-empty-function': 0,
 				'@typescript-eslint/ban-types': 0,
+				'@typescript-eslint/no-explicit-any': 0,
 			},
 		},
 		{

--- a/js/packages/styles/constant.ts
+++ b/js/packages/styles/constant.ts
@@ -3,6 +3,9 @@ import { PixelRatio, Dimensions } from 'react-native'
 export const { height: initialHeight, width: initialWidth } = Dimensions.get('window')
 export const iPhone11ShortEdge = 414
 export const iPhone11LongEdge = 896
+export const iPadShortEdge = 768
+export const iPadLongEdge = 1024
+
 const initialIsLandscape = initialHeight < initialWidth
 
 export const initialScaleSize =

--- a/js/packages/styles/hook.tsx
+++ b/js/packages/styles/hook.tsx
@@ -8,6 +8,10 @@ import {
 	iPhone11ShortEdge,
 	iPhone11LongEdge,
 	initialFontScale,
+	initialHeight,
+	initialWidth,
+	iPadShortEdge,
+	iPadLongEdge,
 } from './constant'
 import { useDimensions } from '@react-native-community/hooks'
 import { PixelRatio } from 'react-native'
@@ -40,6 +44,12 @@ export const ctx: React.Context<any> = createContext<any>([
 		scaleSize: initialScaleSize,
 		scaleHeight: initialScaleHeight,
 		fontScale: initialFontScale,
+		windowHeight: initialHeight,
+		windowWidth: initialWidth,
+		isGteIpadSize:
+			Math.min(initialHeight, initialWidth) >= iPadShortEdge &&
+			Math.max(initialHeight, initialWidth) >= iPadLongEdge,
+		isLandscape: initialWidth > initialHeight,
 	},
 	(decl: Declaration) => {},
 ])
@@ -50,6 +60,9 @@ export const Provider: React.FC = ({ children }) => {
 	const [scaleHeight, setScaleHeight] = useState(initialScaleHeight)
 	const [scaleSize, setScaleSize] = useState(initialScaleSize)
 	const [fontScale, setFontScale] = useState(initialFontScale)
+	const isGteIpadSize =
+		Math.min(initialHeight, initialWidth) >= iPadShortEdge &&
+		Math.max(initialHeight, initialWidth) >= iPadLongEdge
 	React.useEffect(() => {
 		const isLandscape = windowHeight < windowWidth
 		const _scaleHeight =
@@ -73,7 +86,15 @@ export const Provider: React.FC = ({ children }) => {
 		<ctx.Provider
 			value={[
 				stylesState,
-				{ scaleHeight, scaleSize, fontScale },
+				{
+					scaleHeight,
+					scaleSize,
+					fontScale,
+					windowHeight,
+					windowWidth,
+					isGteIpadSize,
+					isLandscape: windowWidth > windowHeight,
+				},
 				(decl: Declaration) =>
 					setStylesDeclaration(decl, setStylesState, {
 						scaleHeight,


### PR DESCRIPTION
- Provide windowHeight, windowWidth, isLandscape, isGteIpadSize in styles API (useage in components: `const ({...styles},{ isLandscape, windowWidth, windowHeight, isGteIpadSize }) = useStyles()`

- Remove all use of useDimensions hook in components package (meaning that current windowHeight and windowWidth can be accessed as above)

- Add `scaleSize` to many absolute sizes (not exhaustive, but should be consistent within files) explicity (~_someSize: 12~ -> `_someSize: 12 * scaleSize`), or implicitly with API (e.g. ~style={{height: 30}}~ -> `style={height(30)}`). _For now the only visible change to UI will be in screens narrower than iPhone 11_

- Fixes some small layout-related UI bugs I came across while doing this

Also:
- fix: animation lag in Privacy onboarding component (forgot to add it when I added it to Performance in #2196 )

Signed-off-by: Elizabeth Kelen <erskelen@gmail.com>