### PR TITLE
chore: update mpconnectivity build constraints

### DIFF
--- a/go/internal/multipeer-connectivity-transport/driver/bridge_darwin.go
+++ b/go/internal/multipeer-connectivity-transport/driver/bridge_darwin.go
@@ -1,4 +1,4 @@
-// +build darwin
+// +build darwin,cgo
 
 package driver
 

--- a/go/internal/multipeer-connectivity-transport/driver/bridge_unsupported.go
+++ b/go/internal/multipeer-connectivity-transport/driver/bridge_unsupported.go
@@ -1,4 +1,4 @@
-// +build !darwin
+// +build !darwin !cgo
 
 package driver
 

--- a/go/internal/multipeer-connectivity-transport/driver/mc-driver/cgo_bridge_darwin.go
+++ b/go/internal/multipeer-connectivity-transport/driver/mc-driver/cgo_bridge_darwin.go
@@ -1,4 +1,4 @@
-// +build darwin
+// +build darwin,cgo
 
 package mcdriver
 

--- a/go/internal/multipeer-connectivity-transport/driver/mc-driver/cgo_bridge_unsupported.go
+++ b/go/internal/multipeer-connectivity-transport/driver/mc-driver/cgo_bridge_unsupported.go
@@ -1,3 +1,3 @@
-// +build !darwin
+// +build !darwin !cgo
 
 package mcdriver


### PR DESCRIPTION
an even better version could be:
* 3 files:
  * `darwin,cgo`   -> real driver
  * `darwin,!cgo`  -> noop driver that returns an init error "requires building with CGO"
  * `!darwin` -> noop driver that returns an init error "only available on darwin platforms" 

btw @D4ryl00, can you note somewhere that this package should be flatten into a unique package without sub-package