### PR TITLE
chore: various Makefile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ ARG             VCS_REF
 ARG             VERSION
 
 # build
-FROM            golang:1.15.0-alpine as builder
+FROM            golang:1.15.2-alpine as builder
 RUN             apk add --no-cache git gcc musl-dev make
 ENV             GO111MODULE=on
 WORKDIR         /go/src/berty.tech/berty

--- a/go/Makefile
+++ b/go/Makefile
@@ -37,8 +37,7 @@ clean:
 
 .PHONY: mini.dev
 mini.dev: generate
-	go install github.com/githubnemo/CompileDaemon
-	CompileDaemon --color=true --build="go install -v" --build-dir="./cmd/berty" --command="berty mini"
+	go run github.com/githubnemo/CompileDaemon --color=true --build="go install -v" --build-dir="./cmd/berty" --command="berty mini"
 
 .PHONY: re
 re: clean generate install
@@ -72,16 +71,14 @@ go.unittest: pb.generate
 
 .PHONY: go.unstable-tests
 go.unstable-tests: pb.generate
-	go install moul.io/testman
-	TEST_STABILITY=unstable testman test -v -timeout=600s -retry=10 -run ^TestUnstable ./pkg/bertymessenger
-	TEST_STABILITY=unstable testman test -v -test.v -timeout=600s -retry=10 -run ^TestScenario_ ./pkg/bertyprotocol # FIXME: run on other unstable functions too
+	TEST_STABILITY=unstable go run moul.io/testman test -v -timeout=600s -retry=10 -run ^TestUnstable ./pkg/bertymessenger
+	TEST_STABILITY=unstable go run moul.io/testman test -v -test.v -timeout=600s -retry=10 -run ^TestScenario_ ./pkg/bertyprotocol # FIXME: run on other unstable functions too
 	# FIXME: run on other packages too
 
 .PHONY: go.broken-tests
 go.broken-tests: pb.generate
-	go install moul.io/testman
-	TEST_STABILITY=broken testman test -continue-on-error -timeout=1200s -test.timeout=60s -retry=5 -run ^TestBroken ./pkg/bertymessenger
-	TEST_STABILITY=broken testman test -continue-on-error -timeout=1200s -test.timeout=60s -retry=5 -run ^TestScenario_ ./pkg/bertyprotocol
+	TEST_STABILITY=broken go run moul.io/testman test -continue-on-error -timeout=1200s -test.timeout=60s -retry=5 -run ^TestBroken ./pkg/bertymessenger
+	TEST_STABILITY=broken go run moul.io/testman test -continue-on-error -timeout=1200s -test.timeout=60s -retry=5 -run ^TestScenario_ ./pkg/bertyprotocol
 
 .PHONY: go.install
 go.install: pb.generate
@@ -134,10 +131,8 @@ $(gen_sum): $(gen_src)
 .PHONY: generate_local
 generate_local:
 	$(call check-program, shasum protoc)
-	go install golang.org/x/tools/cmd/goimports
-	go install github.com/buicongtan1997/protoc-gen-swagger-config
-	protoc-gen-swagger-config -i ../api/bertymessenger.proto -o ../api/bertymessenger.yaml
-	protoc-gen-swagger-config -i ../api/bertyprotocol.proto -o ../api/bertyprotocol.yaml
+	go run github.com/buicongtan1997/protoc-gen-swagger-config -i ../api/bertymessenger.proto -o ../api/bertymessenger.yaml
+	go run github.com/buicongtan1997/protoc-gen-swagger-config -i ../api/bertyprotocol.proto -o ../api/bertyprotocol.yaml
 	protoc $(protoc_opts) --gogo_out=plugins=grpc:$(GOPATH)/src ../api/errcode.proto
 	protoc $(protoc_opts) --gogo_out=plugins=grpc:$(GOPATH)/src ../api/bertybridge.proto
 	protoc $(protoc_opts) --gogo_out=plugins=grpc:$(GOPATH)/src ../api/bertytypes.proto
