### PR TITLE
fix: race condition in the MultipeerConnectivity transporter

### DIFF
--- a/go/internal/multipeer-connectivity-transport/connmgr.go
+++ b/go/internal/multipeer-connectivity-transport/connmgr.go
@@ -33,9 +33,6 @@ func newConn(ctx context.Context, t *Transport, remoteMa ma.Multiaddr,
 		cancel:   cancel,
 	}
 
-	// Unlock gListener locked from discovery.go (HandlePeerFound)
-	gListener.inUse.Done()
-
 	// Stores the conn in connMap, will be deleted during conn.Close()
 	connMap.Store(maconn.RemoteAddr().String(), maconn)
 

--- a/go/internal/multipeer-connectivity-transport/discovery.go
+++ b/go/internal/multipeer-connectivity-transport/discovery.go
@@ -25,7 +25,7 @@ func HandleFoundPeer(sRemotePID string) bool {
 
 	// Checks if a listener is currently running.
 	if gListener == nil || gListener.ctx.Err() != nil {
-		logger.Error("discovery handle peer failed: listener not running", zap.Error(gListener.ctx.Err()))
+		logger.Error("discovery handle peer failed: listener not running")
 		return false
 	}
 

--- a/go/internal/multipeer-connectivity-transport/discovery.go
+++ b/go/internal/multipeer-connectivity-transport/discovery.go
@@ -31,9 +31,6 @@ func HandleFoundPeer(sRemotePID string) bool {
 		return false
 	}
 
-	// Ensures that gListener won't be unset until operations using it are finished
-	gListener.inUse.Add(1)
-
 	// Adds peer to peerstore.
 	gListener.transport.host.Peerstore().AddAddr(remotePID, remoteMa,
 		pstore.TempAddrTTL)
@@ -63,7 +60,6 @@ func HandleFoundPeer(sRemotePID string) bool {
 	}:
 		return true
 	case <-gListener.ctx.Done():
-		gListener.inUse.Done()
 		return false
 	}
 }

--- a/go/internal/multipeer-connectivity-transport/discovery.go
+++ b/go/internal/multipeer-connectivity-transport/discovery.go
@@ -24,6 +24,8 @@ func HandleFoundPeer(sRemotePID string) bool {
 	}
 
 	// Checks if a listener is currently running.
+	gLock.RLock()
+	defer gLock.RUnlock()
 	if gListener == nil || gListener.ctx.Err() != nil {
 		logger.Error("discovery handle peer failed: listener not running")
 		return false

--- a/go/internal/multipeer-connectivity-transport/listener.go
+++ b/go/internal/multipeer-connectivity-transport/listener.go
@@ -31,7 +31,6 @@ type Listener struct {
 	transport      *Transport
 	localMa        ma.Multiaddr
 	inboundConnReq chan connReq // Chan used to accept inbound conn.
-	inUse          sync.WaitGroup
 	ctx            context.Context
 	cancel         func()
 }
@@ -95,10 +94,7 @@ func (l *Listener) Close() error {
 
 	// Removes global listener so transport can instantiate a new one later.
 	gLock.Lock()
-	if gListener != nil {
-		gListener.inUse.Wait()
-		gListener = nil
-	}
+	gListener = nil
 	gLock.Unlock()
 
 	return nil

--- a/go/internal/multipeer-connectivity-transport/listener.go
+++ b/go/internal/multipeer-connectivity-transport/listener.go
@@ -15,7 +15,10 @@ import (
 
 // Global listener is used by discovery (to send incoming conn request to Accept())
 // and transport (to ensure that only one listener is running at a time).
-var gListener *Listener
+var (
+	gListener *Listener
+	gLock     sync.Mutex
+)
 
 // Listener is a tpt.Listener.
 var _ tpt.Listener = &Listener{}
@@ -89,6 +92,8 @@ func (l *Listener) Close() error {
 	mcdrv.StopMCDriver()
 
 	// Removes global listener so transport can instantiate a new one later.
+	gLock.Lock()
+	defer gLock.Unlock()
 	if gListener != nil {
 		gListener.inUse.Wait()
 		gListener = nil

--- a/go/internal/multipeer-connectivity-transport/transport.go
+++ b/go/internal/multipeer-connectivity-transport/transport.go
@@ -68,19 +68,14 @@ func (t *Transport) Dial(ctx context.Context, remoteMa ma.Multiaddr, remotePID p
 		return nil, errors.Wrap(err, "transport dialing peer failed: wrong multiaddr")
 	}
 
-	// Ensures that gListener won't be unset until operations using it are finished
-	gListener.inUse.Add(1)
-
 	// Check if native driver is already connected to peer's device.
 	// With MC you can't really dial, only auto-connect with peer nearby.
 	if !mcdrv.DialPeer(remoteAddr) {
-		gListener.inUse.Done()
 		return nil, errors.New("transport dialing peer failed: peer not connected through MC")
 	}
 
 	// Can't have two connections on the same multiaddr
 	if _, ok := connMap.Load(remoteAddr); ok {
-		gListener.inUse.Done()
 		return nil, errors.New("transport dialing peer failed: already connected to this address")
 	}
 

--- a/go/internal/multipeer-connectivity-transport/transport.go
+++ b/go/internal/multipeer-connectivity-transport/transport.go
@@ -114,6 +114,8 @@ func (t *Transport) Listen(localMa ma.Multiaddr) (tpt.Listener, error) {
 	}
 
 	// If a global listener already exists, returns an error.
+	gLock.Lock()
+	defer gLock.Unlock()
 	if gListener != nil {
 		// TODO: restore this when published as generic lib / fixed in Berty network
 		// config update


### PR DESCRIPTION
The global variable `gListener` is not protected by concurrent execution.
For now, this transporter supports only once instance.

Signed-off-by: d4ryl00 <d4ryl00@gmail.com>