### PR TITLE
fix: missing close empty channel

### DIFF
--- a/go/internal/tinder/driver_localdiscovery.go
+++ b/go/internal/tinder/driver_localdiscovery.go
@@ -214,6 +214,7 @@ func (ld *localDiscovery) FindPeers(ctx context.Context, cid string, opts ...dis
 	if !ok {
 		// This CID is unknown, so return a empty chan
 		chPeer := make(chan peer.AddrInfo)
+		close(chPeer)
 		return chPeer, nil
 	}
 


### PR DESCRIPTION
Signed-off-by: phanquy <phanhuynhquy@gmail.com>

### [Change Description]
Missing close channel peer can results into blocking finding peers

### [Test]
NA