### PR TITLE
chore: update yolo-friendly artifact suffix

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -75,10 +75,13 @@ jobs:
                 -sdk iphoneos \
                 -archivePath /tmp/Berty.xcarchive \
                 CODE_SIGN_IDENTITY="" CODE_SIGNING_ALLOWED=NO
+          mkdir Payload
+          mv /tmp/Berty.xcarchive/Products/Applications/Berty\ Yolo.app Payload/
+          zip -r ${{ github.workspace }}/Berty\ Yolo.unsigned-ipa Payload
 
       - name: Upload the Archive
         uses: actions/upload-artifact@v2
         with:
-          path: /tmp/Berty.xcarchive/Products/Applications/Berty Yolo.app
-          name: berty-yolo.app
+          path: ${{ github.workspace }}/Berty Yolo.unsigned-ipa
+          name: berty-yolo.unsigned-ipa
           if-no-files-found: error


### PR DESCRIPTION
This PR:
* mimics the structure of a .ipa file without the signature stuff
* use a specific artifact name suffix to help yolo detect the artifact as an unsigned .ipa

Basically, this ipa is not installable (lack of signature), but is correct for most tools parsing .ipa archives