### PR TITLE
fix: improve subscribe + some small improvement for logging/testing

### DIFF
--- a/go/pkg/bertymessenger/testing.go
+++ b/go/pkg/bertymessenger/testing.go
@@ -191,6 +191,7 @@ func (a *TestingAccount) NextEvent(t *testing.T) *StreamEvent {
 
 	a.closedMutex.RLock()
 	if a.closed {
+		a.closedMutex.RUnlock()
 		return nil
 	}
 	a.closedMutex.RUnlock()

--- a/go/pkg/bertyprotocol/contact_request_manager.go
+++ b/go/pkg/bertyprotocol/contact_request_manager.go
@@ -238,8 +238,9 @@ func (c *contactRequestsManager) metadataWatcher(ctx context.Context) {
 	}
 	c.lock.Unlock()
 
+	chSub := c.metadataStore.Subscribe(ctx)
 	go func() {
-		for evt := range c.metadataStore.Subscribe(ctx) {
+		for evt := range chSub {
 			e, ok := evt.(*bertytypes.GroupMetadataEvent)
 			if !ok {
 				continue

--- a/go/pkg/bertyprotocol/service_group.go
+++ b/go/pkg/bertyprotocol/service_group.go
@@ -155,16 +155,18 @@ func (s *service) activateGroup(pk crypto.PubKey) error {
 
 		s.openedGroups[string(id)] = cg
 
+		chSub1 := cg.metadataStore.Subscribe(s.ctx)
 		go func() {
-			for e := range cg.metadataStore.Subscribe(s.ctx) {
+			for e := range chSub1 {
 				if evt, ok := e.(*stores.EventNewPeer); ok {
 					s.ipfsCoreAPI.ConnMgr().TagPeer(evt.Peer, fmt.Sprintf("grp_%s", string(id)), 42)
 				}
 			}
 		}()
 
+		chSub2 := cg.messageStore.Subscribe(s.ctx)
 		go func() {
-			for e := range cg.messageStore.Subscribe(s.ctx) {
+			for e := range chSub2 {
 				if evt, ok := e.(*stores.EventNewPeer); ok {
 					s.ipfsCoreAPI.ConnMgr().TagPeer(evt.Peer, fmt.Sprintf("grp_%s", string(id)), 42)
 				}

--- a/go/pkg/bertyprotocol/store_message.go
+++ b/go/pkg/bertyprotocol/store_message.go
@@ -137,8 +137,9 @@ func constructorFactoryGroupMessage(s *bertyOrbitDB) iface.StoreConstructor {
 			return nil, errcode.ErrOrbitDBInit.Wrap(err)
 		}
 
+		chSub := store.Subscribe(ctx)
 		go func() {
-			for e := range store.Subscribe(ctx) {
+			for e := range chSub {
 				entry := ipfslog.Entry(nil)
 
 				switch evt := e.(type) {

--- a/go/pkg/bertyprotocol/store_message_test.go
+++ b/go/pkg/bertyprotocol/store_message_test.go
@@ -55,8 +55,9 @@ func Test_AddMessage_ListMessages_manually_supplying_secrets(t *testing.T) {
 	assert.Equal(t, 1, countEntries(out))
 
 	watcherCtx, watcherCancel := context.WithTimeout(ctx, time.Second*2)
+	chSub := peers[1].GC.MessageStore().Subscribe(watcherCtx)
 	go func() {
-		for range peers[1].GC.MessageStore().Subscribe(watcherCtx) {
+		for range chSub {
 			c, err := peers[1].GC.MessageStore().ListMessages(watcherCtx)
 			if !assert.NoError(t, err) {
 				watcherCancel()

--- a/go/pkg/bertyprotocol/store_metadata.go
+++ b/go/pkg/bertyprotocol/store_metadata.go
@@ -838,11 +838,12 @@ func constructorFactoryGroupMetadata(s *bertyOrbitDB) iface.StoreConstructor {
 			g:      g,
 			mks:    s.messageKeystore,
 			devKS:  s.deviceKeystore,
-			logger: zap.NewNop(),
+			logger: s.Logger(),
 		}
 
+		chSub := store.Subscribe(ctx)
 		go func() {
-			for e := range store.Subscribe(ctx) {
+			for e := range chSub {
 				var entry ipfslog.Entry
 
 				switch evt := e.(type) {


### PR DESCRIPTION
### [Change description]
- Should Subscribe() before do listen subscribed events in go routine to prevent later schedule go routine - lost events
- inherit orbitdb's logger in metadata_store
- Fix missing mutex unlock in test

### [Test]
Run current tests