### PR TITLE
feat: improve scenario test

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -95,11 +95,11 @@ jobs:
       - name: Run fast tests multiple times
         run: |
           cd go
-          SKIP_SLOW_TESTS=1 make go.unittest GO_TEST_OPTS="-v -test.timeout=600s -count 5"
+          TEST_SPEED=fast make go.unittest GO_TEST_OPTS="-v -test.timeout=600s -count 5"
       - name: Run all tests
         run: |
           cd go
-          SKIP_SLOW_TESTS=0 make go.unittest GO_TEST_OPTS="-v -test.timeout=600s -count 1"
+          TEST_SPEED=any make go.unittest GO_TEST_OPTS="-v -test.timeout=600s -count 1"
       #- name: Run all tests with race flag and generate coverage
       #  uses: nick-invision/retry@v1
       #  with:
@@ -107,11 +107,11 @@ jobs:
       #    max_attempts: 5
       #    command: |
       #      cd go
-      #      SKIP_SLOW_TESTS=0 make go.unittest GO_TEST_OPTS="-v -test.timeout=1200s -count 1 -race -cover -coverprofile=coverage.txt -covermode=atomic"
+      #      TEST_SPEED=any make go.unittest GO_TEST_OPTS="-v -test.timeout=1200s -count 1 -race -cover -coverprofile=coverage.txt -covermode=atomic"
       - name: Run all tests with race flag and generate coverage
         run: |
           cd go
-          SKIP_SLOW_TESTS=0 make go.unittest GO_TEST_OPTS="-v -test.timeout=1200s -count 1 -race -cover -coverprofile=coverage.txt -covermode=atomic"
+          TEST_SPEED=any make go.unittest GO_TEST_OPTS="-v -test.timeout=1200s -count 1 -race -cover -coverprofile=coverage.txt -covermode=atomic"
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:

--- a/go/Makefile
+++ b/go/Makefile
@@ -75,11 +75,11 @@ go.unstable-tests:
 	go install moul.io/retry
 	cd ./pkg/bertymessenger && go test -c -o ./tests.bin .
 	@for test in `cd ./pkg/bertymessenger; go test -list . | grep -E "^TestUnstable"`; do \
-	  (set -xe; DONT_SKIP_UNSTABLE=1 retry -m 10 ./pkg/bertymessenger/tests.bin -test.count 1 -test.run "^$$test\$$" 2>/dev/null || echo "  $$test failed 10/10 times"); \
+	  (set -xe; TEST_STABILITY='unstable' retry -m 10 ./pkg/bertymessenger/tests.bin -test.count 1 -test.run "^$$test\$$" 2>/dev/null || echo "  $$test failed 10/10 times"); \
 	done
 	cd ./pkg/bertyprotocol && go test -c -o ./tests.bin .
 	@for test in `cd ./pkg/bertyprotocol; go test -list . | grep -E "^TestScenario_"`; do \
-	  (set -xe; TEST_FILTER='unstable' retry -m 10 ./pkg/bertyprotocol/tests.bin -test.count 1 -test.run "^$$test\$$" 2>/dev/null || echo "  $$test failed 10/10 times"); \
+	  (set -xe; TEST_STABILITY='unstable' retry -m 10 ./pkg/bertyprotocol/tests.bin -test.count 1 -test.run "^$$test\$$" 2>/dev/null || echo "  $$test failed 10/10 times"); \
 	done
 
 .PHONY: go.install

--- a/go/Makefile
+++ b/go/Makefile
@@ -77,7 +77,10 @@ go.unstable-tests:
 	@for test in `cd ./pkg/bertymessenger; go test -list . | grep -E "^TestUnstable"`; do \
 	  (set -xe; DONT_SKIP_UNSTABLE=1 retry -m 10 ./pkg/bertymessenger/tests.bin -test.count 1 -test.run "^$$test\$$" 2>/dev/null || echo "  $$test failed 10/10 times"); \
 	done
-	@# FIXME: support bertyprotocol
+	cd ./pkg/bertyprotocol && go test -c -o ./tests.bin .
+	@for test in `cd ./pkg/bertyprotocol; go test -list . | grep -E "^TestScenario_"`; do \
+	  (set -xe; TEST_FILTER='unstable' retry -m 10 ./pkg/bertyprotocol/tests.bin -test.count 1 -test.run "^$$test\$$" 2>/dev/null || echo "  $$test failed 10/10 times"); \
+	done
 
 .PHONY: go.install
 go.install: pb.generate

