### PR TITLE
fix: Panic in WaitGroup in the Multipeer Connectivity transport

### DIFF
--- a/go/cmd/berty/mini/main.go
+++ b/go/cmd/berty/mini/main.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"berty.tech/berty/v2/go/internal/config"
 	"berty.tech/berty/v2/go/internal/ipfsutil"
 	"berty.tech/berty/v2/go/internal/tinder"
 	"berty.tech/berty/v2/go/internal/tracer"
@@ -66,12 +67,7 @@ func newService(ctx context.Context, logger *zap.Logger, opts *Opts) (bertyproto
 			fmt.Sprintf("/ip6/0.0.0.0/udp/%d/quic", opts.Port+1),
 		}
 	} else {
-		swarmAddresses = []string{
-			"/ip4/0.0.0.0/tcp/0",
-			"/ip6/0.0.0.0/tcp/0",
-			"/ip4/0.0.0.0/udp/0/quic",
-			"/ip6/0.0.0.0/udp/0/quic",
-		}
+		swarmAddresses = config.BertyDev.DefaultSwarmAddrs
 	}
 
 	if opts.RendezVousPeer == nil {

--- a/go/framework/bertybridge/bridge_protocol.go
+++ b/go/framework/bertybridge/bridge_protocol.go
@@ -20,6 +20,7 @@ import (
 	ipfs_badger "github.com/ipfs/go-ds-badger"
 	"github.com/ipfs/go-ipfs/core"
 	ipfs_repo "github.com/ipfs/go-ipfs/repo"
+	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p-core/host"
 	"github.com/libp2p/go-libp2p-core/peer"
 	"github.com/libp2p/go-libp2p-core/peerstore"
@@ -39,6 +40,7 @@ import (
 
 	"berty.tech/berty/v2/go/internal/config"
 	"berty.tech/berty/v2/go/internal/ipfsutil"
+	mc "berty.tech/berty/v2/go/internal/multipeer-connectivity-transport"
 	"berty.tech/berty/v2/go/internal/tinder"
 	"berty.tech/berty/v2/go/internal/tracer"
 	"berty.tech/berty/v2/go/pkg/bertyprotocol"
@@ -185,8 +187,7 @@ func newProtocolBridge(ctx context.Context, logger *zap.Logger, config *Messenge
 				SwarmAddrs:        defaultSwarmAddrs,
 				APIAddrs:          defaultAPIAddrs,
 				APIConfig:         APIConfig,
-				// @FIXME: this can cause some crash in debug, disable it for the moment
-				// ExtraLibp2pOption: libp2p.ChainOptions(libp2p.Transport(mc.NewTransportConstructorWithLogger(logger))),
+				ExtraLibp2pOption: libp2p.ChainOptions(libp2p.Transport(mc.NewTransportConstructorWithLogger(logger))),
 				HostConfig: func(h host.Host, _ routing.Routing) error {
 					var err error
 

--- a/go/internal/config/berty.go
+++ b/go/internal/config/berty.go
@@ -16,11 +16,17 @@ type BertyConfig struct {
 }
 
 var BertyDev = &BertyConfig{
-	Bootstrap:         ipfs_cfg.DefaultBootstrapAddresses,
-	RendezVousPeer:    "/dnsaddr/rdvp.berty.io/ipfs/QmdT7AmhhnbuwvCpa5PH1ySK9HJVB82jr3fo1bxMxBPW6p",
-	DefaultSwarmAddrs: []string{mc.DefaultBind},
-	Tracing:           "jaeger.berty.io:8443",
-	DefaultAPIAddrs:   []string{"/ip4/127.0.0.1/tcp/5001"},
+	Bootstrap:      ipfs_cfg.DefaultBootstrapAddresses,
+	RendezVousPeer: "/dnsaddr/rdvp.berty.io/ipfs/QmdT7AmhhnbuwvCpa5PH1ySK9HJVB82jr3fo1bxMxBPW6p",
+	DefaultSwarmAddrs: []string{
+		mc.DefaultBind,
+		"/ip4/0.0.0.0/tcp/0",
+		"/ip6/::/tcp/0",
+		"/ip4/0.0.0.0/udp/0/quic",
+		"/ip6/::/udp/0/quic",
+	},
+	Tracing:         "jaeger.berty.io:8443",
+	DefaultAPIAddrs: []string{"/ip4/127.0.0.1/tcp/5001"},
 	APIConfig: config.API{
 		HTTPHeaders: map[string][]string{
 			"Access-Control-Allow-Origin":  {"*"},
@@ -30,11 +36,17 @@ var BertyDev = &BertyConfig{
 }
 
 var BertyMobile = &BertyConfig{
-	Bootstrap:         ipfs_cfg.DefaultBootstrapAddresses,
-	RendezVousPeer:    "/ip4/163.172.106.31/tcp/4040/p2p/QmdT7AmhhnbuwvCpa5PH1ySK9HJVB82jr3fo1bxMxBPW6p",
-	DefaultSwarmAddrs: []string{mc.DefaultBind},
-	Tracing:           "jaeger.berty.io:8443",
-	DefaultAPIAddrs:   []string{"/ip4/127.0.0.1/tcp/5001"},
+	Bootstrap:      ipfs_cfg.DefaultBootstrapAddresses,
+	RendezVousPeer: "/ip4/163.172.106.31/tcp/4040/p2p/QmdT7AmhhnbuwvCpa5PH1ySK9HJVB82jr3fo1bxMxBPW6p",
+	DefaultSwarmAddrs: []string{
+		mc.DefaultBind,
+		"/ip4/0.0.0.0/tcp/0",
+		"/ip6/::/tcp/0",
+		"/ip4/0.0.0.0/udp/0/quic",
+		"/ip6/::/udp/0/quic",
+	},
+	Tracing:         "jaeger.berty.io:8443",
+	DefaultAPIAddrs: []string{"/ip4/127.0.0.1/tcp/5001"},
 	APIConfig: config.API{
 		HTTPHeaders: map[string][]string{
 			"Access-Control-Allow-Origin":  {"*"},

--- a/go/internal/ipfsutil/repo.go
+++ b/go/internal/ipfsutil/repo.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"berty.tech/berty/v2/go/internal/config"
 	"berty.tech/berty/v2/go/pkg/errcode"
 	ipfs_ds "github.com/ipfs/go-datastore"
 	ipfs_cfg "github.com/ipfs/go-ipfs-config"
@@ -98,12 +99,7 @@ func createBaseConfig() (*ipfs_cfg.Config, error) {
 	c.Discovery.MDNS.Interval = 5
 
 	// swarm listeners
-	c.Addresses.Swarm = []string{
-		"/ip4/0.0.0.0/tcp/0",
-		"/ip6/::/tcp/0",
-		"/ip4/0.0.0.0/udp/0/quic",
-		"/ip6/::/udp/0/quic",
-	}
+	c.Addresses.Swarm = config.BertyDev.DefaultSwarmAddrs
 
 	// Swarm
 	c.Swarm.EnableAutoRelay = true

--- a/go/internal/multipeer-connectivity-transport/transport.go
+++ b/go/internal/multipeer-connectivity-transport/transport.go
@@ -34,6 +34,7 @@ type Transport struct {
 
 func NewTransportConstructorWithLogger(l *zap.Logger) func(h host.Host, u *tptu.Upgrader) (*Transport, error) {
 	if l != nil {
+		l.Named("MC Transport")
 		logger = l
 	}
 	return NewTransport
@@ -42,6 +43,7 @@ func NewTransportConstructorWithLogger(l *zap.Logger) func(h host.Host, u *tptu.
 // NewTransport creates a transport object that tracks dialers and listener.
 // It also starts the discovery service.
 func NewTransport(h host.Host, u *tptu.Upgrader) (*Transport, error) {
+	logger.Debug("New multipeer connectivity transport")
 	return &Transport{
 		host:     h,
 		upgrader: u,

--- a/go/internal/multipeer-connectivity-transport/transport.go
+++ b/go/internal/multipeer-connectivity-transport/transport.go
@@ -64,14 +64,19 @@ func (t *Transport) Dial(ctx context.Context, remoteMa ma.Multiaddr, remotePID p
 		return nil, errors.Wrap(err, "transport dialing peer failed: wrong multiaddr")
 	}
 
+	// Ensures that gListener won't be unset until operations using it are finished
+	gListener.inUse.Add(1)
+
 	// Check if native driver is already connected to peer's device.
 	// With MC you can't really dial, only auto-connect with peer nearby.
 	if !mcdrv.DialPeer(remoteAddr) {
+		gListener.inUse.Done()
 		return nil, errors.New("transport dialing peer failed: peer not connected through MC")
 	}
 
 	// Can't have two connections on the same multiaddr
 	if _, ok := connMap.Load(remoteAddr); ok {
+		gListener.inUse.Done()
 		return nil, errors.New("transport dialing peer failed: already connected to this address")
 	}
 


### PR DESCRIPTION
bug: negative counter in the **WaitGroup** field of the `Listener` struct.

In outgoing connections (`Dial()` method), no **Add** method of WaitGroup is called. So when `newConn` calls **Done** of WaitGroup, the counter becomes negative.

Signed-off-by: d4ryl00 <d4ryl00@gmail.com>