### PR TITLE
WIP: feat(messenger): Add fingerprint modal on group join success

### DIFF
--- a/js/packages/components/main/Scan.tsx
+++ b/js/packages/components/main/Scan.tsx
@@ -109,7 +109,6 @@ const DevReferenceInput = () => {
 			<TextInput
 				value={ref}
 				onChangeText={setRef}
-				//eslint-disable-next-line react-native/no-inline-styles
 				style={{ backgroundColor: 'white', padding: 8 }}
 			/>
 			<Button

--- a/js/packages/components/modals/ManageGroupInvitation.tsx
+++ b/js/packages/components/modals/ManageGroupInvitation.tsx
@@ -1,10 +1,132 @@
-import React from 'react'
-import { ActivityIndicator } from 'react-native'
+import { useStyles } from '@berty-tech/styles'
+import { useNavigation } from '@react-navigation/native'
+import React, { useState } from 'react'
+import { Text, TouchableOpacity, View } from 'react-native'
+import { Icon } from 'react-native-ui-kitten'
+import { TabBar } from '../shared-components'
+import { FingerprintContent } from '../shared-components/FingerprintContent'
+import { ProceduralCircleAvatar } from '../shared-components/ProceduralCircleAvatar'
 
-import { useNavigation } from '@berty-tech/navigation'
+const useStylesModal = () => {
+	const [{ width, border, height, opacity }] = useStyles()
+	return {
+		closeRequest: [width(45), height(45), border.radius.scale(22.5)],
+		closeRequestIcon: opacity(0.5),
+	}
+}
 
-export const ManageGroupInvitation: React.FC = () => {
-	const { navigate } = useNavigation()
-	navigate.main.home()
-	return <ActivityIndicator size='large' />
+const BodyAddThisContactContent: React.FC<{}> = ({ children }) => {
+	const [{ margin }] = useStyles()
+	return (
+		<View style={[margin.top.big]}>
+			<View>{children}</View>
+		</View>
+	)
+}
+
+const SelectedContent = ({ contentName, groupPk }: { contentName: string; groupPk: string }) => {
+	const [{ padding }] = useStyles()
+	switch (contentName) {
+		case 'Fingerprint':
+			return <FingerprintContent seed={groupPk} />
+		default:
+			return (
+				<Text style={[padding.horizontal.medium]}>Error: Unknown content name "{contentName}"</Text>
+			)
+	}
+}
+
+export const ManageGroupInvitation: React.FC<{
+	groupPk: string
+	displayName: string
+}> = ({ groupPk = '', displayName = '' }) => {
+	const navigation = useNavigation()
+	const [
+		{ row, text, column, color, flex, absolute, margin, padding, background, border },
+	] = useStyles()
+	const _styles = useStylesModal()
+	const [selectedContent, setSelectedContent] = useState('Fingerprint')
+
+	return (
+		<View
+			style={[{ justifyContent: 'center', alignItems: 'center', height: '100%' }, padding.medium]}
+		>
+			<View
+				style={[
+					background.white,
+					padding.horizontal.medium,
+					padding.bottom.medium,
+					border.radius.large,
+					{ width: '100%' },
+				]}
+			>
+				<View style={[absolute.scale({ top: -50 }), row.item.justify]}>
+					<ProceduralCircleAvatar
+						seed={groupPk}
+						style={[border.shadow.big, row.center]}
+						diffSize={30}
+					/>
+				</View>
+				<View style={[padding.top.scale(55)]}>
+					<Text style={[text.color.blue, margin.vertical.small, { textAlign: 'center' }]}>
+						You've joined the group
+						<Text style={[text.bold.medium]}> {displayName}</Text>
+					</Text>
+					<TabBar
+						tabs={[
+							{ name: 'Fingerprint', icon: 'fingerprint', iconPack: 'custom' } as any, // TODO: fix typing
+							{ name: 'Info', icon: 'info-outline', buttonDisabled: true },
+							{
+								name: 'Devices',
+								icon: 'smartphone',
+								iconSize: 20,
+								iconPack: 'feather',
+								iconTransform: [{ rotate: '22.5deg' }, { scale: 0.8 }],
+								buttonDisabled: true,
+							} as any,
+						]}
+						onTabChange={setSelectedContent}
+					/>
+					<BodyAddThisContactContent>
+						<SelectedContent contentName={selectedContent} groupPk={groupPk} />
+					</BodyAddThisContactContent>
+				</View>
+				<View style={[padding.top.big, row.fill, padding.medium]}>
+					<TouchableOpacity
+						onPress={() => {
+							navigation.navigate('Main.HomeModal')
+						}}
+						style={[
+							flex.medium,
+							background.light.blue,
+							padding.vertical.scale(12),
+							border.radius.small,
+						]}
+					>
+						<Text style={[text.color.blue, { textAlign: 'center' }]}>Got it!</Text>
+					</TouchableOpacity>
+				</View>
+			</View>
+			<TouchableOpacity
+				style={[
+					background.white,
+					padding.vertical.medium,
+					border.shadow.medium,
+					row.item.justify,
+					column.justify,
+					_styles.closeRequest,
+					{ position: 'absolute', bottom: '2%' },
+				]}
+				onPress={navigation.goBack}
+			>
+				<Icon
+					style={[row.item.justify, _styles.closeRequestIcon]}
+					name='close-outline'
+					width={25}
+					height={25}
+					fill={color.grey}
+				/>
+			</TouchableOpacity>
+		</View>
+	)
 }

--- a/js/packages/store/messenger/account.js
+++ b/js/packages/store/messenger/account.js
@@ -67,9 +67,9 @@ const eventHandler = createSlice({
 			}
 			return state
 		},
-		handleDeepLinkDone: (state, { payload: { link, kind } }) => {
+		handleDeepLinkDone: (state, { payload: { link, kind, parsedData } }) => {
 			if (state) {
-				state.deepLinkStatus = { link, kind }
+				state.deepLinkStatus = { link, kind, parsedData }
 			}
 			return state
 		},
@@ -185,7 +185,7 @@ export const transactions = {
 			} else {
 				kind = 'unknown'
 			}
-			yield put(events.handleDeepLinkDone({ link: url, kind }))
+			yield put(events.handleDeepLinkDone({ link: url, kind, parsedData: data }))
 		} catch (e) {
 			if (e.name === 'GRPCError') {
 				const error = new Error('Corrupted deep link.').toString()

--- a/js/packages/store/messenger/conversation.js
+++ b/js/packages/store/messenger/conversation.js
@@ -412,7 +412,8 @@ export const transactions = {
 				group: reply.bertyGroup?.group,
 			})
 		} catch (e) {
-			console.warn('Failed to join multi-member group:', e)
+			console.warn(e.toString())
+			throw new Error('Error joining group. Are you already a member?')
 		}
 	},
 	createOneToOne: function* (payload) {


### PR DESCRIPTION
WIP: Blocked by #2227 

After checking for successful group join, group ID (Fingerprint) is displayed after scanning group.

Changes to JS store:

- **refactor**: Adds `parsedData` key to deepLinkStatus object
- **breaking change**: conversation `join` throws on `multiMemberGroupJoin` error

Next step:

- Add confirm/discard action buttons to this modal

Preview:

<img width="355" alt="image" src="https://user-images.githubusercontent.com/24300177/90819810-72929100-e2fe-11ea-8946-67e9a03b7605.png">


Closes #2219