### PR TITLE
fix: ignore ipfs api errors

### DIFF
--- a/go/framework/bertybridge/bridge_protocol.go
+++ b/go/framework/bertybridge/bridge_protocol.go
@@ -268,9 +268,10 @@ func newProtocolBridge(ctx context.Context, logger *zap.Logger, config *Messenge
 			api = ipfsutil.InjectPubSubCoreAPIExtendedAdaptater(api, psapi)
 
 			// construct http api endpoint
+			// ignore error to allow two berty instances in the same place
 			err = ipfsutil.ServeHTTPApi(logger, node, config.rootDirectory+"/ipfs")
 			if err != nil {
-				return nil, errcode.TODO.Wrap(err)
+				logger.Warn("API Ipfs error", zap.Error(err))
 			}
 
 			// serve the embedded ipfs webui

--- a/go/internal/initutil/node.go
+++ b/go/internal/initutil/node.go
@@ -116,10 +116,11 @@ func (m *Manager) getLocalProtocolServer() (bertyprotocol.Service, error) {
 	}
 
 	// construct http api endpoint
+	// ignore error to allow two berty instances in the same place
 	if m.Node.Protocol.IPFSAPIListeners != "" {
 		err = ipfsutil.ServeHTTPApi(logger, m.Node.Protocol.ipfsNode, "")
 		if err != nil {
-			return nil, errcode.TODO.Wrap(err)
+			logger.Warn("API Ipfs error", zap.Error(err))
 		}
 	}
 


### PR DESCRIPTION
Ignore API Ipfs errors to allow two Berty instances in the same place

Signed-off-by: D4ryl00 <d4ryl00@gmail.com>