### PR TITLE
fix: restore git version in system info on mobile

### DIFF
--- a/js/Makefile
+++ b/js/Makefile
@@ -23,7 +23,7 @@ rwildcard = $(foreach d,$(wildcard $1*),$(call rwildcard,$d/,$2) $(filter $(subs
 check-program = $(foreach exec,$(1),$(if $(shell PATH="$(PATH)" which $(exec)),,$(error "Missing deps: no '$(exec)' in PATH")))
 export PATH := $(PWD)/node_modules/.bin:$(PATH)
 author = Berty Technologies <oss@berty.tech>
-ext_ldflags = -ldflags="-X berty.tech/berty/go/pkg/bertyversion.VcsRef=$(VCS_REF) -X berty.tech/berty/go/pkg/bertyversion.Version=$(VERSION)"
+ext_ldflags = -ldflags="-X berty.tech/berty/v2/go/pkg/bertyversion.VcsRef=$(VCS_REF) -X berty.tech/berty/v2/go/pkg/bertyversion.Version=$(VERSION)"
 pkg := $(dir $(wildcard $(PWD)/packages/*/package.json))
 pkg_mod := $(patsubst %, %/node_modules, $(pkg)) node_modules
 pkg_desc := $(patsubst %, %/package.json, $(pkg)) package.json

--- a/js/gen.sum
+++ b/js/gen.sum
@@ -1,5 +1,5 @@
 8294c28699c62f110ca306150e0428edbaf00376  packages/codegen/index.gen.js.hbs
-8b241892fb23c6ce65bf8e149f0433c17c4be8fd  Makefile
+8a96c2dc0363682eb9fdfe5464da5932bc84b627  Makefile
 c0780732a41bed0d8e686d2178ac969e11ca6d5c  packages/api/index.gen.js.hbs
 cf19ceacd8817b855a9355b4cc03bf5f161d6b50  ../api/bertymessenger.proto
 d6a4ae84dc55f2af4e863767e9edb8e001f61486  ../api/bertyprotocol.proto


### PR DESCRIPTION
![B969838A-1C65-428D-8D62-BD9A7F3C74CD_1_105_c](https://user-images.githubusercontent.com/94029/95308034-ac593000-0889-11eb-8ca4-0ed2dda47be0.jpeg)

This PR repairs the versioning in the system info view

However, it has a strange bug showing a commit sha that I never committed myself, I will investigate in a further PR why it happens and I will maybe update the Makefile to compute the "last known" sha if it's specific to github actions