### PR TITLE
fix: bump gorm and avoid syntax error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	github.com/libp2p/go-libp2p-transport-upgrader v0.3.0
 	github.com/libp2p/go-yamux v1.3.8 // indirect
 	github.com/markbates/pkger v0.17.1
-	github.com/mattn/go-sqlite3 v1.14.0
+	github.com/mattn/go-sqlite3 v1.14.3
 	github.com/mdp/qrterminal/v3 v3.0.0
 	github.com/mgutz/ansi v0.0.0-20200706080929-d51e80ef957d // indirect
 	github.com/mitchellh/copystructure v1.0.0 // indirect
@@ -92,8 +92,8 @@ require (
 	google.golang.org/grpc/examples v0.0.0-20200922230038-4e932bbcb079
 	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f // indirect
 	gopkg.in/square/go-jose.v2 v2.5.1
-	gorm.io/driver/sqlite v1.0.8
-	gorm.io/gorm v0.2.26
+	gorm.io/driver/sqlite v1.1.3
+	gorm.io/gorm v1.20.2
 	moul.io/godev v1.7.0
 	moul.io/openfiles v1.2.0
 	moul.io/srand v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -71,7 +71,6 @@ github.com/Masterminds/sprig v2.22.0+incompatible h1:z4yfnGrZ7netVz+0EDJ0Wi+5VZC
 github.com/Masterminds/sprig v2.22.0+incompatible/go.mod h1:y6hNFY5UBTIWBxnzTeuNhlNS5hqE0NB0E6fgfo2Br3o=
 github.com/OneOfOne/xxhash v1.2.2 h1:KMrpdQIwFcEqXDklaen+P1axHaj9BSKzvpUUfnHldSE=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
-github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
 github.com/Stebalien/go-bitfield v0.0.0-20180330043415-076a62f9ce6e/go.mod h1:3oM7gXIttpYDAJXpVNnSCiUMYBLIZ6cb1t+Ip982MRo=
 github.com/Stebalien/go-bitfield v0.0.1 h1:X3kbSSPUaJK60wV2hjOPZwmpljr6VGCqdq4cBLhbQBo=
 github.com/Stebalien/go-bitfield v0.0.1/go.mod h1:GNjFpasyUVkHMsfEOk8EFLJ9syQ6SI+XWrX9Wf2XH0s=
@@ -86,7 +85,6 @@ github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRF
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alexbrainman/goissue34681 v0.0.0-20191006012335-3fc7a47baff5 h1:iW0a5ljuFxkLGPNem5Ui+KBjFJzKg4Fv2fnxe4dvzpM=
 github.com/alexbrainman/goissue34681 v0.0.0-20191006012335-3fc7a47baff5/go.mod h1:Y2QMoi1vgtOIfc+6DhrMOGkLoGzqSV2rKp4Sm+opsyA=
-github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/anmitsu/go-shlex v0.0.0-20161002113705-648efa622239/go.mod h1:2FmKhYUyUczH0OGQWaF5ceTx0UBShxjsH6f8oGKYe2c=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/aokoli/goutils v1.0.1/go.mod h1:SijmP0QR8LtwsmDs8Yii5Z/S4trXFGFC2oO5g9DP+DQ=
@@ -988,8 +986,8 @@ github.com/mattn/go-runewidth v0.0.8/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m
 github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
-github.com/mattn/go-sqlite3 v1.14.0 h1:mLyGNKR8+Vv9CAU7PphKa2hkEqxxhn8i32J6FPj1/QA=
-github.com/mattn/go-sqlite3 v1.14.0/go.mod h1:JIl7NbARA7phWnGvh0LKTyg7S9BA+6gx71ShQilpsus=
+github.com/mattn/go-sqlite3 v1.14.3 h1:j7a/xn1U6TKA/PHHxqZuzh64CdtRc7rU9M+AvkOl5bA=
+github.com/mattn/go-sqlite3 v1.14.3/go.mod h1:WVKg1VTActs4Qso6iwGbiFih2UIHo0ENGwNd0Lj+XmI=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/mdp/qrterminal v1.0.1 h1:07+fzVDlPuBlXS8tB0ktTAyf+Lp1j2+2zK3fBOL5b7c=
@@ -1423,7 +1421,6 @@ golang.org/x/mod v0.1.1-0.20191209134235-331c550502dd/go.mod h1:s0Qsj1ACt9ePp/hM
 golang.org/x/mod v0.2.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
 golang.org/x/mod v0.3.0 h1:RM4zey1++hCTbCVQfnWeKs9/IEsaBLA8vTkd0WVtmH4=
 golang.org/x/mod v0.3.0/go.mod h1:s0Qsj1ACt9ePp/hMypM3fl4fZqREWJwdYDEqhRiZZUA=
-golang.org/x/net v0.0.0-20180218175443-cbe0f9307d01/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180524181706-dfa909b99c79/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180724234803-3673e40ba225/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20180826012351-8a410e7b638d/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
@@ -1758,12 +1755,12 @@ gopkg.in/yaml.v3 v3.0.0-20190709130402-674ba3eaed22/go.mod h1:K4uyk7z7BCEPqu6E+C
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 h1:tQIYjPdBoyREyB9XMu+nnTclpTYkz2zFM+lzLJFO4gQ=
 gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
-gorm.io/driver/sqlite v1.0.8 h1:omllgSb7/eh9D6lGvLZOdU1ZElxdXuO3dn3Rk+dQxUE=
-gorm.io/driver/sqlite v1.0.8/go.mod h1:xkm8/CEmA3yc4zRd0pdCqm43BjO8Hm6avfTpxWb/7c4=
-gorm.io/gorm v0.2.7/go.mod h1:0HFTzE/SqkGTzK6TlDPPQbAYCluiVvhzoA1+aVyzenw=
+gorm.io/driver/sqlite v1.1.3 h1:BYfdVuZB5He/u9dt4qDpZqiqDJ6KhPqs5QUqsr/Eeuc=
+gorm.io/driver/sqlite v1.1.3/go.mod h1:AKDgRWk8lcSQSw+9kxCJnX/yySj8G3rdwYlU57cB45c=
 gorm.io/gorm v0.2.18/go.mod h1:0HFTzE/SqkGTzK6TlDPPQbAYCluiVvhzoA1+aVyzenw=
-gorm.io/gorm v0.2.26 h1:+GoQpJGwCmKkI8f6yIuSUrG6+cG4EobQeH28gcqTZdM=
-gorm.io/gorm v0.2.26/go.mod h1:0HFTzE/SqkGTzK6TlDPPQbAYCluiVvhzoA1+aVyzenw=
+gorm.io/gorm v1.20.1/go.mod h1:0HFTzE/SqkGTzK6TlDPPQbAYCluiVvhzoA1+aVyzenw=
+gorm.io/gorm v1.20.2 h1:bZzSEnq7NDGsrd+n3evOOedDrY5oLM5QPlCjZJUK2ro=
+gorm.io/gorm v1.20.2/go.mod h1:0HFTzE/SqkGTzK6TlDPPQbAYCluiVvhzoA1+aVyzenw=
 grpc.go4.org v0.0.0-20170609214715-11d0a25b4919 h1:tmXTu+dfa+d9Evp8NpJdgOy6+rt8/x4yG7qPBrtNfLY=
 grpc.go4.org v0.0.0-20170609214715-11d0a25b4919/go.mod h1:77eQGdRu53HpSqPFJFmuJdjuHRquDANNeA4x7B8WQ9o=
 honnef.co/go/tools v0.0.0-20180728063816-88497007e858/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=

--- a/go/internal/initutil/node.go
+++ b/go/internal/initutil/node.go
@@ -435,7 +435,10 @@ func (m *Manager) getMessengerDB() (*gorm.DB, error) {
 		sqliteConn = path.Join(dir, "messenger.sqlite")
 	}
 
-	cfg := &gorm.Config{Logger: zapgorm2.New(logger.Named("gorm"))}
+	cfg := &gorm.Config{
+		Logger:                                   zapgorm2.New(logger.Named("gorm")),
+		DisableForeignKeyConstraintWhenMigrating: true,
+	}
 	db, err := gorm.Open(sqlite.Open(sqliteConn), cfg)
 	if err != nil {
 		return nil, errcode.TODO.Wrap(err)

--- a/go/pkg/bertymessenger/db.go
+++ b/go/pkg/bertymessenger/db.go
@@ -126,6 +126,10 @@ func (d *dbWrapper) addConversationForContact(groupPK, contactPK string) (*Conve
 }
 
 func (d *dbWrapper) addConversation(groupPK string) (*Conversation, error) {
+	if groupPK == "" {
+		return nil, errcode.ErrInvalidInput.Wrap(fmt.Errorf("a conversation public key is required"))
+	}
+
 	conversation := &Conversation{
 		PublicKey:   groupPK,
 		Type:        Conversation_MultiMemberType,
@@ -145,7 +149,7 @@ func (d *dbWrapper) addConversation(groupPK string) (*Conversation, error) {
 
 func (d *dbWrapper) updateConversation(c Conversation) error {
 	if c.PublicKey == "" {
-		return errcode.ErrInvalidInput.Wrap(fmt.Errorf("no public key specified"))
+		return errcode.ErrInvalidInput.Wrap(fmt.Errorf("a conversation public key is required"))
 	}
 
 	columns := []string(nil)
@@ -182,6 +186,10 @@ func (d *dbWrapper) updateConversation(c Conversation) error {
 }
 
 func (d *dbWrapper) updateConversationReadState(pk string, newUnread bool, eventDate time.Time) error {
+	if pk == "" {
+		return errcode.ErrInvalidInput.Wrap(fmt.Errorf("a conversation public key is required"))
+	}
+
 	updates := map[string]interface{}{
 		"last_update": timestampMs(eventDate),
 	}
@@ -206,6 +214,10 @@ func (d *dbWrapper) updateConversationReadState(pk string, newUnread bool, event
 }
 
 func (d *dbWrapper) addAccount(pk, url string) error {
+	if pk == "" {
+		return errcode.ErrInvalidInput.Wrap(fmt.Errorf("an account public key is required"))
+	}
+
 	acc := &Account{
 		PublicKey: pk,
 		Link:      url,
@@ -225,6 +237,10 @@ func (d *dbWrapper) addAccount(pk, url string) error {
 }
 
 func (d *dbWrapper) updateAccount(pk, url, displayName string) (*Account, error) {
+	if pk == "" {
+		return nil, errcode.ErrInvalidInput.Wrap(fmt.Errorf("an account public key is required"))
+	}
+
 	acc := &Account{}
 
 	values := map[string]interface{}{}
@@ -259,6 +275,10 @@ func (d *dbWrapper) getAccount() (*Account, error) {
 }
 
 func (d *dbWrapper) getDeviceByPK(publicKey string) (*Device, error) {
+	if publicKey == "" {
+		return nil, errcode.ErrInvalidInput.Wrap(fmt.Errorf("a device public key is required"))
+	}
+
 	device := &Device{}
 
 	if err := d.db.First(&device, &Device{PublicKey: publicKey}).Error; err != nil {
@@ -269,6 +289,10 @@ func (d *dbWrapper) getDeviceByPK(publicKey string) (*Device, error) {
 }
 
 func (d *dbWrapper) getContactByPK(publicKey string) (*Contact, error) {
+	if publicKey == "" {
+		return nil, errcode.ErrInvalidInput.Wrap(fmt.Errorf("a contact public key is required"))
+	}
+
 	contact := &Contact{}
 
 	if err := d.db.First(&contact, &Contact{PublicKey: publicKey}).Error; err != nil {
@@ -279,6 +303,10 @@ func (d *dbWrapper) getContactByPK(publicKey string) (*Contact, error) {
 }
 
 func (d *dbWrapper) getConversationByPK(publicKey string) (*Conversation, error) {
+	if publicKey == "" {
+		return nil, errcode.ErrInvalidInput.Wrap(fmt.Errorf("a conversation public key is required"))
+	}
+
 	conversation := &Conversation{}
 
 	if err := d.db.First(&conversation, &Conversation{PublicKey: publicKey}).Error; err != nil {
@@ -292,6 +320,7 @@ func (d *dbWrapper) getMemberByPK(publicKey string) (*Member, error) {
 	if publicKey == "" {
 		return nil, errcode.ErrInvalidInput.Wrap(fmt.Errorf("member public key cannot be empty"))
 	}
+
 	member := &Member{}
 
 	if err := d.db.First(&member, &Member{PublicKey: publicKey}).Error; err != nil {
@@ -332,11 +361,19 @@ func (d *dbWrapper) getAllInteractions() ([]*Interaction, error) {
 }
 
 func (d *dbWrapper) getInteractionByCID(cid string) (*Interaction, error) {
+	if cid == "" {
+		return nil, errcode.ErrInvalidInput.Wrap(fmt.Errorf("an interaction cid is required"))
+	}
+
 	interaction := &Interaction{}
 	return interaction, d.db.Preload(clause.Associations).First(&interaction, &Interaction{CID: cid}).Error
 }
 
 func (d *dbWrapper) addContactRequestOutgoingEnqueued(contactPK, displayName, convPK string) (*Contact, error) {
+	if contactPK == "" {
+		return nil, errcode.ErrInvalidInput.Wrap(fmt.Errorf("a contact public key is required"))
+	}
+
 	contact := &Contact{
 		PublicKey:             contactPK,
 		DisplayName:           displayName,
@@ -356,6 +393,10 @@ func (d *dbWrapper) addContactRequestOutgoingEnqueued(contactPK, displayName, co
 }
 
 func (d *dbWrapper) addContactRequestOutgoingSent(contactPK string) (*Contact, error) {
+	if contactPK == "" {
+		return nil, errcode.ErrInvalidInput.Wrap(fmt.Errorf("a contact public key is required"))
+	}
+
 	contact := &Contact{}
 
 	if res := d.db.
@@ -376,6 +417,10 @@ func (d *dbWrapper) addContactRequestOutgoingSent(contactPK string) (*Contact, e
 }
 
 func (d *dbWrapper) addContactRequestIncomingReceived(contactPK, displayName string) (*Contact, error) {
+	if contactPK == "" {
+		return nil, errcode.ErrInvalidInput.Wrap(fmt.Errorf("a contact public key is required"))
+	}
+
 	if err := d.db.
 		Clauses(clause.OnConflict{DoNothing: true}).
 		Create(&Contact{
@@ -443,6 +488,10 @@ func (d *dbWrapper) addContactRequestIncomingAccepted(contactPK, groupPK string)
 }
 
 func (d *dbWrapper) markInteractionAsAcknowledged(cid string) (*Interaction, error) {
+	if cid == "" {
+		return nil, errcode.ErrInvalidInput.Wrap(fmt.Errorf("an interaction cid is required"))
+	}
+
 	count := int64(0)
 
 	if err := d.db.Model(&Interaction{}).Where(map[string]interface{}{"cid": cid}).Count(&count).Error; err != nil {
@@ -467,6 +516,10 @@ func (d *dbWrapper) markInteractionAsAcknowledged(cid string) (*Interaction, err
 }
 
 func (d *dbWrapper) getAcknowledgementsCIDsForInteraction(cid string) ([]string, error) {
+	if cid == "" {
+		return nil, errcode.ErrInvalidInput.Wrap(fmt.Errorf("an interaction cid is required"))
+	}
+
 	var cids []string
 
 	if err := d.db.Model(&Interaction{}).Where(&Interaction{
@@ -480,6 +533,10 @@ func (d *dbWrapper) getAcknowledgementsCIDsForInteraction(cid string) ([]string,
 }
 
 func (d *dbWrapper) deleteInteractions(cids []string) error {
+	if len(cids) == 0 {
+		return errcode.ErrInvalidInput.Wrap(fmt.Errorf("a list of cids is required"))
+	}
+
 	return d.db.Model(&Interaction{}).Delete(&Interaction{}, &cids).Error
 }
 
@@ -512,6 +569,14 @@ func (d *dbWrapper) getDBInfo() (*SystemInfo_DB, error) {
 }
 
 func (d *dbWrapper) addDevice(devicePK string, memberPK string) (*Device, error) {
+	if devicePK == "" {
+		return nil, errcode.ErrInvalidInput.Wrap(fmt.Errorf("a device public key is required"))
+	}
+
+	if memberPK == "" {
+		return nil, errcode.ErrInvalidInput.Wrap(fmt.Errorf("a member public key is required"))
+	}
+
 	if err := d.tx(func(tx *dbWrapper) error {
 		// Check if this device already exists for another member
 		{
@@ -564,6 +629,10 @@ func (d *dbWrapper) updateContact(contact Contact) error {
 }
 
 func (d *dbWrapper) addInteraction(i Interaction, ignoreExisting bool) (*Interaction, error) {
+	if i.CID == "" {
+		return nil, errcode.ErrInvalidInput.Wrap(fmt.Errorf("an interaction cid is required"))
+	}
+
 	query := d.db
 	if ignoreExisting {
 		query = query.Clauses(clause.OnConflict{DoNothing: true})
@@ -687,6 +756,10 @@ func (d *dbWrapper) addMember(memberPK, groupPK, displayName string) (*Member, e
 }
 
 func (d *dbWrapper) setConversationIsOpenStatus(conversationPK string, status bool) (*Conversation, bool, error) {
+	if conversationPK == "" {
+		return nil, false, errcode.ErrInvalidInput.Wrap(fmt.Errorf("a conversation public key is required"))
+	}
+
 	conversation, err := d.getConversationByPK(conversationPK)
 	if err != nil {
 		return nil, false, err
@@ -718,6 +791,10 @@ func (d *dbWrapper) setConversationIsOpenStatus(conversationPK string, status bo
 }
 
 func (d *dbWrapper) isConversationOpened(conversationPK string) (bool, error) {
+	if conversationPK == "" {
+		return false, errcode.ErrInvalidInput.Wrap(fmt.Errorf("a conversation public key is required"))
+	}
+
 	var ret int64
 
 	err := d.db.
@@ -742,6 +819,10 @@ func (d *dbLogWrapper) Trace(ctx context.Context, begin time.Time, fc func() (st
 }
 
 func (d *dbWrapper) addServiceToken(accountPK string, serviceToken *bertytypes.ServiceToken) error {
+	if accountPK == "" {
+		return errcode.ErrInvalidInput.Wrap(fmt.Errorf("an account public key is required"))
+	}
+
 	if len(serviceToken.SupportedServices) == 0 {
 		return errcode.ErrInvalidInput.Wrap(fmt.Errorf("no services specified"))
 	}

--- a/go/pkg/bertymessenger/db.go
+++ b/go/pkg/bertymessenger/db.go
@@ -289,6 +289,9 @@ func (d *dbWrapper) getConversationByPK(publicKey string) (*Conversation, error)
 }
 
 func (d *dbWrapper) getMemberByPK(publicKey string) (*Member, error) {
+	if publicKey == "" {
+		return nil, errcode.ErrInvalidInput.Wrap(fmt.Errorf("member public key cannot be empty"))
+	}
 	member := &Member{}
 
 	if err := d.db.First(&member, &Member{PublicKey: publicKey}).Error; err != nil {

--- a/go/pkg/bertymessenger/db_test.go
+++ b/go/pkg/bertymessenger/db_test.go
@@ -64,6 +64,11 @@ func Test_dbWrapper_addConversation(t *testing.T) {
 	db, dispose := getInMemoryTestDB(t)
 	defer dispose()
 
+	convErr, err := db.addConversation("")
+	require.Error(t, err)
+	require.True(t, errcode.Is(err, errcode.ErrInvalidInput))
+	require.Nil(t, convErr)
+
 	conv1, err := db.addConversation(groupPK1)
 	require.NoError(t, err)
 	require.Equal(t, groupPK1, conv1.PublicKey)
@@ -83,6 +88,11 @@ func Test_dbWrapper_getDeviceByPK(t *testing.T) {
 	defer dispose()
 
 	pk1 := "pk1"
+
+	devErr, err := db.getDeviceByPK("")
+	require.Error(t, err)
+	require.True(t, errcode.Is(err, errcode.ErrInvalidInput))
+	require.Nil(t, devErr)
 
 	dev, err := db.getDeviceByPK(pk1)
 	require.Error(t, err)
@@ -117,6 +127,11 @@ func Test_dbWrapper_getContactByPK(t *testing.T) {
 	defer dispose()
 
 	pk1 := "pk1"
+
+	contactErr, err := db.getContactByPK("")
+	require.Error(t, err)
+	require.True(t, errcode.Is(err, errcode.ErrInvalidInput))
+	require.Nil(t, contactErr)
 
 	contact, err := db.getContactByPK(pk1)
 	require.Error(t, err)
@@ -164,6 +179,7 @@ func Test_dbWrapper_addAccount(t *testing.T) {
 
 	err := db.addAccount("", "http://url1/")
 	require.Error(t, err)
+	require.True(t, errcode.Is(err, errcode.ErrInvalidInput))
 
 	err = db.addAccount("pk_1", "http://url1/")
 	require.NoError(t, err)
@@ -180,6 +196,11 @@ func Test_dbWrapper_addContactRequestIncomingReceived(t *testing.T) {
 	)
 
 	defer dispose()
+
+	contactErr, err := db.addContactRequestIncomingReceived("", "some name")
+	require.Error(t, err)
+	require.True(t, errcode.Is(err, errcode.ErrInvalidInput))
+	require.Nil(t, contactErr)
 
 	contact, err := db.addContactRequestIncomingReceived(contact1PK, contact1Name)
 	require.NoError(t, err)
@@ -201,7 +222,19 @@ func Test_dbWrapper_addContactRequestIncomingAccepted(t *testing.T) {
 	db, dispose := getInMemoryTestDB(t)
 	defer dispose()
 
-	contact, conversation, err := db.addContactRequestIncomingAccepted("contact_1", "group_1")
+	contact, conversation, err := db.addContactRequestIncomingAccepted("", "group_1")
+	require.Error(t, err)
+	require.True(t, errcode.Is(err, errcode.ErrInvalidInput))
+	require.Nil(t, contact)
+	require.Nil(t, conversation)
+
+	contact, conversation, err = db.addContactRequestIncomingAccepted("contact_1", "")
+	require.Error(t, err)
+	require.True(t, errcode.Is(err, errcode.ErrInvalidInput))
+	require.Nil(t, contact)
+	require.Nil(t, conversation)
+
+	contact, conversation, err = db.addContactRequestIncomingAccepted("contact_1", "group_1")
 	require.Error(t, err)
 	require.Empty(t, contact)
 	require.Empty(t, conversation)
@@ -220,7 +253,12 @@ func Test_dbWrapper_addContactRequestOutgoingEnqueued(t *testing.T) {
 
 	defer dispose()
 
-	contact, err := db.addContactRequestOutgoingEnqueued(contactPK, displayName, convPK)
+	contact, err := db.addContactRequestOutgoingEnqueued("", displayName, convPK)
+	require.Error(t, err)
+	require.True(t, errcode.Is(err, errcode.ErrInvalidInput))
+	require.Nil(t, contact)
+
+	contact, err = db.addContactRequestOutgoingEnqueued(contactPK, displayName, convPK)
 	require.NoError(t, err)
 	require.NotNil(t, contact)
 
@@ -250,6 +288,11 @@ func Test_dbWrapper_addContactRequestOutgoingSent(t *testing.T) {
 	require.Equal(t, convPK, contact.ConversationPublicKey)
 	require.Equal(t, Contact_OutgoingRequestEnqueued, contact.State)
 
+	contact, err = db.addContactRequestOutgoingSent("")
+	require.Error(t, err)
+	require.True(t, errcode.Is(err, errcode.ErrInvalidInput))
+	require.Nil(t, contact)
+
 	contact, err = db.addContactRequestOutgoingSent(contactPK)
 	require.NoError(t, err)
 	require.NotNil(t, contact)
@@ -277,11 +320,13 @@ func Test_dbWrapper_addConversationForContact(t *testing.T) {
 	// should raise an error when passing an empty conversation pk
 	conv, err := db.addConversationForContact("", "contact_1")
 	require.Error(t, err)
+	require.True(t, errcode.Is(err, errcode.ErrInvalidInput))
 	require.Nil(t, conv)
 
 	// should raise an error when passing an empty contact pk
 	conv, err = db.addConversationForContact("convo_1", "")
 	require.Error(t, err)
+	require.True(t, errcode.Is(err, errcode.ErrInvalidInput))
 	require.Nil(t, conv)
 
 	// should be ok
@@ -327,7 +372,17 @@ func Test_dbWrapper_addDevice(t *testing.T) {
 	db, dispose := getInMemoryTestDB(t)
 	defer dispose()
 
-	device, err := db.addDevice("device1", "member1")
+	device, err := db.addDevice("", "member1")
+	require.Error(t, err)
+	require.True(t, errcode.Is(err, errcode.ErrInvalidInput))
+	require.Nil(t, device)
+
+	device, err = db.addDevice("device1", "")
+	require.Error(t, err)
+	require.True(t, errcode.Is(err, errcode.ErrInvalidInput))
+	require.Nil(t, device)
+
+	device, err = db.addDevice("device1", "member1")
 	require.NoError(t, err)
 	require.NotNil(t, device)
 	require.Equal(t, "device1", device.PublicKey)
@@ -355,6 +410,14 @@ func Test_dbWrapper_addInteraction(t *testing.T) {
 	defer dispose()
 
 	i, err := db.addInteraction(Interaction{
+		CID:     "",
+		Payload: []byte("payload1"),
+	}, true)
+	require.Error(t, err)
+	require.True(t, errcode.Is(err, errcode.ErrInvalidInput))
+	require.Nil(t, i)
+
+	i, err = db.addInteraction(Interaction{
 		CID:     "Qm00001",
 		Payload: []byte("payload1"),
 	}, true)
@@ -415,10 +478,12 @@ func Test_dbWrapper_addMember(t *testing.T) {
 
 	member, err := db.addMember("member_1", "", "Display1")
 	require.Error(t, err)
+	require.True(t, errcode.Is(err, errcode.ErrInvalidInput))
 	require.Nil(t, member)
 
 	member, err = db.addMember("", "conversation_1", "Display1")
 	require.Error(t, err)
+	require.True(t, errcode.Is(err, errcode.ErrInvalidInput))
 	require.Nil(t, member)
 
 	member, err = db.addMember("member_1", "conversation_1", "")
@@ -467,14 +532,17 @@ func Test_dbWrapper_attributeBacklogInteractions(t *testing.T) {
 
 	interactions, err := db.attributeBacklogInteractions("", "conv3", "member1")
 	require.Error(t, err)
+	require.True(t, errcode.Is(err, errcode.ErrInvalidInput))
 	require.Empty(t, interactions)
 
 	interactions, err = db.attributeBacklogInteractions("device3", "", "member1")
 	require.Error(t, err)
+	require.True(t, errcode.Is(err, errcode.ErrInvalidInput))
 	require.Empty(t, interactions)
 
 	interactions, err = db.attributeBacklogInteractions("device3", "conv3", "")
 	require.Error(t, err)
+	require.True(t, errcode.Is(err, errcode.ErrInvalidInput))
 	require.Empty(t, interactions)
 
 	interactions, err = db.attributeBacklogInteractions("device3", "conv3", "member1")
@@ -531,8 +599,16 @@ func Test_dbWrapper_deleteInteractions(t *testing.T) {
 	db, dispose := getInMemoryTestDB(t)
 	defer dispose()
 
+	err := db.deleteInteractions(nil)
+	require.Error(t, err)
+	require.True(t, errcode.Is(err, errcode.ErrInvalidInput))
+
+	err = db.deleteInteractions([]string{})
+	require.Error(t, err)
+	require.True(t, errcode.Is(err, errcode.ErrInvalidInput))
+
 	// Should we raise an error if a CID is not found
-	err := db.deleteInteractions([]string{"Qm0001", "Qm0002", "Qm0003"})
+	err = db.deleteInteractions([]string{"Qm0001", "Qm0002", "Qm0003"})
 	require.NoError(t, err)
 
 	db.db.Create(&Interaction{CID: "Qm0001"})
@@ -622,7 +698,12 @@ func Test_dbWrapper_getAcknowledgementsCIDsForInteraction(t *testing.T) {
 	db, dispose := getInMemoryTestDB(t)
 	defer dispose()
 
-	cids, err := db.getAcknowledgementsCIDsForInteraction("QmXX")
+	cids, err := db.getAcknowledgementsCIDsForInteraction("")
+	require.Error(t, err)
+	require.True(t, errcode.Is(err, errcode.ErrInvalidInput))
+	require.Empty(t, cids)
+
+	cids, err = db.getAcknowledgementsCIDsForInteraction("QmXX")
 	require.NoError(t, err)
 	require.Empty(t, cids)
 
@@ -740,7 +821,12 @@ func Test_dbWrapper_updateAccount(t *testing.T) {
 	db, dispose := getInMemoryTestDB(t)
 	defer dispose()
 
-	acc, err := db.updateAccount("pk_1", "https://url1/", "DisplayName1")
+	acc, err := db.updateAccount("", "https://url1/", "DisplayName1")
+	require.Error(t, err)
+	require.True(t, errcode.Is(err, errcode.ErrInvalidInput))
+	require.Nil(t, acc)
+
+	acc, err = db.updateAccount("pk_1", "https://url1/", "DisplayName1")
 	require.Error(t, err)
 	require.Nil(t, acc)
 
@@ -777,6 +863,7 @@ func Test_dbWrapper_updateContact(t *testing.T) {
 
 	err := db.updateContact(Contact{})
 	require.Error(t, err)
+	require.True(t, errcode.Is(err, errcode.ErrInvalidInput))
 
 	err = db.updateContact(Contact{PublicKey: "pk_1"})
 	require.Error(t, err)
@@ -810,6 +897,7 @@ func Test_dbWrapper_updateConversation(t *testing.T) {
 	defer dispose()
 
 	err := db.updateConversation(Conversation{})
+	require.True(t, errcode.Is(err, errcode.ErrInvalidInput))
 	require.Error(t, err)
 
 	err = db.updateConversation(Conversation{PublicKey: "conv_1"})
@@ -846,7 +934,12 @@ func Test_dbWrapper_getConversationByPK(t *testing.T) {
 	db, dispose := getInMemoryTestDB(t)
 	defer dispose()
 
-	conversation, err := db.getConversationByPK("unknown")
+	conversation, err := db.getConversationByPK("")
+	require.Error(t, err)
+	require.True(t, errcode.Is(err, errcode.ErrInvalidInput))
+	require.Nil(t, conversation)
+
+	conversation, err = db.getConversationByPK("unknown")
 	require.Error(t, err)
 	require.Nil(t, conversation)
 
@@ -915,7 +1008,12 @@ func Test_dbWrapper_getMemberByPK(t *testing.T) {
 	db, dispose := getInMemoryTestDB(t)
 	defer dispose()
 
-	member, err := db.getMemberByPK("unknown")
+	member, err := db.getMemberByPK("")
+	require.Error(t, err)
+	require.True(t, errcode.Is(err, errcode.ErrInvalidInput))
+	require.Nil(t, member)
+
+	member, err = db.getMemberByPK("unknown")
 	require.Error(t, err)
 	require.Nil(t, member)
 
@@ -949,7 +1047,12 @@ func Test_dbWrapper_markInteractionAsAcknowledged(t *testing.T) {
 	db, dispose := getInMemoryTestDB(t)
 	defer dispose()
 
-	interaction, err := db.markInteractionAsAcknowledged("QmXXXX")
+	interaction, err := db.markInteractionAsAcknowledged("")
+	require.Error(t, err)
+	require.True(t, errcode.Is(err, errcode.ErrInvalidInput))
+	require.Nil(t, interaction)
+
+	interaction, err = db.markInteractionAsAcknowledged("QmXXXX")
 	require.Error(t, err)
 	require.Equal(t, err, gorm.ErrRecordNotFound)
 	require.Nil(t, interaction)
@@ -975,7 +1078,13 @@ func Test_dbWrapper_setConversationIsOpenStatus(t *testing.T) {
 	db, dispose := getInMemoryTestDB(t)
 	defer dispose()
 
-	conv, updated, err := db.setConversationIsOpenStatus("conv_xxx", true)
+	conv, updated, err := db.setConversationIsOpenStatus("", true)
+	require.Error(t, err)
+	require.True(t, errcode.Is(err, errcode.ErrInvalidInput))
+	require.False(t, updated)
+	require.Nil(t, conv)
+
+	conv, updated, err = db.setConversationIsOpenStatus("conv_xxx", true)
 	require.Error(t, err)
 	require.False(t, updated)
 
@@ -1075,6 +1184,10 @@ func Test_dbWrapper_updateConversationReadState(t *testing.T) {
 	require.Equal(t, int32(0), c.UnreadCount)
 	require.Equal(t, timestampMs(time.Unix(10000, 0)), c.LastUpdate)
 
+	err := db.updateConversationReadState("", false, time.Unix(10001, 0))
+	require.Error(t, err)
+	require.True(t, errcode.Is(err, errcode.ErrInvalidInput))
+
 	require.NoError(t, db.updateConversationReadState("convo_a", false, time.Unix(10001, 0)))
 
 	c = &Conversation{}
@@ -1132,7 +1245,11 @@ func Test_dbWrapper_isConversationOpened(t *testing.T) {
 	require.NoError(t, db.db.Create(&Conversation{PublicKey: "convo_a", IsOpen: true}).Error)
 	require.NoError(t, db.db.Create(&Conversation{PublicKey: "convo_b", IsOpen: false}).Error)
 
-	opened, err := db.isConversationOpened("convo_a")
+	opened, err := db.isConversationOpened("")
+	require.Error(t, err)
+	require.True(t, errcode.Is(err, errcode.ErrInvalidInput))
+
+	opened, err = db.isConversationOpened("convo_a")
 	require.NoError(t, err)
 	require.True(t, opened)
 
@@ -1163,7 +1280,19 @@ func Test_dbWrapper_addServiceToken(t *testing.T) {
 		},
 	}
 
-	err := db.addServiceToken("acc_1", tok1)
+	err := db.addServiceToken("", tok1)
+	require.Error(t, err)
+	require.True(t, errcode.Is(err, errcode.ErrInvalidInput))
+
+	err = db.addServiceToken("", &bertytypes.ServiceToken{
+		Token:             "tok2",
+		AuthenticationURL: "https://url2/",
+		SupportedServices: []*bertytypes.ServiceTokenSupportedService{},
+	})
+	require.Error(t, err)
+	require.True(t, errcode.Is(err, errcode.ErrInvalidInput))
+
+	err = db.addServiceToken("acc_1", tok1)
 	require.NoError(t, err)
 
 	err = db.addServiceToken("acc_1", tok2)

--- a/go/pkg/bertymessenger/db_test.go
+++ b/go/pkg/bertymessenger/db_test.go
@@ -34,7 +34,9 @@ func getInMemoryTestDB(t testing.TB, opts ...getInMemoryTestDBOpts) (*dbWrapper,
 		}
 	}
 
-	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{})
+	db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{
+		DisableForeignKeyConstraintWhenMigrating: true,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1103,7 +1105,6 @@ func Test_dropAllTables(t *testing.T) {
 	defer dispose()
 
 	tables := []string(nil)
-
 	err := db.db.Raw("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'").Scan(&tables).Error
 	require.NoError(t, err)
 	require.NotEmpty(t, tables)
@@ -1111,6 +1112,7 @@ func Test_dropAllTables(t *testing.T) {
 	err = dropAllTables(db.db)
 	require.NoError(t, err)
 
+	tables = []string(nil)
 	err = db.db.Raw("SELECT name FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%'").Scan(&tables).Error
 	require.NoError(t, err)
 	require.Empty(t, tables)

--- a/go/pkg/bertymessenger/service.go
+++ b/go/pkg/bertymessenger/service.go
@@ -62,7 +62,10 @@ func (opts *Opts) applyDefaults() (func(), error) {
 		opts.Logger.Warn("Messenger started without database, creating a volatile one in memory")
 		zapLogger := zapgorm2.New(opts.Logger.Named("gorm"))
 		zapLogger.SetAsDefault()
-		db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{Logger: zapLogger})
+		db, err := gorm.Open(sqlite.Open("file::memory:?cache=shared"), &gorm.Config{
+			Logger:                                   zapLogger,
+			DisableForeignKeyConstraintWhenMigrating: true,
+		})
 		if err != nil {
 			return nil, err
 		}

--- a/go/pkg/bertymessenger/testing.go
+++ b/go/pkg/bertymessenger/testing.go
@@ -43,7 +43,10 @@ func TestingService(ctx context.Context, t *testing.T, opts *TestingServiceOpts)
 
 	zapLogger := zapgorm2.New(opts.Logger.Named("gorm"))
 	zapLogger.SetAsDefault()
-	db, err := gorm.Open(sqlite.Open("file:memdb"+strconv.Itoa(opts.Index)+"?mode=memory&cache=shared"), &gorm.Config{Logger: zapLogger})
+	db, err := gorm.Open(sqlite.Open("file:memdb"+strconv.Itoa(opts.Index)+"?mode=memory&cache=shared"), &gorm.Config{
+		Logger:                                   zapLogger,
+		DisableForeignKeyConstraintWhenMigrating: true,
+	})
 	if err != nil {
 		cleanup()
 		require.NoError(t, err)


### PR DESCRIPTION
* [x] bump gorm (details: https://github.com/go-gorm/gorm/compare/v0.2.26...v1.20.2)
* [x] avoid syntax error when calling `db.getMemberByPK("")`
* [ ] avoid calling `db.getMemberByPK` with empty PK (https://github.com/berty/berty/blob/master/go/pkg/bertymessenger/handlers.go#L726)