--- a/go/framework/bertybridge/bridge_test.go
+++ b/go/framework/bertybridge/bridge_test.go
@@ -120,8 +120,7 @@ func TestPersistenceProtocol(t *testing.T) {
 
 	const n_try = 4
 
-	testutil.SkipSlow(t)
-	testutil.SkipUnstable(t)
+	testutil.FilterStabilityAndSpeed(t, testutil.Unstable, testutil.Slow)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/go/gen.sum
+++ b/go/gen.sum
@@ -5,4 +5,4 @@ d70e7e0659761f25577333ff20f13a8a79fd8f4b  ../api/bertytypes.proto
 ed8568e7c66e8f4b8a9bf2435f0423b05ef4a8be  ../api/errcode.proto
 c314cc3d08e8849bd0693039e42da117c39efef5  ../api/go-internal/handshake.proto
 9b4665f0290b8e94e5ef4b80572a9304f587c2c7  ../api/go-internal/records.proto
-8a2384dbf28e1cb854f4e8c7390254658395862f  Makefile
+160941572966b80d3f54f364479136024b4a2362  Makefile

--- a/go/gen.sum
+++ b/go/gen.sum
@@ -5,4 +5,4 @@ d70e7e0659761f25577333ff20f13a8a79fd8f4b  ../api/bertytypes.proto
 ed8568e7c66e8f4b8a9bf2435f0423b05ef4a8be  ../api/errcode.proto
 c314cc3d08e8849bd0693039e42da117c39efef5  ../api/go-internal/handshake.proto
 9b4665f0290b8e94e5ef4b80572a9304f587c2c7  ../api/go-internal/records.proto
-160941572966b80d3f54f364479136024b4a2362  Makefile
+695ed4bdd66d5f3c124ce23fce2aeb8de62fa15e  Makefile

--- a/go/internal/handshake/handshake_test.go
+++ b/go/internal/handshake/handshake_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func TestValidHandshake(t *testing.T) {
-	testutil.SkipSlow(t)
+	testutil.FilterSpeed(t, testutil.Slow)
 
 	var requesterTest requesterTestFunc = func(
 		t *testing.T,
@@ -59,7 +59,7 @@ func TestValidHandshake(t *testing.T) {
 }
 
 func TestInvalidRequesterHello(t *testing.T) {
-	testutil.SkipSlow(t)
+	testutil.FilterSpeed(t, testutil.Slow)
 
 	t.Log("Requester interrupts by closing stream")
 	{
@@ -93,7 +93,7 @@ func TestInvalidRequesterHello(t *testing.T) {
 }
 
 func TestInvalidResponderHello(t *testing.T) {
-	testutil.SkipSlow(t)
+	testutil.FilterSpeed(t, testutil.Slow)
 
 	t.Log("Responder interrupts by closing stream")
 	{
@@ -136,7 +136,7 @@ func TestInvalidResponderHello(t *testing.T) {
 }
 
 func TestInvalidRequesterAuthenticate(t *testing.T) {
-	testutil.SkipSlow(t)
+	testutil.FilterSpeed(t, testutil.Slow)
 
 	t.Log("Requester interrupts by closing stream")
 	{
@@ -679,7 +679,7 @@ func TestInvalidRequesterAuthenticate(t *testing.T) {
 }
 
 func TestInvalidResponderAccept(t *testing.T) {
-	testutil.SkipSlow(t)
+	testutil.FilterSpeed(t, testutil.Slow)
 
 	t.Log("Responder interrupts by closing stream")
 	{
@@ -1106,7 +1106,7 @@ func TestInvalidResponderAccept(t *testing.T) {
 }
 
 func TestInvalidResponderAcceptAck(t *testing.T) {
-	testutil.SkipSlow(t)
+	testutil.FilterSpeed(t, testutil.Slow)
 
 	t.Log("Requester interrupts by closing stream")
 	{

--- a/go/pkg/bertymessenger/service_test.go
+++ b/go/pkg/bertymessenger/service_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestUnstableServiceStream(t *testing.T) {
-	testutil.SkipUnstable(t)
+	testutil.FilterStability(t, testutil.Unstable)
 
 	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
 	node, cleanup := testingNode(ctx, t)
@@ -49,7 +49,7 @@ func TestUnstableServiceStream(t *testing.T) {
 }
 
 func TestUnstableServiceSetName(t *testing.T) {
-	testutil.SkipUnstable(t)
+	testutil.FilterStability(t, testutil.Unstable)
 
 	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
 	node, cleanup := testingNode(ctx, t)
@@ -140,7 +140,7 @@ func TestServiceSetNameAsync(t *testing.T) {
 }
 
 func TestUnstableServiceStreamCancel(t *testing.T) {
-	testutil.SkipUnstable(t)
+	testutil.FilterStability(t, testutil.Unstable)
 
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	node, cleanup := testingNode(ctx, t)
@@ -166,7 +166,7 @@ func TestUnstableServiceStreamCancel(t *testing.T) {
 }
 
 func TestUnstableServiceContactRequest(t *testing.T) {
-	testutil.SkipUnstable(t)
+	testutil.FilterStability(t, testutil.Unstable)
 
 	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
 	node, cleanup := testingNode(ctx, t)
@@ -217,7 +217,7 @@ func TestUnstableServiceContactRequest(t *testing.T) {
 }
 
 func TestUnstableServiceConversationCreateLive(t *testing.T) {
-	testutil.SkipUnstable(t)
+	testutil.FilterStability(t, testutil.Unstable)
 
 	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
 	node, cleanup := testingNode(ctx, t)
@@ -258,7 +258,7 @@ func TestUnstableServiceConversationCreateLive(t *testing.T) {
 }
 
 func TestUnstableServiceConversationCreateAsync(t *testing.T) {
-	testutil.SkipUnstable(t)
+	testutil.FilterStability(t, testutil.Unstable)
 
 	ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
 	node, cleanup := testingNode(ctx, t)
@@ -308,8 +308,7 @@ func TestUnstableServiceConversationCreateAsync(t *testing.T) {
 }
 
 func TestUnstable1To1AddContact(t *testing.T) {
-	testutil.SkipSlow(t)
-	testutil.SkipUnstable(t)
+	testutil.FilterStabilityAndSpeed(t, testutil.Unstable, testutil.Slow)
 
 	logger := testutil.Logger(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -355,8 +354,7 @@ func TestUnstable1To1AddContact(t *testing.T) {
 }
 
 func TestUnstable1To1Exchange(t *testing.T) {
-	testutil.SkipSlow(t)
-	testutil.SkipUnstable(t)
+	testutil.FilterStabilityAndSpeed(t, testutil.Unstable, testutil.Slow)
 
 	logger := testutil.Logger(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
@@ -409,8 +407,7 @@ func TestUnstable1To1Exchange(t *testing.T) {
 }
 
 func TestBrokenPeersCreateJoinConversation(t *testing.T) {
-	testutil.SkipSlow(t)
-	testutil.SkipBroken(t)
+	testutil.FilterStabilityAndSpeed(t, testutil.Broken, testutil.Slow)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
@@ -505,8 +502,7 @@ func TestBrokenPeersCreateJoinConversation(t *testing.T) {
 }
 
 func TestBroken3PeersExchange(t *testing.T) {
-	testutil.SkipSlow(t)
-	testutil.SkipBroken(t)
+	testutil.FilterStabilityAndSpeed(t, testutil.Broken, testutil.Slow)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -564,8 +560,7 @@ func TestBroken3PeersExchange(t *testing.T) {
 }
 
 func TestBrokenConversationInvitation(t *testing.T) {
-	testutil.SkipBroken(t)
-	testutil.SkipSlow(t)
+	testutil.FilterStabilityAndSpeed(t, testutil.Broken, testutil.Slow)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
 	defer cancel()
@@ -630,8 +625,7 @@ func TestBrokenConversationInvitation(t *testing.T) {
 }
 
 func TestBrokenConversationInvitationAndExchange(t *testing.T) {
-	testutil.SkipSlow(t)
-	testutil.SkipBroken(t)
+	testutil.FilterStabilityAndSpeed(t, testutil.Broken, testutil.Slow)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
@@ -704,8 +698,7 @@ func TestBrokenConversationInvitationAndExchange(t *testing.T) {
 }
 
 func TestUnstableConversationOpenClose(t *testing.T) {
-	testutil.SkipSlow(t)
-	testutil.SkipUnstable(t)
+	testutil.FilterStabilityAndSpeed(t, testutil.Unstable, testutil.Slow)
 
 	logger := testutil.Logger(t)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)

--- a/go/pkg/bertyprotocol/contact_request_manager_test.go
+++ b/go/pkg/bertyprotocol/contact_request_manager_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestContactRequestFlow(t *testing.T) {
-	testutil.SkipSlow(t)
+	testutil.FilterSpeed(t, testutil.Slow)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*20)
 	defer cancel()
@@ -136,7 +136,7 @@ func TestContactRequestFlow(t *testing.T) {
 }
 
 func TestContactRequestFlowWithoutIncoming(t *testing.T) {
-	testutil.SkipSlow(t)
+	testutil.FilterSpeed(t, testutil.Slow)
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*5)
 	defer cancel()

--- a/go/pkg/bertyprotocol/keystore_message_utils_test.go
+++ b/go/pkg/bertyprotocol/keystore_message_utils_test.go
@@ -379,7 +379,7 @@ func testMessageKeyHolderCatchUp(t *testing.T, expectedNewDevices int, isSlow bo
 	defer cancel()
 
 	if isSlow {
-		testutil.SkipSlow(t)
+		testutil.FilterSpeed(t, testutil.Slow)
 	}
 
 	dir := path.Join(os.TempDir(), fmt.Sprintf("%d", os.Getpid()), "MessageKeyHolderCatchUp")
@@ -441,7 +441,7 @@ func testMessageKeyHolderSubscription(t *testing.T, expectedNewDevices int, isSl
 	defer cancel()
 
 	if isSlow {
-		testutil.SkipSlow(t)
+		testutil.FilterSpeed(t, testutil.Slow)
 	}
 
 	dir := path.Join(os.TempDir(), fmt.Sprintf("%d", os.Getpid()), "MessageKeyHolderSubscription")

--- a/go/pkg/bertyprotocol/orbitdb_many_adds_berty_test.go
+++ b/go/pkg/bertyprotocol/orbitdb_many_adds_berty_test.go
@@ -23,7 +23,7 @@ import (
 
 func testAddBerty(ctx context.Context, t *testing.T, node ipfsutil.CoreAPIMock, g *bertytypes.Group, pathBase string, amountToAdd, amountCurrentlyPresent int) {
 	t.Helper()
-	testutil.SkipSlow(t)
+	testutil.FilterSpeed(t, testutil.Slow)
 
 	api := node.API()
 	ctx, cancel := context.WithCancel(ctx)

--- a/go/pkg/bertyprotocol/orbitdb_test.go
+++ b/go/pkg/bertyprotocol/orbitdb_test.go
@@ -54,7 +54,7 @@ func newTestOrbitDB(ctx context.Context, t *testing.T, logger *zap.Logger, node 
 }
 
 func TestDifferentStores(t *testing.T) {
-	testutil.SkipSlow(t)
+	testutil.FilterSpeed(t, testutil.Slow)
 	logger := testutil.Logger(t)
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/go/pkg/bertyprotocol/scenario_test.go
+++ b/go/pkg/bertyprotocol/scenario_test.go
@@ -26,27 +26,12 @@ import (
 	"berty.tech/berty/v2/go/pkg/errcode"
 )
 
-type stability int
-
-const (
-	stable stability = iota
-	unstable
-	broken
-)
-
-type speed int
-
-const (
-	fast speed = iota
-	slow
-)
-
 type testCase struct {
 	Name           string
 	NumberOfClient int
 	ConnectFunc    ConnnectTestingProtocolFunc
-	Speed          speed
-	Stability      stability
+	Speed          testutil.Speed
+	Stability      testutil.Stability
 	Timeout        time.Duration
 }
 
@@ -56,15 +41,15 @@ type testFunc func(context.Context, *testing.T, ...*TestingProtocol)
 
 func TestScenario_CreateMultiMemberGroup(t *testing.T) {
 	cases := []testCase{
-		{"2 clients/connectAll", 2, ConnectAll, fast, stable, time.Second * 10},
-		{"3 clients/connectAll", 3, ConnectAll, fast, stable, time.Second * 10},
-		{"3 clients/connectInLine", 3, ConnectInLine, fast, stable, time.Second * 10},
-		{"5 clients/connectAll", 5, ConnectAll, slow, stable, time.Second * 20},
-		{"5 clients/connectInLine", 5, ConnectInLine, slow, stable, time.Second * 20},
-		{"8 clients/connectAll", 8, ConnectAll, slow, unstable, time.Second * 30},
-		{"8 clients/connectInLine", 8, ConnectInLine, slow, unstable, time.Second * 30},
-		{"10 clients/connectAll", 10, ConnectAll, slow, unstable, time.Second * 40},
-		{"10 clients/connectInLine", 10, ConnectInLine, slow, unstable, time.Second * 40},
+		{"2 clients/connectAll", 2, ConnectAll, testutil.Fast, testutil.Unstable, time.Second * 10},
+		{"3 clients/connectAll", 3, ConnectAll, testutil.Fast, testutil.Unstable, time.Second * 10},
+		{"3 clients/connectInLine", 3, ConnectInLine, testutil.Fast, testutil.Unstable, time.Second * 10},
+		{"5 clients/connectAll", 5, ConnectAll, testutil.Slow, testutil.Unstable, time.Second * 20},
+		{"5 clients/connectInLine", 5, ConnectInLine, testutil.Slow, testutil.Unstable, time.Second * 20},
+		{"8 clients/connectAll", 8, ConnectAll, testutil.Slow, testutil.Unstable, time.Second * 30},
+		{"8 clients/connectInLine", 8, ConnectInLine, testutil.Slow, testutil.Unstable, time.Second * 30},
+		{"10 clients/connectAll", 10, ConnectAll, testutil.Slow, testutil.Unstable, time.Second * 40},
+		{"10 clients/connectInLine", 10, ConnectInLine, testutil.Slow, testutil.Unstable, time.Second * 40},
 	}
 
 	testingScenario(t, cases, func(ctx context.Context, t *testing.T, tps ...*TestingProtocol) {
@@ -74,15 +59,15 @@ func TestScenario_CreateMultiMemberGroup(t *testing.T) {
 
 func TestScenario_MessageMultiMemberGroup(t *testing.T) {
 	cases := []testCase{
-		{"2 clients/connectAll", 2, ConnectAll, fast, unstable, time.Second * 10},
-		{"3 clients/connectAll", 3, ConnectAll, fast, unstable, time.Second * 10},
-		{"3 clients/connectInLine", 3, ConnectInLine, fast, unstable, time.Second * 10},
-		{"5 clients/connectAll", 5, ConnectAll, slow, unstable, time.Second * 20},
-		{"5 clients/connectInLine", 5, ConnectInLine, slow, unstable, time.Second * 20},
-		{"8 clients/connectAll", 8, ConnectAll, slow, unstable, time.Second * 30},
-		{"8 clients/connectInLine", 8, ConnectInLine, slow, unstable, time.Second * 30},
-		{"10 clients/connectAll", 10, ConnectAll, slow, unstable, time.Second * 40},
-		{"10 clients/connectInLine", 10, ConnectInLine, slow, unstable, time.Second * 40},
+		{"2 clients/connectAll", 2, ConnectAll, testutil.Fast, testutil.Unstable, time.Second * 10},
+		{"3 clients/connectAll", 3, ConnectAll, testutil.Fast, testutil.Unstable, time.Second * 10},
+		{"3 clients/connectInLine", 3, ConnectInLine, testutil.Fast, testutil.Unstable, time.Second * 10},
+		{"5 clients/connectAll", 5, ConnectAll, testutil.Slow, testutil.Unstable, time.Second * 20},
+		{"5 clients/connectInLine", 5, ConnectInLine, testutil.Slow, testutil.Unstable, time.Second * 20},
+		{"8 clients/connectAll", 8, ConnectAll, testutil.Slow, testutil.Unstable, time.Second * 30},
+		{"8 clients/connectInLine", 8, ConnectInLine, testutil.Slow, testutil.Unstable, time.Second * 30},
+		{"10 clients/connectAll", 10, ConnectAll, testutil.Slow, testutil.Unstable, time.Second * 40},
+		{"10 clients/connectInLine", 10, ConnectInLine, testutil.Slow, testutil.Unstable, time.Second * 40},
 	}
 
 	testingScenario(t, cases, func(ctx context.Context, t *testing.T, tps ...*TestingProtocol) {
@@ -99,15 +84,15 @@ func TestScenario_MessageSeveralMultiMemberGroups(t *testing.T) {
 	const ngroup = 3
 
 	cases := []testCase{
-		{"2 clients/connectAll", 2, ConnectAll, fast, unstable, time.Second * 10},
-		{"3 clients/connectAll", 3, ConnectAll, fast, unstable, time.Second * 10},
-		{"3 clients/connectInLine", 3, ConnectInLine, fast, unstable, time.Second * 10},
-		{"5 clients/connectAll", 5, ConnectAll, slow, unstable, time.Second * 20},
-		{"5 clients/connectInLine", 5, ConnectInLine, slow, unstable, time.Second * 20},
-		{"8 clients/connectAll", 8, ConnectAll, slow, unstable, time.Second * 30},
-		{"8 clients/connectInLine", 8, ConnectInLine, slow, unstable, time.Second * 30},
-		{"10 clients/connectAll", 10, ConnectAll, slow, unstable, time.Second * 40},
-		{"10 clients/connectInLine", 10, ConnectInLine, slow, unstable, time.Second * 40},
+		{"2 clients/connectAll", 2, ConnectAll, testutil.Fast, testutil.Unstable, time.Second * 10},
+		{"3 clients/connectAll", 3, ConnectAll, testutil.Fast, testutil.Unstable, time.Second * 10},
+		{"3 clients/connectInLine", 3, ConnectInLine, testutil.Fast, testutil.Unstable, time.Second * 10},
+		{"5 clients/connectAll", 5, ConnectAll, testutil.Slow, testutil.Unstable, time.Second * 20},
+		{"5 clients/connectInLine", 5, ConnectInLine, testutil.Slow, testutil.Unstable, time.Second * 20},
+		{"8 clients/connectAll", 8, ConnectAll, testutil.Slow, testutil.Unstable, time.Second * 30},
+		{"8 clients/connectInLine", 8, ConnectInLine, testutil.Slow, testutil.Unstable, time.Second * 30},
+		{"10 clients/connectAll", 10, ConnectAll, testutil.Slow, testutil.Unstable, time.Second * 40},
+		{"10 clients/connectInLine", 10, ConnectInLine, testutil.Slow, testutil.Unstable, time.Second * 40},
 	}
 
 	testingScenario(t, cases, func(ctx context.Context, t *testing.T, tps ...*TestingProtocol) {
@@ -125,15 +110,15 @@ func TestScenario_MessageSeveralMultiMemberGroups(t *testing.T) {
 
 func TestScenario_AddContact(t *testing.T) {
 	cases := []testCase{
-		{"2 clients/connectAll", 2, ConnectAll, fast, unstable, time.Second * 20},       // marked as "unstable" because it failed multiple times on the CI recently
-		{"3 clients/connectAll", 3, ConnectAll, fast, unstable, time.Second * 20},       // marked as "unstable" because it failed multiple times on the CI recently
-		{"3 clients/connectInLine", 3, ConnectInLine, fast, unstable, time.Second * 20}, // marked as "unstable" because it failed multiple times on the CI recently
-		{"5 clients/connectAll", 5, ConnectAll, slow, unstable, time.Second * 30},       // marked as "unstable" because it failed multiple times on the CI recently
-		{"5 clients/connectInLine", 5, ConnectInLine, slow, unstable, time.Second * 30}, // marked as "unstable" because it failed multiple times on the CI recently
-		{"8 clients/connectAll", 8, ConnectAll, slow, unstable, time.Second * 40},       // marked as "unstable" because it failed multiple times on the CI recently
-		{"8 clients/connectInLine", 8, ConnectInLine, slow, unstable, time.Second * 40}, // marked as "unstable" because it failed multiple times on the CI recently
-		{"10 clients/connectAll", 10, ConnectAll, slow, broken, time.Second * 60},
-		{"10 clients/connectInLine", 10, ConnectInLine, slow, broken, time.Second * 60},
+		{"2 clients/connectAll", 2, ConnectAll, testutil.Fast, testutil.Unstable, time.Second * 20},       // marked as "unstable" because it failed multiple times on the CI recently
+		{"3 clients/connectAll", 3, ConnectAll, testutil.Fast, testutil.Unstable, time.Second * 20},       // marked as "unstable" because it failed multiple times on the CI recently
+		{"3 clients/connectInLine", 3, ConnectInLine, testutil.Fast, testutil.Unstable, time.Second * 20}, // marked as "unstable" because it failed multiple times on the CI recently
+		{"5 clients/connectAll", 5, ConnectAll, testutil.Slow, testutil.Unstable, time.Second * 30},       // marked as "unstable" because it failed multiple times on the CI recently
+		{"5 clients/connectInLine", 5, ConnectInLine, testutil.Slow, testutil.Unstable, time.Second * 30}, // marked as "unstable" because it failed multiple times on the CI recently
+		{"8 clients/connectAll", 8, ConnectAll, testutil.Slow, testutil.Unstable, time.Second * 40},       // marked as "unstable" because it failed multiple times on the CI recently
+		{"8 clients/connectInLine", 8, ConnectInLine, testutil.Slow, testutil.Unstable, time.Second * 40}, // marked as "unstable" because it failed multiple times on the CI recently
+		{"10 clients/connectAll", 10, ConnectAll, testutil.Slow, testutil.Broken, time.Second * 60},
+		{"10 clients/connectInLine", 10, ConnectInLine, testutil.Slow, testutil.Broken, time.Second * 60},
 	}
 
 	testingScenario(t, cases, func(ctx context.Context, t *testing.T, tps ...*TestingProtocol) {
@@ -143,15 +128,15 @@ func TestScenario_AddContact(t *testing.T) {
 
 func TestScenario_MessageContactGroup(t *testing.T) {
 	cases := []testCase{
-		{"2 clients/connectAll", 2, ConnectAll, fast, unstable, time.Second * 20},
-		{"3 clients/connectAll", 3, ConnectAll, fast, unstable, time.Second * 20},
-		{"3 clients/connectInLine", 3, ConnectInLine, fast, unstable, time.Second * 20},
-		{"5 clients/connectAll", 5, ConnectAll, slow, unstable, time.Second * 30},
-		{"5 clients/connectInLine", 5, ConnectInLine, slow, unstable, time.Second * 30},
-		{"8 clients/connectAll", 8, ConnectAll, slow, broken, time.Second * 40},
-		{"8 clients/connectInLine", 8, ConnectInLine, slow, broken, time.Second * 40},
-		{"10 clients/connectAll", 10, ConnectAll, slow, broken, time.Second * 60},
-		{"10 clients/connectInLine", 10, ConnectInLine, slow, broken, time.Second * 60},
+		{"2 clients/connectAll", 2, ConnectAll, testutil.Fast, testutil.Unstable, time.Second * 20},
+		{"3 clients/connectAll", 3, ConnectAll, testutil.Fast, testutil.Unstable, time.Second * 20},
+		{"3 clients/connectInLine", 3, ConnectInLine, testutil.Fast, testutil.Unstable, time.Second * 20},
+		{"5 clients/connectAll", 5, ConnectAll, testutil.Slow, testutil.Unstable, time.Second * 30},
+		{"5 clients/connectInLine", 5, ConnectInLine, testutil.Slow, testutil.Unstable, time.Second * 30},
+		{"8 clients/connectAll", 8, ConnectAll, testutil.Slow, testutil.Broken, time.Second * 40},
+		{"8 clients/connectInLine", 8, ConnectInLine, testutil.Slow, testutil.Broken, time.Second * 40},
+		{"10 clients/connectAll", 10, ConnectAll, testutil.Slow, testutil.Broken, time.Second * 60},
+		{"10 clients/connectInLine", 10, ConnectInLine, testutil.Slow, testutil.Broken, time.Second * 60},
 	}
 
 	testingScenario(t, cases, func(ctx context.Context, t *testing.T, tps ...*TestingProtocol) {
@@ -167,7 +152,7 @@ func TestScenario_MessageContactGroup(t *testing.T) {
 
 func TestScenario_MessageAccountGroup(t *testing.T) {
 	cases := []testCase{
-		{"1 client/connectAll", 1, ConnectAll, fast, stable, time.Second * 10},
+		{"1 client/connectAll", 1, ConnectAll, testutil.Fast, testutil.Stable, time.Second * 10},
 	}
 
 	testingScenario(t, cases, func(ctx context.Context, t *testing.T, tps ...*TestingProtocol) {
@@ -184,15 +169,15 @@ func TestScenario_MessageAccountGroup(t *testing.T) {
 
 func TestScenario_MessageAccountAndMultiMemberGroups(t *testing.T) {
 	cases := []testCase{
-		{"2 clients/connectAll", 2, ConnectAll, fast, broken, time.Second * 10},
-		{"3 clients/connectAll", 3, ConnectAll, fast, broken, time.Second * 10},
-		{"3 clients/connectInLine", 3, ConnectInLine, fast, broken, time.Second * 10},
-		{"5 clients/connectAll", 5, ConnectAll, slow, broken, time.Second * 20},
-		{"5 clients/connectInLine", 5, ConnectInLine, slow, broken, time.Second * 20},
-		{"8 clients/connectAll", 8, ConnectAll, slow, broken, time.Second * 30},
-		{"8 clients/connectInLine", 8, ConnectInLine, slow, broken, time.Second * 30},
-		{"10 clients/connectAll", 10, ConnectAll, slow, broken, time.Second * 40},
-		{"10 clients/connectInLine", 10, ConnectInLine, slow, broken, time.Second * 40},
+		{"2 clients/connectAll", 2, ConnectAll, testutil.Fast, testutil.Broken, time.Second * 10},
+		{"3 clients/connectAll", 3, ConnectAll, testutil.Fast, testutil.Broken, time.Second * 10},
+		{"3 clients/connectInLine", 3, ConnectInLine, testutil.Fast, testutil.Broken, time.Second * 10},
+		{"5 clients/connectAll", 5, ConnectAll, testutil.Slow, testutil.Broken, time.Second * 20},
+		{"5 clients/connectInLine", 5, ConnectInLine, testutil.Slow, testutil.Broken, time.Second * 20},
+		{"8 clients/connectAll", 8, ConnectAll, testutil.Slow, testutil.Broken, time.Second * 30},
+		{"8 clients/connectInLine", 8, ConnectInLine, testutil.Slow, testutil.Broken, time.Second * 30},
+		{"10 clients/connectAll", 10, ConnectAll, testutil.Slow, testutil.Broken, time.Second * 40},
+		{"10 clients/connectInLine", 10, ConnectInLine, testutil.Slow, testutil.Broken, time.Second * 40},
 	}
 
 	testingScenario(t, cases, func(ctx context.Context, t *testing.T, tps ...*TestingProtocol) {
@@ -226,15 +211,15 @@ func TestScenario_MessageAccountAndMultiMemberGroups(t *testing.T) {
 
 func TestScenario_MessageAccountAndContactGroups(t *testing.T) {
 	cases := []testCase{
-		{"2 clients/connectAll", 2, ConnectAll, fast, broken, time.Second * 10},
-		{"3 clients/connectAll", 3, ConnectAll, fast, broken, time.Second * 10},
-		{"3 clients/connectInLine", 3, ConnectInLine, fast, broken, time.Second * 10},
-		{"5 clients/connectAll", 5, ConnectAll, slow, broken, time.Second * 20},
-		{"5 clients/connectInLine", 5, ConnectInLine, slow, broken, time.Second * 20},
-		{"8 clients/connectAll", 8, ConnectAll, slow, broken, time.Second * 30},
-		{"8 clients/connectInLine", 8, ConnectInLine, slow, broken, time.Second * 30},
-		{"10 clients/connectAll", 10, ConnectAll, slow, broken, time.Second * 40},
-		{"10 clients/connectInLine", 10, ConnectInLine, slow, broken, time.Second * 40},
+		{"2 clients/connectAll", 2, ConnectAll, testutil.Fast, testutil.Broken, time.Second * 10},
+		{"3 clients/connectAll", 3, ConnectAll, testutil.Fast, testutil.Broken, time.Second * 10},
+		{"3 clients/connectInLine", 3, ConnectInLine, testutil.Fast, testutil.Broken, time.Second * 10},
+		{"5 clients/connectAll", 5, ConnectAll, testutil.Slow, testutil.Broken, time.Second * 20},
+		{"5 clients/connectInLine", 5, ConnectInLine, testutil.Slow, testutil.Broken, time.Second * 20},
+		{"8 clients/connectAll", 8, ConnectAll, testutil.Slow, testutil.Broken, time.Second * 30},
+		{"8 clients/connectInLine", 8, ConnectInLine, testutil.Slow, testutil.Broken, time.Second * 30},
+		{"10 clients/connectAll", 10, ConnectAll, testutil.Slow, testutil.Broken, time.Second * 40},
+		{"10 clients/connectInLine", 10, ConnectInLine, testutil.Slow, testutil.Broken, time.Second * 40},
 	}
 
 	testingScenario(t, cases, func(ctx context.Context, t *testing.T, tps ...*TestingProtocol) {
@@ -296,22 +281,7 @@ func testingScenario(t *testing.T, tcs []testCase, tf testFunc) {
 
 	for _, tc := range tcs {
 		t.Run(tc.Name, func(t *testing.T) {
-			if tc.Speed == slow {
-				testutil.SkipSlow(t)
-			}
-			if filter := os.Getenv("TEST_FILTER"); filter == "unstable" || filter == "broken" {
-				if filter == "unstable" && tc.Stability != unstable {
-					t.Skip("run only unstable tests")
-				} else if filter == "broken" && tc.Stability != broken {
-					t.Skip("run only broken tests")
-				}
-			} else {
-				if tc.Stability == unstable {
-					testutil.SkipUnstable(t)
-				} else if tc.Stability == broken {
-					testutil.SkipBroken(t)
-				}
-			}
+			testutil.FilterStabilityAndSpeed(t, tc.Stability, tc.Speed)
 
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()

--- a/go/pkg/bertyprotocol/scenario_test.go
+++ b/go/pkg/bertyprotocol/scenario_test.go
@@ -26,12 +26,27 @@ import (
 	"berty.tech/berty/v2/go/pkg/errcode"
 )
 
+type stability int
+
+const (
+	stable stability = iota
+	unstable
+	broken
+)
+
+type speed int
+
+const (
+	fast speed = iota
+	slow
+)
+
 type testCase struct {
 	Name           string
 	NumberOfClient int
 	ConnectFunc    ConnnectTestingProtocolFunc
-	IsSlowTest     bool
-	IsUnstableTest bool
+	Speed          speed
+	Stability      stability
 	Timeout        time.Duration
 }
 
@@ -41,15 +56,15 @@ type testFunc func(context.Context, *testing.T, ...*TestingProtocol)
 
 func TestScenario_CreateMultiMemberGroup(t *testing.T) {
 	cases := []testCase{
-		{"2 clients/connectAll", 2, ConnectAll, false, true, time.Second * 10},
-		{"3 clients/connectAll", 3, ConnectAll, false, true, time.Second * 10},
-		{"3 clients/connectInLine", 3, ConnectInLine, false, true, time.Second * 10},
-		{"5 clients/connectAll", 5, ConnectAll, true, true, time.Second * 10},
-		{"5 clients/connectInLine", 5, ConnectInLine, true, true, time.Second * 10},
-		{"8 clients/connectAll", 8, ConnectAll, true, true, time.Second * 10},
-		{"8 clients/connectInLine", 8, ConnectInLine, true, true, time.Second * 10},
-		{"10 clients/connectAll", 10, ConnectAll, true, true, time.Second * 10},
-		{"10 clients/connectInLine", 10, ConnectInLine, true, true, time.Second * 10},
+		{"2 clients/connectAll", 2, ConnectAll, fast, stable, time.Second * 10},
+		{"3 clients/connectAll", 3, ConnectAll, fast, stable, time.Second * 10},
+		{"3 clients/connectInLine", 3, ConnectInLine, fast, stable, time.Second * 10},
+		{"5 clients/connectAll", 5, ConnectAll, slow, stable, time.Second * 20},
+		{"5 clients/connectInLine", 5, ConnectInLine, slow, stable, time.Second * 20},
+		{"8 clients/connectAll", 8, ConnectAll, slow, unstable, time.Second * 30},
+		{"8 clients/connectInLine", 8, ConnectInLine, slow, unstable, time.Second * 30},
+		{"10 clients/connectAll", 10, ConnectAll, slow, unstable, time.Second * 40},
+		{"10 clients/connectInLine", 10, ConnectInLine, slow, unstable, time.Second * 40},
 	}
 
 	testingScenario(t, cases, func(ctx context.Context, t *testing.T, tps ...*TestingProtocol) {
@@ -59,15 +74,15 @@ func TestScenario_CreateMultiMemberGroup(t *testing.T) {
 
 func TestScenario_MessageMultiMemberGroup(t *testing.T) {
 	cases := []testCase{
-		{"2 clients/connectAll", 2, ConnectAll, false, true, time.Second * 10},
-		{"3 clients/connectAll", 3, ConnectAll, false, true, time.Second * 10},
-		{"3 clients/connectInLine", 3, ConnectInLine, false, true, time.Second * 10},
-		{"5 clients/connectAll", 5, ConnectAll, true, true, time.Second * 10},
-		{"5 clients/connectInLine", 5, ConnectInLine, true, true, time.Second * 10},
-		{"8 clients/connectAll", 8, ConnectAll, true, true, time.Second * 10},
-		{"8 clients/connectInLine", 8, ConnectInLine, true, true, time.Second * 10},
-		{"10 clients/connectAll", 10, ConnectAll, true, true, time.Second * 10},
-		{"10 clients/connectInLine", 10, ConnectInLine, true, true, time.Second * 10},
+		{"2 clients/connectAll", 2, ConnectAll, fast, unstable, time.Second * 10},
+		{"3 clients/connectAll", 3, ConnectAll, fast, unstable, time.Second * 10},
+		{"3 clients/connectInLine", 3, ConnectInLine, fast, unstable, time.Second * 10},
+		{"5 clients/connectAll", 5, ConnectAll, slow, unstable, time.Second * 20},
+		{"5 clients/connectInLine", 5, ConnectInLine, slow, unstable, time.Second * 20},
+		{"8 clients/connectAll", 8, ConnectAll, slow, unstable, time.Second * 30},
+		{"8 clients/connectInLine", 8, ConnectInLine, slow, unstable, time.Second * 30},
+		{"10 clients/connectAll", 10, ConnectAll, slow, unstable, time.Second * 40},
+		{"10 clients/connectInLine", 10, ConnectInLine, slow, unstable, time.Second * 40},
 	}
 
 	testingScenario(t, cases, func(ctx context.Context, t *testing.T, tps ...*TestingProtocol) {
@@ -84,15 +99,15 @@ func TestScenario_MessageSeveralMultiMemberGroups(t *testing.T) {
 	const ngroup = 3
 
 	cases := []testCase{
-		{"2 clients/connectAll", 2, ConnectAll, false, true, time.Second * 10},
-		{"3 clients/connectAll", 3, ConnectAll, false, true, time.Second * 10},
-		{"3 clients/connectInLine", 3, ConnectInLine, false, true, time.Second * 10},
-		{"5 clients/connectAll", 5, ConnectAll, true, true, time.Second * 10},
-		{"5 clients/connectInLine", 5, ConnectInLine, true, true, time.Second * 10},
-		{"8 clients/connectAll", 8, ConnectAll, true, true, time.Second * 10},
-		{"8 clients/connectInLine", 8, ConnectInLine, true, true, time.Second * 10},
-		{"10 clients/connectAll", 10, ConnectAll, true, true, time.Second * 10},
-		{"10 clients/connectInLine", 10, ConnectInLine, true, true, time.Second * 10},
+		{"2 clients/connectAll", 2, ConnectAll, fast, unstable, time.Second * 10},
+		{"3 clients/connectAll", 3, ConnectAll, fast, unstable, time.Second * 10},
+		{"3 clients/connectInLine", 3, ConnectInLine, fast, unstable, time.Second * 10},
+		{"5 clients/connectAll", 5, ConnectAll, slow, unstable, time.Second * 20},
+		{"5 clients/connectInLine", 5, ConnectInLine, slow, unstable, time.Second * 20},
+		{"8 clients/connectAll", 8, ConnectAll, slow, unstable, time.Second * 30},
+		{"8 clients/connectInLine", 8, ConnectInLine, slow, unstable, time.Second * 30},
+		{"10 clients/connectAll", 10, ConnectAll, slow, unstable, time.Second * 40},
+		{"10 clients/connectInLine", 10, ConnectInLine, slow, unstable, time.Second * 40},
 	}
 
 	testingScenario(t, cases, func(ctx context.Context, t *testing.T, tps ...*TestingProtocol) {
@@ -110,16 +125,15 @@ func TestScenario_MessageSeveralMultiMemberGroups(t *testing.T) {
 
 func TestScenario_AddContact(t *testing.T) {
 	cases := []testCase{
-		{"2 clients/connectAll", 2, ConnectAll, false, true, time.Second * 20},       // marked as "unstable" because it failed multiple times on the CI recently
-		{"3 clients/connectAll", 3, ConnectAll, false, true, time.Second * 20},       // marked as "unstable" because it failed multiple times on the CI recently
-		{"3 clients/connectInLine", 3, ConnectInLine, false, true, time.Second * 20}, // marked as "unstable" because it failed multiple times on the CI recently
-		{"5 clients/connectAll", 5, ConnectAll, true, true, time.Second * 30},        // marked as "unstable" because it failed multiple times on the CI recently
-		{"5 clients/connectInLine", 5, ConnectInLine, true, true, time.Second * 30},  // marked as "unstable" because it failed multiple times on the CI recently
-		{"8 clients/connectAll", 8, ConnectAll, true, true, time.Second * 300},       // marked as "unstable" because too slow, but it works
-		{"8 clients/connectInLine", 8, ConnectInLine, true, true, time.Second * 300}, // marked as "unstable" because too slow, but it works
-		// FIXME: all test cases below
-		// {"10 clients/connectAll", 10, ConnectAll, true, false, time.Second * 60},
-		// {"10 clients/connectInLine", 10, ConnectInLine, true, false, time.Second * 60},
+		{"2 clients/connectAll", 2, ConnectAll, fast, unstable, time.Second * 20},       // marked as "unstable" because it failed multiple times on the CI recently
+		{"3 clients/connectAll", 3, ConnectAll, fast, unstable, time.Second * 20},       // marked as "unstable" because it failed multiple times on the CI recently
+		{"3 clients/connectInLine", 3, ConnectInLine, fast, unstable, time.Second * 20}, // marked as "unstable" because it failed multiple times on the CI recently
+		{"5 clients/connectAll", 5, ConnectAll, slow, unstable, time.Second * 30},       // marked as "unstable" because it failed multiple times on the CI recently
+		{"5 clients/connectInLine", 5, ConnectInLine, slow, unstable, time.Second * 30}, // marked as "unstable" because it failed multiple times on the CI recently
+		{"8 clients/connectAll", 8, ConnectAll, slow, unstable, time.Second * 40},       // marked as "unstable" because it failed multiple times on the CI recently
+		{"8 clients/connectInLine", 8, ConnectInLine, slow, unstable, time.Second * 40}, // marked as "unstable" because it failed multiple times on the CI recently
+		{"10 clients/connectAll", 10, ConnectAll, slow, broken, time.Second * 60},
+		{"10 clients/connectInLine", 10, ConnectInLine, slow, broken, time.Second * 60},
 	}
 
 	testingScenario(t, cases, func(ctx context.Context, t *testing.T, tps ...*TestingProtocol) {
@@ -129,16 +143,15 @@ func TestScenario_AddContact(t *testing.T) {
 
 func TestScenario_MessageContactGroup(t *testing.T) {
 	cases := []testCase{
-		// FIXME: all test cases below
-		{"2 clients/connectAll", 2, ConnectAll, false, true, time.Second * 20},
-		{"3 clients/connectAll", 3, ConnectAll, false, true, time.Second * 20},
-		{"3 clients/connectInLine", 3, ConnectInLine, false, true, time.Second * 20},
-		{"5 clients/connectAll", 5, ConnectAll, true, true, time.Second * 30},
-		{"5 clients/connectInLine", 5, ConnectInLine, true, true, time.Second * 30},
-		// {"8 clients/connectAll", 8, ConnectAll, true, false, time.Second * 40},
-		// {"8 clients/connectInLine", 8, ConnectInLine, true, false, time.Second * 40},
-		// {"10 clients/connectAll", 10, ConnectAll, true, false, time.Second * 60},
-		// {"10 clients/connectInLine", 10, ConnectInLine, true, false, time.Second * 60},
+		{"2 clients/connectAll", 2, ConnectAll, fast, unstable, time.Second * 20},
+		{"3 clients/connectAll", 3, ConnectAll, fast, unstable, time.Second * 20},
+		{"3 clients/connectInLine", 3, ConnectInLine, fast, unstable, time.Second * 20},
+		{"5 clients/connectAll", 5, ConnectAll, slow, unstable, time.Second * 30},
+		{"5 clients/connectInLine", 5, ConnectInLine, slow, unstable, time.Second * 30},
+		{"8 clients/connectAll", 8, ConnectAll, slow, broken, time.Second * 40},
+		{"8 clients/connectInLine", 8, ConnectInLine, slow, broken, time.Second * 40},
+		{"10 clients/connectAll", 10, ConnectAll, slow, broken, time.Second * 60},
+		{"10 clients/connectInLine", 10, ConnectInLine, slow, broken, time.Second * 60},
 	}
 
 	testingScenario(t, cases, func(ctx context.Context, t *testing.T, tps ...*TestingProtocol) {
@@ -154,7 +167,7 @@ func TestScenario_MessageContactGroup(t *testing.T) {
 
 func TestScenario_MessageAccountGroup(t *testing.T) {
 	cases := []testCase{
-		{"1 client/connectAll", 1, ConnectAll, false, false, time.Second * 10},
+		{"1 client/connectAll", 1, ConnectAll, fast, stable, time.Second * 10},
 	}
 
 	testingScenario(t, cases, func(ctx context.Context, t *testing.T, tps ...*TestingProtocol) {
@@ -171,16 +184,15 @@ func TestScenario_MessageAccountGroup(t *testing.T) {
 
 func TestScenario_MessageAccountAndMultiMemberGroups(t *testing.T) {
 	cases := []testCase{
-		// FIXME: all test cases below
-		// {"2 clients/connectAll", 2, ConnectAll, false, false, time.Second * 10},
-		// {"3 clients/connectAll", 3, ConnectAll, false, true, time.Second * 10},
-		// {"3 clients/connectInLine", 3, ConnectInLine, false, true, time.Second * 10},
-		// {"5 clients/connectAll", 5, ConnectAll, true, true, time.Second * 10},
-		// {"5 clients/connectInLine", 5, ConnectInLine, true, true, time.Second * 10},
-		// {"8 clients/connectAll", 8, ConnectAll, true, true, time.Second * 10},
-		// {"8 clients/connectInLine", 8, ConnectInLine, true, true, time.Second * 10},
-		// {"10 clients/connectAll", 10, ConnectAll, true, true, time.Second * 10},
-		// {"10 clients/connectInLine", 10, ConnectInLine, true, true, time.Second * 10},
+		{"2 clients/connectAll", 2, ConnectAll, fast, broken, time.Second * 10},
+		{"3 clients/connectAll", 3, ConnectAll, fast, broken, time.Second * 10},
+		{"3 clients/connectInLine", 3, ConnectInLine, fast, broken, time.Second * 10},
+		{"5 clients/connectAll", 5, ConnectAll, slow, broken, time.Second * 20},
+		{"5 clients/connectInLine", 5, ConnectInLine, slow, broken, time.Second * 20},
+		{"8 clients/connectAll", 8, ConnectAll, slow, broken, time.Second * 30},
+		{"8 clients/connectInLine", 8, ConnectInLine, slow, broken, time.Second * 30},
+		{"10 clients/connectAll", 10, ConnectAll, slow, broken, time.Second * 40},
+		{"10 clients/connectInLine", 10, ConnectInLine, slow, broken, time.Second * 40},
 	}
 
 	testingScenario(t, cases, func(ctx context.Context, t *testing.T, tps ...*TestingProtocol) {
@@ -214,16 +226,15 @@ func TestScenario_MessageAccountAndMultiMemberGroups(t *testing.T) {
 
 func TestScenario_MessageAccountAndContactGroups(t *testing.T) {
 	cases := []testCase{
-		// FIXME: all test cases below
-		// {"2 clients/connectAll", 2, ConnectAll, false, false, time.Second * 10},
-		// {"3 clients/connectAll", 3, ConnectAll, false, true, time.Second * 10},
-		// {"3 clients/connectInLine", 3, ConnectInLine, false, true, time.Second * 10},
-		// {"5 clients/connectAll", 5, ConnectAll, true, true, time.Second * 10},
-		// {"5 clients/connectInLine", 5, ConnectInLine, true, true, time.Second * 10},
-		// {"8 clients/connectAll", 8, ConnectAll, true, true, time.Second * 10},
-		// {"8 clients/connectInLine", 8, ConnectInLine, true, true, time.Second * 10},
-		// {"10 clients/connectAll", 10, ConnectAll, true, true, time.Second * 10},
-		// {"10 clients/connectInLine", 10, ConnectInLine, true, true, time.Second * 10},
+		{"2 clients/connectAll", 2, ConnectAll, fast, broken, time.Second * 10},
+		{"3 clients/connectAll", 3, ConnectAll, fast, broken, time.Second * 10},
+		{"3 clients/connectInLine", 3, ConnectInLine, fast, broken, time.Second * 10},
+		{"5 clients/connectAll", 5, ConnectAll, slow, broken, time.Second * 20},
+		{"5 clients/connectInLine", 5, ConnectInLine, slow, broken, time.Second * 20},
+		{"8 clients/connectAll", 8, ConnectAll, slow, broken, time.Second * 30},
+		{"8 clients/connectInLine", 8, ConnectInLine, slow, broken, time.Second * 30},
+		{"10 clients/connectAll", 10, ConnectAll, slow, broken, time.Second * 40},
+		{"10 clients/connectInLine", 10, ConnectInLine, slow, broken, time.Second * 40},
 	}
 
 	testingScenario(t, cases, func(ctx context.Context, t *testing.T, tps ...*TestingProtocol) {
@@ -285,11 +296,21 @@ func testingScenario(t *testing.T, tcs []testCase, tf testFunc) {
 
 	for _, tc := range tcs {
 		t.Run(tc.Name, func(t *testing.T) {
-			if tc.IsSlowTest {
+			if tc.Speed == slow {
 				testutil.SkipSlow(t)
 			}
-			if tc.IsUnstableTest {
-				testutil.SkipUnstable(t)
+			if filter := os.Getenv("TEST_FILTER"); filter == "unstable" || filter == "broken" {
+				if filter == "unstable" && tc.Stability != unstable {
+					t.Skip("run only unstable tests")
+				} else if filter == "broken" && tc.Stability != broken {
+					t.Skip("run only broken tests")
+				}
+			} else {
+				if tc.Stability == unstable {
+					testutil.SkipUnstable(t)
+				} else if tc.Stability == broken {
+					testutil.SkipBroken(t)
+				}
 			}
 
 			ctx, cancel := context.WithCancel(context.Background())

--- a/go/pkg/bertyprotocol/store_message_test.go
+++ b/go/pkg/bertyprotocol/store_message_test.go
@@ -22,7 +22,7 @@ func countEntries(out <-chan *bertytypes.GroupMessageEvent) int {
 }
 
 func Test_AddMessage_ListMessages_manually_supplying_secrets(t *testing.T) {
-	testutil.SkipSlow(t)
+	testutil.FilterSpeed(t, testutil.Slow)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -81,7 +81,7 @@ func Test_AddMessage_ListMessages_manually_supplying_secrets(t *testing.T) {
 	out, err = peers[1].GC.MessageStore().ListMessages(ctx)
 	assert.NoError(t, err)
 
-	testutil.SkipUnstable(t) // after this line, the test is unstable, especially on low hardware
+	testutil.FilterStability(t, testutil.Unstable)
 
 	<-time.After(time.Second)
 

--- a/go/pkg/bertyprotocol/store_metadata_test.go
+++ b/go/pkg/bertyprotocol/store_metadata_test.go
@@ -91,7 +91,7 @@ func TestMetadataStoreMember(t *testing.T) {
 			if tc.slow {
 				// TODO: re-enable this test
 				t.Skip()
-				testutil.SkipSlow(t)
+				testutil.FilterSpeed(t, testutil.Slow)
 			}
 
 			testMemberStore(t, tc.memberCount, tc.deviceCount)
@@ -486,7 +486,7 @@ func TestMetadataContactLifecycle(t *testing.T) {
 }
 
 func TestMetadataAliasLifecycle(t *testing.T) {
-	testutil.SkipSlow(t)
+	testutil.FilterSpeed(t, testutil.Slow)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/go/pkg/bertyprotocol/tinder_swiper_test.go
+++ b/go/pkg/bertyprotocol/tinder_swiper_test.go
@@ -98,7 +98,7 @@ func TestGenerateRendezvousPointForPeriod(t *testing.T) {
 }
 
 func TestAnnounceWatchForPeriod(t *testing.T) {
-	testutil.SkipSlow(t)
+	testutil.FilterSpeed(t, testutil.Slow)
 	cases := []struct {
 		expectedPeersFound int
 		topicA             []byte


### PR DESCRIPTION
Extends #2259
- [x] add 'broken' stability state to scenario test
- [x] add bertyprotocol scenario to go.unstable_test Makefile rule
- [x] refactor speed and stability filters for tests to skip