### PR TITLE
fix: multipeer transport race condition

### DIFF
--- a/go/framework/bertybridge/bridge_test.go
+++ b/go/framework/bertybridge/bridge_test.go
@@ -121,8 +121,6 @@ func TestPersistenceProtocol(t *testing.T) {
 
 	const n_try = 4
 
-	testutil.FilterStabilityAndSpeed(t, testutil.Unstable, testutil.Slow)
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 


### PR DESCRIPTION
Signed-off-by: phanquy <phanhuynhquy@gmail.com>

### [Change Description]
Some improve in HandleFoundPeer()
- Missing mutex and checking valid of gListener in go routine forked in HandleFoundPeer() - so if Listener.Close() is called, potentially gListener is set is nill before go routine is executed
- mutex cover also  the case `case listener.inboundConnReq <- connReq{` - this can be blocked in case missing call to Accept(), and will block Close(), Dial()...

### [Test]
None