### PR TITLE
feat(messenger): lock portrait mode on mobile

### DIFF
--- a/js/packages/berty-app/android/app/src/main/AndroidManifest.xml
+++ b/js/packages/berty-app/android/app/src/main/AndroidManifest.xml
@@ -16,6 +16,7 @@
         android:label="@string/app_name"
         android:configChanges="keyboard|keyboardHidden|orientation|screenSize|uiMode"
         android:launchMode="singleTask"
+        android:screenOrientation="portrait"
         android:windowSoftInputMode="adjustResize">
         <intent-filter>
             <action android:name="android.intent.action.MAIN" />

--- a/js/packages/berty-app/ios/Berty/Info.plist
+++ b/js/packages/berty-app/ios/Berty/Info.plist
@@ -102,8 +102,6 @@
 	<key>UISupportedInterfaceOrientations</key>
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
-		<string>UIInterfaceOrientationLandscapeLeft</string>
-		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>


### PR DESCRIPTION
As it says on the tin. I'm not removing orientation conditions/listeners from UI for the moment; this is to unblock the issue of broken landscape views that are too time-consuming to maintain.