### PR TITLE
chore: display errors and above on unit tests by default

### DIFF
--- a/go/internal/testutil/logging.go
+++ b/go/internal/testutil/logging.go
@@ -24,8 +24,23 @@ func Logger(t *testing.T) *zap.Logger {
 		isDebugEnabled = bertyDebug || orbitdbDebug || libp2pDebug
 	)
 
+	// if no logger configured, return a zap logger that only prints errors and above
 	if !isDebugEnabled {
-		return zap.NewNop()
+		config := zap.NewDevelopmentConfig()
+		config.DisableStacktrace = true
+		config.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
+		config.Level.SetLevel(zap.ErrorLevel)
+		if bertylogfile != "" {
+			config.OutputPaths = []string{bertylogfile}
+		}
+
+		// build logger
+		logger, err := config.Build()
+		if err != nil {
+			t.Errorf("setup debug logger error: `%v`", err)
+			return zap.NewNop()
+		}
+		return logger
 	}
 
 	// setup zap config


### PR DESCRIPTION
Specific to go tests

Currently, when running `go test -v`, you don't have any berty logging (nop logger), you need to call `go test -v --debug`

This PR changes this behavior by returning a zap logger with min level==error

Note that if you rn `go test` without `-v` you won't have any logging

Warning, this PR makes tests a lot more verbose, but I think it's a good thing to motivate us cleaning up some logs, especially orbit-db ones