@@ -148,7 +143,7 @@ generate_local:
 	sed -i s@berty.tech/berty/go@berty.tech/berty/v2/go@ ./framework/bertybridge/internal/bridgepb/*.pb.go
 	sed -i s@berty.tech/berty/go@berty.tech/berty/v2/go@ ./pkg/*/*.pb.go
 	sed -i s@berty.tech/berty/go@berty.tech/berty/v2/go@ ./pkg/*/*.pb.gw.go
-	goimports -w ./pkg ./cmd ./internal
+	go run golang.org/x/tools/cmd/goimports -w ./pkg ./cmd ./internal
 	shasum $(gen_src) | sort -k 2 > $(gen_sum).tmp
 	mv $(gen_sum).tmp $(gen_sum)
 
@@ -171,7 +166,7 @@ doc.generate: install
 	for sub in `berty -h 2>&1 | grep "^  [a-z]" | sed 1d | awk '{print $$1}'`; do \
 		echo >> .tmp/usage.txt; \
 		echo 'foo@bar:~$$ berty '$$sub' -h' >> .tmp/usage.txt; \
-		(berty $$sub -h || true) 2>> .tmp/usage.txt; \
+		(OBberty $$sub -h || true) 2>> .tmp/usage.txt; \
 	done
 
 	echo 'foo@bar:~$$ berty share-invite' > .tmp/share-invite.txt

--- a/go/Makefile
+++ b/go/Makefile
@@ -124,6 +124,19 @@ print-%:
 	@echo $* = $($*)
 
 
+minimum_go_minor_version = 14
+validate-go-version:
+	@if [ ! "x`$(GO) version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f1`" = "x1" ]; then \
+		echo "error: Golang version should be \"1.x\". Please use 1.$(minimum_go_minor_version) or more recent."; \
+		exit 1; \
+	fi
+	@if [ `$(GO) version | cut -c 14- | cut -d' ' -f1 | cut -d'.' -f2` -lt $(minimum_go_minor_version) ]; then \
+		echo "error: Golang version is not supported. Please use 1.$(minimum_go_minor_version) or more recent."; \
+		exit 1; \
+	fi
+.PHONY: validate-go-version
+
+
 ##
 ## Code gen
 ##
@@ -133,7 +146,7 @@ protos_src := $(wildcard ../api/*.proto) $(wildcard ../api/go-internal/*.proto)
 gen_src := $(protos_src) Makefile
 gen_sum := gen.sum
 protoc_opts := -I ../api:`go list -m -f {{.Dir}} github.com/grpc-ecosystem/grpc-gateway`/third_party/googleapis:`go list -m -f {{.Dir}} github.com/gogo/protobuf`:/protobuf
-pb.generate: gen.sum
+pb.generate: gen.sum validate-go-version
 $(gen_sum): $(gen_src)
 	$(call check-program, shasum docker $(GO))
 	@shasum $(gen_src) | sort -k 2 > $(gen_sum).tmp

--- a/go/Makefile
+++ b/go/Makefile
@@ -2,6 +2,7 @@
 ## Config
 ##
 
+
 GO ?= go
 GOPATH ?= $(HOME)/go
 GO_TEST_OPTS ?= -test.timeout=300s -race -cover -coverprofile=coverage.txt -covermode=atomic
@@ -10,104 +11,128 @@ GO_TEST_PATH ?= ./...
 BUILD_DATE ?= `date +%s`
 VCS_REF ?= `git rev-parse --short HEAD`
 VERSION ?= `git describe --tags --always`
-LDFLAGS ?= -ldflags="-X berty.tech/berty/v2/go/pkg/bertymessenger.VcsRef=$(VCS_REF) -X berty.tech/berty/v2/go/pkg/bertymessenger.Version=$(VERSION) -X berty.tech/berty/v2/go/pkg/bertymessenger.BuildTime=$(BUILD_DATE)"
+LDFLAGS ?= -ldflags="-X berty.tech/berty/v2/go/pkg/bertymessenger.VcsRef=$(VCS_REF) -X berty.tech/berty/v2/go/pkg/bertymessenger.Version=$(VERSION)"
+
 
 ##
 ## General rules
 ##
 
-.PHONY: test
+
 test: unittest lint tidy
+.PHONY: test
 
-.PHONY: unittest
+
 unittest: go.unittest
+.PHONY: unittest
 
-.PHONY: generate
+
 generate: pb.generate
+.PHONY: generate
 
-.PHONY: regenerate
+
 regenerate: gen.clean generate
+.PHONY: regenerate
 
-.PHONY: install
+
 install: go.install
+.PHONY: install
 
-.PHONY: clean
+
 clean:
 	rm -rf out/
+.PHONY: clean
 
-.PHONY: mini.dev
+
 mini.dev: generate
 	go run github.com/githubnemo/CompileDaemon --color=true --build="go install -v" --build-dir="./cmd/berty" --command="berty mini"
+.PHONY: mini.dev
 
-.PHONY: re
+
 re: clean generate install
+.PHONY: re
 
-.PHONY: tidy
+
 tidy: go.tidy
+.PHONY: tidy
 
-.PHONY: lint
+
 lint: go.lint
+.PHONY: lint
+
 
 ##
 ## Other rules
 ##
 
+
 check-program = $(foreach exec,$(1),$(if $(shell PATH="$(PATH)" which $(exec)),,$(error "No $(exec) in PATH")))
 
-.PHONY: go.tidy
+
 go.tidy: pb.generate
 	$(call check-program, $(GO))
 	GO111MODULE=on $(GO) mod tidy
+.PHONY: go.tidy
 
-.PHONY: go.lint
+
 go.lint: pb.generate
 	$(call check-program, golangci-lint)
 	golangci-lint run --timeout=120s --verbose ./...
+.PHONY: go.lint
 
-.PHONY: go.unittest
+
 go.unittest: pb.generate
 	$(call check-program, $(GO))
 	$(GO_TEST_ENV) GO111MODULE=on $(GO) test $(GO_TEST_OPTS) $(GO_TEST_PATH)
+.PHONY: go.unittest
 
-.PHONY: go.unstable-tests
+
 go.unstable-tests: pb.generate
 	TEST_STABILITY=unstable go run moul.io/testman test -v -timeout=600s -retry=10 -run ^TestUnstable ./pkg/bertymessenger
 	TEST_STABILITY=unstable go run moul.io/testman test -v -test.v -timeout=600s -retry=10 -run ^TestScenario_ ./pkg/bertyprotocol # FIXME: run on other unstable functions too
 	# FIXME: run on other packages too
+.PHONY: go.unstable-tests
 
-.PHONY: go.broken-tests
+
 go.broken-tests: pb.generate
 	TEST_STABILITY=broken go run moul.io/testman test -continue-on-error -timeout=1200s -test.timeout=60s -retry=5 -run ^TestBroken ./pkg/bertymessenger
 	TEST_STABILITY=broken go run moul.io/testman test -continue-on-error -timeout=1200s -test.timeout=60s -retry=5 -run ^TestScenario_ ./pkg/bertyprotocol
+.PHONY: go.broken-tests
 
-.PHONY: go.install
+
 go.install: pb.generate
 	$(call check-program, $(GO))
 	GO111MODULE=on $(GO) install $(LDFLAGS) -v ./cmd/...
+.PHONY: go.install
 
-.PHONY: docker.build
+
 docker.build: pb.generate
 	$(call check-program, docker)
 	docker build -t bertytech/berty ..
+.PHONY: docker.build
 
-.PHONY: docker.fast
-docker.fast: args ?= -h
-docker.fast: run_opts ?=
+
 docker.fast: pb.generate
 	$(call check-program, $(GO) docker)
 	@mkdir -p out
 	GOOS=linux GOARCH=amd64 GO111MODULE=on $(GO) build -v -o ./out/berty-linux-static ./cmd/berty
-	docker run -it --rm -v $(PWD)/out/berty-linux-static:/bin/berty $(run_opts) ubuntu berty $(args)
+	docker run -it --rm -v $(PWD)/out/berty-linux-static:/bin/berty $(RUN_OPTS) ubuntu berty $(ARGS)
+.PHONY: docker.fast
+
+
+print-%:
+	@echo $* = $($*)
+
 
 ##
 ## Code gen
 ##
 
+
 protos_src := $(wildcard ../api/*.proto) $(wildcard ../api/go-internal/*.proto)
 gen_src := $(protos_src) Makefile
 gen_sum := gen.sum
 protoc_opts := -I ../api:`go list -m -f {{.Dir}} github.com/grpc-ecosystem/grpc-gateway`/third_party/googleapis:`go list -m -f {{.Dir}} github.com/gogo/protobuf`:/protobuf
-.PHONY: pb.generate
 pb.generate: gen.sum
 $(gen_sum): $(gen_src)
 	$(call check-program, shasum docker $(GO))
@@ -127,8 +152,9 @@ $(gen_sum): $(gen_src)
 	    -xec 'make generate_local'; \
 	    $(MAKE) tidy \
 	)
+.PHONY: pb.generate
 
-.PHONY: generate_local
+
 generate_local:
 	$(call check-program, shasum protoc)
 	go run github.com/buicongtan1997/protoc-gen-swagger-config -i ../api/bertymessenger.proto -o ../api/bertymessenger.yaml
@@ -146,16 +172,19 @@ generate_local:
 	go run golang.org/x/tools/cmd/goimports -w ./pkg ./cmd ./internal
 	shasum $(gen_src) | sort -k 2 > $(gen_sum).tmp
 	mv $(gen_sum).tmp $(gen_sum)
+.PHONY: generate_local
 
-.PHONY: gen.clean
+
 gen.clean:
 	rm -f gen.sum $(wildcard */*/*.pb.go) $(wildcard */*/*pb_test.go) $(wildcard */*/*pb.gw.go)
+.PHONY: gen.clean
+
 
 ##
 ## Doc gen
 ##
 
-.PHONY: doc.generate
+
 doc.generate: install
 	mkdir -p .tmp
 	GO111MODULE=off go get github.com/campoy/embedmd
@@ -183,10 +212,4 @@ doc.generate: install
 
 	embedmd -w README.md
 	#rm -rf .tmp
-
-##
-## Dev
-##
-
-print-%:
-	@echo $* = $($*)
+.PHONY: doc.generate

--- a/go/cmd/berty/version.go
+++ b/go/cmd/berty/version.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"fmt"
+	"runtime"
 
+	"berty.tech/berty/v2/go/pkg/bertymessenger"
 	"github.com/peterbourgon/ff/v3/ffcli"
 )
 
@@ -12,7 +14,11 @@ func versionCommand() *ffcli.Command {
 		Name:      "version",
 		ShortHelp: "print software version",
 		Exec: func(_ context.Context, _ []string) error {
-			fmt.Println("dev")
+			fmt.Printf("git version  %s\n", bertymessenger.Version)
+			if bertymessenger.VcsRef != "n/a" {
+				fmt.Printf("vcs          https://github.com/berty/berty/commits/%s\n", bertymessenger.VcsRef)
+			}
+			fmt.Printf("go           %s\n", runtime.Version())
 			return nil
 		},
 	}

--- a/go/gen.sum
+++ b/go/gen.sum
@@ -5,4 +5,4 @@ fcf115a5906b6c6442e290108deb1327162373b5  ../api/bertyprotocol.proto
 18083bf9ea2b90960bfabafe14cac9aa10bb4e02  ../api/errcode.proto
 c314cc3d08e8849bd0693039e42da117c39efef5  ../api/go-internal/handshake.proto
 9b4665f0290b8e94e5ef4b80572a9304f587c2c7  ../api/go-internal/records.proto
-b88491883ccb102ff010512de388dc8a6471b81b  Makefile
+dbd3fa5e766e6eb085d5e946acc6f7ac749e8aa3  Makefile

--- a/go/gen.sum
+++ b/go/gen.sum
@@ -5,4 +5,4 @@ fcf115a5906b6c6442e290108deb1327162373b5  ../api/bertyprotocol.proto
 18083bf9ea2b90960bfabafe14cac9aa10bb4e02  ../api/errcode.proto
 c314cc3d08e8849bd0693039e42da117c39efef5  ../api/go-internal/handshake.proto
 9b4665f0290b8e94e5ef4b80572a9304f587c2c7  ../api/go-internal/records.proto
-55cbfd6f0322216f0bd2149c540a4c804f49157d  Makefile
+b88491883ccb102ff010512de388dc8a6471b81b  Makefile

--- a/go/gen.sum
+++ b/go/gen.sum
@@ -5,4 +5,4 @@ fcf115a5906b6c6442e290108deb1327162373b5  ../api/bertyprotocol.proto
 18083bf9ea2b90960bfabafe14cac9aa10bb4e02  ../api/errcode.proto
 c314cc3d08e8849bd0693039e42da117c39efef5  ../api/go-internal/handshake.proto
 9b4665f0290b8e94e5ef4b80572a9304f587c2c7  ../api/go-internal/records.proto
-8c2342e5502bd1ee494076d48e602f85ffe27fd9  Makefile
+55cbfd6f0322216f0bd2149c540a4c804f49157d  Makefile

--- a/js/Makefile
+++ b/js/Makefile
@@ -318,18 +318,16 @@ packages/berty-app/ios/Podfile:
 	touch $@
 
 packages/go-bridge/ios/Frameworks/Bertybridge.framework: $(bridge_src)
-	cd ..; go mod download
-	cd ..; go install golang.org/x/mobile/cmd/gomobile
-	cd ..; gomobile init
+	cd .. && go mod download
+	cd .. && go run golang.org/x/mobile/cmd/gomobile init
 	@mkdir -p "packages/go-bridge/ios/Frameworks"
-	cd .. && GO111MODULE=on gomobile bind -o js/$@ -v $(ext_ldflags) -target ios ./go/framework/bertybridge
+	cd .. && GO111MODULE=on go run golang.org/x/mobile/cmd/gomobile bind -o js/$@ -v $(ext_ldflags) -target ios ./go/framework/bertybridge
 	touch $@
 
 packages/go-bridge/android/libs/gobridge.aar: $(bridge_src)
-	cd ..; go mod download
-	cd ..; go install golang.org/x/mobile/cmd/gomobile
-	cd ..; gomobile init
+	cd .. && go mod download
+	cd .. && go run golang.org/x/mobile/cmd/gomobile init
 	rm -fr packages/go-bridge/android/build # remove broken cache
 	@mkdir -p "packages/go-bridge/android/libs"
-	cd .. && GO111MODULE=on gomobile bind -o js/$@ -v $(ext_ldflags) -target android ./go/framework/bertybridge
+	cd .. && GO111MODULE=on go run golang.org/x/mobile/cmd/gomobile bind -o js/$@ -v $(ext_ldflags) -target android ./go/framework/bertybridge
 	touch $@

--- a/js/gen.sum
+++ b/js/gen.sum
@@ -1,5 +1,5 @@
 17e8f7cb38e260eed70f5bd62d289c43848f3f80  ../api/bertytypes.proto
-78ff0d5344915e4bc099a535e0f7e09b5f26abe7  Makefile
+57193fb3c1e50fde956f0f9db63ec421f874effb  Makefile
 8294c28699c62f110ca306150e0428edbaf00376  packages/codegen/index.gen.js.hbs
 c0780732a41bed0d8e686d2178ac969e11ca6d5c  packages/api/index.gen.js.hbs
 d3b2e6e14675f370541f59d82099e7fc8f1a53e5  ../api/bertymessenger.proto

--- a/js/gen.sum
+++ b/js/gen.sum
@@ -1,5 +1,5 @@
+06ff30653d6ee6cc03a4ea4b521e5c9cb3badeb1  Makefile
 17e8f7cb38e260eed70f5bd62d289c43848f3f80  ../api/bertytypes.proto
-57193fb3c1e50fde956f0f9db63ec421f874effb  Makefile
 8294c28699c62f110ca306150e0428edbaf00376  packages/codegen/index.gen.js.hbs
 c0780732a41bed0d8e686d2178ac969e11ca6d5c  packages/api/index.gen.js.hbs
 d3b2e6e14675f370541f59d82099e7fc8f1a53e5  ../api/bertymessenger.proto


### PR DESCRIPTION
* avoid polluting user's PATH fs
* avoid managing support for people using a misconfigured PATH env var
* Makefile styling: move .PHONY lines below their rule definitions and separate rules by two newlines
* remove BuildTime from LDFLAGS to maximize go's binary caching system
* make `berty version` dynamic
* check for support go version in the Makefile