### PR TITLE
feat(messenger): improve swipe screen navigation

### DIFF
--- a/js/packages/components/chat/MultiMember.tsx
+++ b/js/packages/components/chat/MultiMember.tsx
@@ -232,12 +232,16 @@ const MessageList: React.FC<{ id: string; scrollToMessage?: string }> = ({
 			}
 		}
 	}, [interactions, scrollToMessage])
-	const flatListRef = React.useRef(null)
+	const flatListRef: any = React.useRef(null)
 
 	const onScrollToIndexFailed = () => {
 		// Not sure why this happens (something to do with item/screen dimensions I think)
-		flatListRef.current?.scrollToIndex({ index: 0 })
+		flatListRef?.current?.scrollToIndex({ index: 0 })
 	}
+
+	const items: any = React.useMemo(() => {
+		return interactions?.reverse() || []
+	}, [interactions])
 
 	if (!conversation) {
 		return <CenteredActivityIndicator />
@@ -256,7 +260,7 @@ const MessageList: React.FC<{ id: string; scrollToMessage?: string }> = ({
 				margin.bottom.medium,
 				{ marginTop: 140 * scaleHeight },
 			]}
-			data={interactions.reverse()}
+			data={items}
 			inverted
 			ListFooterComponent={<InfosMultiMember {...conversation} />}
 			keyExtractor={(item) => item.cid}
@@ -266,7 +270,7 @@ const MessageList: React.FC<{ id: string; scrollToMessage?: string }> = ({
 					convKind={messengerpb.Conversation.Type.MultiMemberType}
 					convPK={conversation.publicKey}
 					members={members}
-					previousMessageId={index > 0 ? interactions.reverse()[index - 1]?.cid : ''}
+					previousMessageId={index > 0 ? items[index - 1]?.cid : ''}
 				/>
 			)}
 		/>

--- a/js/packages/components/chat/OneToOne.tsx
+++ b/js/packages/components/chat/OneToOne.tsx
@@ -27,6 +27,7 @@ import BlurView from '../shared-components/BlurView'
 
 // import { useReadEffect } from '../hooks'
 import { ChatFooter, ChatDate } from './shared-components/Chat'
+import { SwipeNavRecognizer } from '../shared-components/SwipeNavRecognizer'
 
 //
 // Chat
@@ -195,7 +196,7 @@ const MessageList: React.FC<{ convPk: string; scrollToMessage?: string }> = ({
 			msg.type === messengerpb.AppMessage.Type.TypeGroupInvitation,
 	)
 
-	const flatListRef = useRef(null)
+	const flatListRef: any = useRef(null)
 
 	const onScrollToIndexFailed = () => {
 		// Not sure why this happens (something to do with item/screen dimensions I think)
@@ -212,13 +213,17 @@ const MessageList: React.FC<{ convPk: string; scrollToMessage?: string }> = ({
 		}
 	}, [messages, scrollToMessage])
 
+	const items: any = React.useMemo(() => {
+		return messages?.reverse() || []
+	}, [messages])
+
 	return (
 		<FlatList
 			initialScrollIndex={initialScrollIndex}
 			onScrollToIndexFailed={onScrollToIndexFailed}
 			ref={flatListRef}
 			keyboardDismissMode='on-drag'
-			data={messages.reverse()}
+			data={items}
 			inverted
 			keyExtractor={(item: any) => item.cid}
 			ListFooterComponent={<InfosChat {...conv} />}
@@ -227,7 +232,7 @@ const MessageList: React.FC<{ convPk: string; scrollToMessage?: string }> = ({
 					id={item.cid}
 					convKind={messengerpb.Conversation.Type.ContactType}
 					convPK={conv.publicKey}
-					previousMessageId={index > 0 ? messages.reverse()[index - 1]?.cid : ''}
+					previousMessageId={index > 0 ? items[index - 1]?.cid : ''}
 				/>
 			)}
 		/>
@@ -238,17 +243,23 @@ export const OneToOne: React.FC<ScreenProps.Chat.OneToOne> = ({ route }) => {
 	const [inputIsFocused, setInputFocus] = useState(false)
 	const [{ flex, background }] = useStyles()
 	useReadEffect(route.params.convId, 1000)
+
 	return (
-		<View style={[StyleSheet.absoluteFill, background.white]}>
-			<KeyboardAvoidingView style={[flex.tiny]} behavior='padding'>
-				<MessageList convPk={route.params.convId} scrollToMessage={route.params.scrollToMessage} />
-				<ChatFooter
-					convPk={route.params.convId}
-					isFocused={inputIsFocused}
-					setFocus={setInputFocus}
-				/>
-				<ChatHeader convPk={route.params.convId} />
-			</KeyboardAvoidingView>
+		<View style={[StyleSheet.absoluteFill, background.white, { flex: 1 }]}>
+			<SwipeNavRecognizer>
+				<KeyboardAvoidingView style={[flex.tiny]} behavior='padding'>
+					<MessageList
+						convPk={route.params.convId}
+						scrollToMessage={route.params.scrollToMessage}
+					/>
+					<ChatFooter
+						convPk={route.params.convId}
+						isFocused={inputIsFocused}
+						setFocus={setInputFocus}
+					/>
+					<ChatHeader convPk={route.params.convId} />
+				</KeyboardAvoidingView>
+			</SwipeNavRecognizer>
 		</View>
 	)
 }

--- a/js/packages/components/main/Home.tsx
+++ b/js/packages/components/main/Home.tsx
@@ -32,6 +32,7 @@ import moment from 'moment'
 import Logo from './1_berty_picto.svg'
 import EmptyChat from './empty_chat.svg'
 import AvatarGroup19 from './Avatar_Group_Copy_19.png'
+import { SwipeNavRecognizer } from '../shared-components/SwipeNavRecognizer'
 
 //
 // Main List
@@ -430,6 +431,7 @@ export const Home: React.FC<ScreenProps.Main.Home> = () => {
 	const [isOnTop, setIsOnTop] = useState<boolean>(false)
 	const [dirScroll, setDirScroll] = useState<string>('')
 	const [bgColor, setBgColor] = useState<any>()
+	const { navigate } = useNavigation()
 
 	useEffect(() => {
 		if (!requests.length) {
@@ -442,56 +444,61 @@ export const Home: React.FC<ScreenProps.Main.Home> = () => {
 	return (
 		<>
 			<View style={[flex.tiny]}>
-				<ScrollView
-					ref={scrollRef}
-					style={[{ backgroundColor: bgColor }]}
-					stickyHeaderIndices={[1]}
-					showsVerticalScrollIndicator={false}
-					scrollEventThrottle={16}
-					onScroll={(e) => {
-						if (e.nativeEvent.contentOffset) {
-							if (e.nativeEvent.contentOffset.y >= layoutRequests.height) {
-								setIsOnTop(true)
-							} else {
-								setIsOnTop(false)
-							}
-							if (offset && e.nativeEvent.contentOffset.y >= offset.y) {
-								setDirScroll('up')
-							} else if (offset && e.nativeEvent.contentOffset.y < offset.y) {
-								setDirScroll('down')
-							}
-							setOffset(e.nativeEvent.contentOffset)
-						}
-					}}
+				<SwipeNavRecognizer
+					onSwipeLeft={navigate.settings.home}
+					onSwipeRight={navigate.main.search}
 				>
-					<IncomingRequests items={requests} onLayout={onLayoutRequests} />
-					<HomeHeader
-						isOnTop={isOnTop}
-						onLayout={onLayoutHeader}
-						hasRequests={requests.length > 0}
-						scrollRef={scrollRef}
-					/>
-					{isConversation ? (
-						<Conversations items={conversations} onLayout={onLayoutConversations} />
-					) : (
-						<View style={[background.white]}>
-							<View style={[flex.justify.center, flex.align.center, margin.top.scale(60)]}>
-								<EmptyChat width={350} height={350} />
-								<TextNative
-									style={[
-										text.align.center,
-										text.color.grey,
-										text.bold.small,
-										opacity(0.3),
-										margin.top.big,
-									]}
-								>
-									You don't have any contacts or chat yet
-								</TextNative>
+					<ScrollView
+						ref={scrollRef}
+						style={[{ backgroundColor: bgColor }]}
+						stickyHeaderIndices={[1]}
+						showsVerticalScrollIndicator={false}
+						scrollEventThrottle={16}
+						onScroll={(e) => {
+							if (e.nativeEvent.contentOffset) {
+								if (e.nativeEvent.contentOffset.y >= layoutRequests.height) {
+									setIsOnTop(true)
+								} else {
+									setIsOnTop(false)
+								}
+								if (offset && e.nativeEvent.contentOffset.y >= offset.y) {
+									setDirScroll('up')
+								} else if (offset && e.nativeEvent.contentOffset.y < offset.y) {
+									setDirScroll('down')
+								}
+								setOffset(e.nativeEvent.contentOffset)
+							}
+						}}
+					>
+						<IncomingRequests items={requests} onLayout={onLayoutRequests} />
+						<HomeHeader
+							isOnTop={isOnTop}
+							onLayout={onLayoutHeader}
+							hasRequests={requests.length > 0}
+							scrollRef={scrollRef}
+						/>
+						{isConversation ? (
+							<Conversations items={conversations} onLayout={onLayoutConversations} />
+						) : (
+							<View style={[background.white]}>
+								<View style={[flex.justify.center, flex.align.center, margin.top.scale(60)]}>
+									<EmptyChat width={350} height={350} />
+									<TextNative
+										style={[
+											text.align.center,
+											text.color.grey,
+											text.bold.small,
+											opacity(0.3),
+											margin.top.big,
+										]}
+									>
+										You don't have any contacts or chat yet
+									</TextNative>
+								</View>
 							</View>
-						</View>
-					)}
-				</ScrollView>
+						)}
+					</ScrollView>
+				</SwipeNavRecognizer>
 			</View>
 			<LinearGradient
 				style={[

--- a/js/packages/components/main/Search.tsx
+++ b/js/packages/components/main/Search.tsx
@@ -30,6 +30,7 @@ import {
 import { messenger as messengerpb } from '@berty-tech/api/index.js'
 import * as api from '@berty-tech/api/index.pb'
 import { ProceduralCircleAvatar } from '../shared-components/ProceduralCircleAvatar'
+import { SwipeNavRecognizer } from '../shared-components/SwipeNavRecognizer'
 
 // Styles
 
@@ -628,6 +629,7 @@ export const Search: React.FC<{}> = () => {
 			(searchIn || '').toLowerCase().includes(lowSearchText),
 		[lowSearchText],
 	)
+	const { navigate } = useNavigation()
 
 	const ctx = useMsgrContext()
 
@@ -670,23 +672,25 @@ export const Search: React.FC<{}> = () => {
 	return (
 		<>
 			<Layout style={[flex.tiny, background.yellow]}>
-				<SafeAreaConsumer>
-					{(insets: EdgeInsets | null) => {
-						return (
-							<View style={[flex.tiny]}>
-								<SearchComponent
-									insets={insets}
-									contacts={contacts}
-									interactions={interactions}
-									conversations={conversations}
-									searchText={searchText}
-									setSearchText={setSearchText}
-									hasResults={hasResults}
-								/>
-							</View>
-						)
-					}}
-				</SafeAreaConsumer>
+				<SwipeNavRecognizer onSwipeLeft={navigate.main.home}>
+					<SafeAreaConsumer>
+						{(insets: EdgeInsets | null) => {
+							return (
+								<View style={[flex.tiny]}>
+									<SearchComponent
+										insets={insets}
+										contacts={contacts}
+										interactions={interactions}
+										conversations={conversations}
+										searchText={searchText}
+										setSearchText={setSearchText}
+										hasResults={hasResults}
+									/>
+								</View>
+							)
+						}}
+					</SafeAreaConsumer>
+				</SwipeNavRecognizer>
 			</Layout>
 			{hasResults && (
 				<LinearGradient

--- a/js/packages/components/package.json
+++ b/js/packages/components/package.json
@@ -53,6 +53,7 @@
     "react-native-qrcode-scanner": "^1.3.1",
     "react-native-raw-bottom-sheet": "^2.0.6",
     "react-native-redash": "^8.6.0",
+    "react-native-swipe-gestures": "^1.0.5",
     "react-native-swiper": "^1.6.0-rc.1",
     "react-native-ui-kitten": "^4.4.1",
     "react-use": "^13.9.0",

--- a/js/packages/components/settings/Home.tsx
+++ b/js/packages/components/settings/Home.tsx
@@ -9,6 +9,7 @@ import { ScreenProps, useNavigation } from '@berty-tech/navigation'
 import { Messenger } from '@berty-tech/store/oldhooks'
 import { SafeAreaView } from 'react-native-safe-area-context'
 import LinearGradient from 'react-native-linear-gradient'
+import { SwipeNavRecognizer } from '../shared-components/SwipeNavRecognizer'
 
 //
 // Home Vue
@@ -153,22 +154,26 @@ export const Home: React.FC<ScreenProps.Settings.Home> = () => {
 	const account = Messenger.useAccount()
 	const _styles = useStylesHome()
 	const [{ flex, background, row, absolute }] = useStyles()
+	const { navigate } = useNavigation()
+
 	return (
 		<>
 			<View style={[flex.tiny, background.white]}>
-				{account == null ? (
-					<ActivityIndicator size='large' style={[row.center]} />
-				) : (
-					<ScrollView bounces={false} contentContainerStyle={[_styles.scrollViewPadding]}>
-						<HeaderSettings>
-							<View>
-								<HomeHeader />
-								<HomeHeaderGroupButton />
-							</View>
-						</HeaderSettings>
-						<HomeBodySettings />
-					</ScrollView>
-				)}
+				<SwipeNavRecognizer onSwipeRight={navigate.main.home}>
+					{account == null ? (
+						<ActivityIndicator size='large' style={[row.center]} />
+					) : (
+						<ScrollView bounces={false} contentContainerStyle={[_styles.scrollViewPadding]}>
+							<HeaderSettings>
+								<View>
+									<HomeHeader />
+									<HomeHeaderGroupButton />
+								</View>
+							</HeaderSettings>
+							<HomeBodySettings />
+						</ScrollView>
+					)}
+				</SwipeNavRecognizer>
 			</View>
 			<LinearGradient
 				style={[

--- a/js/packages/components/shared-components/SwipeNavRecognizer.tsx
+++ b/js/packages/components/shared-components/SwipeNavRecognizer.tsx
@@ -1,0 +1,44 @@
+import { useNavigation } from '@berty-tech/navigation'
+import { debounce } from 'lodash'
+import React from 'react'
+import { View } from 'react-native'
+import GestureRecognizer from 'react-native-swipe-gestures'
+
+//
+// Without any props, this will call goBack() on swipe right
+//
+// This component's parent must have flex: 1
+//
+// The onSwipe callbacks do not have to be navigation functions,
+// but might be best for sanity if they are.
+//
+
+export const SwipeNavRecognizer: React.FC<{
+	children: any
+	stylesRecognizer?: any
+	onSwipe?: (gestureName: string) => void
+	onSwipeRight?: () => void
+	onSwipeLeft?: () => void
+}> = ({ children = null, stylesRecognizer = { flex: 1 }, onSwipe, onSwipeLeft, onSwipeRight }) => {
+	const { goBack } = useNavigation()
+	const debouncer = (fn: any) => debounce(fn, 500, { leading: true })
+
+	return (
+		// <View style={{ flex: 1 }}>
+		<GestureRecognizer
+			onSwipeRight={
+				onSwipeRight
+					? debouncer(onSwipeRight)
+					: !onSwipe && !onSwipeLeft
+					? debouncer(goBack)
+					: undefined
+			}
+			onSwipeLeft={onSwipeLeft && debouncer(onSwipeLeft)}
+			onSwipe={onSwipe && debouncer((gestureName: string) => onSwipe(gestureName))}
+			style={stylesRecognizer}
+		>
+			{children}
+		</GestureRecognizer>
+		// </View>
+	)
+}

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -19727,7 +19727,7 @@ react-native-svg@^11.0.1:
     css-select "^2.1.0"
     css-tree "^1.0.0-alpha.39"
 
-react-native-swipe-gestures@^1.0.4:
+react-native-swipe-gestures@^1.0.4, react-native-swipe-gestures@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/react-native-swipe-gestures/-/react-native-swipe-gestures-1.0.5.tgz#a172cb0f3e7478ccd681fd36b8bfbcdd098bde7c"
   integrity sha512-Ns7Bn9H/Tyw278+5SQx9oAblDZ7JixyzeOczcBK8dipQk2pD7Djkcfnf1nB/8RErAmMLL9iXgW0QHqiII8AhKw==


### PR DESCRIPTION
- Adds a component that triggers a back navigation on swiped-right child (uses simple external module https://github.com/glepur/react-native-swipe-gestures based on RN's PanResponder)
- Component takes arbitrary callbacks for horizontal swipes that can override goBack()
- Implemented in main bottom tab views, Search/Settings/Home
- Implemented in OneToOne chat

I didn't put this everywhere as I'm not sure I'm happy with it.