### PR TITLE
chore(ci): use expected commit at checkout for versionning

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -26,11 +26,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}  # see https://github.com/actions/checkout/issues/299
 
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.2
+          go-version: 1.15.x
 
       - name: Setup Node
         uses: actions/setup-node@v1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.2
+          go-version: 1.15.x
       - name: Cache Go modules
         uses: actions/cache@v1
         with:
@@ -62,10 +62,7 @@ jobs:
     strategy:
       matrix:
         golang:
-          #- 1.13
-          #- 1.14.7
-          - 1.15.2
-          #- tip
+          - 1.15.x
     env:
       OS: ubuntu-latest
       GOLANG: ${{ matrix.golang }}
@@ -109,9 +106,8 @@ jobs:
     strategy:
       matrix:
         golang:
-          #- 1.13
-          - 1.14.7
-          - 1.15.2
+          - 1.14.x
+          - 1.15.x
           #- tip
     env:
       OS: ubuntu-latest

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -26,11 +26,15 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha }}  # see https://github.com/actions/checkout/issues/299
 
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.2
+          go-version: 1.15.x
 
       - name: Setup Node
         uses: actions/setup-node@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,26 +9,21 @@ jobs:
     name: releaser
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@master
-      -
-        name: Unshallow
+      - name: Unshallow
         run: git fetch --prune --unshallow
-      -
-        name: Run Semantic Release
+      - name: Run Semantic Release
         id: semantic
         uses: codfish/semantic-release-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Set up Go
+      - name: Set up Go
         if: steps.semantic.outputs.new-release-published == 'true'
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.2
-      -
-        name: Cache Go modules
+          go-version: 1.15.x
+      - name: Cache Go modules
         if: steps.semantic.outputs.new-release-published == 'true'
         uses: actions/cache@v1
         with:
@@ -36,8 +31,7 @@ jobs:
           key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
-      -
-        name: Run GoReleaser
+      - name: Run GoReleaser
         if: steps.semantic.outputs.new-release-published == 'true'
         uses: goreleaser/goreleaser-action@v2
         with:
@@ -45,8 +39,7 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      -
-        name: Register version on pkg.go.dev
+      - name: Register version on pkg.go.dev
         if: steps.semantic.outputs.new-release-published == 'true'
         run: |
           package=$(cat go.mod | grep ^module | awk '{print $2}')


### PR DESCRIPTION
* `fetch-depth: 42` on `iOS` and `Android`, to increase chances of determining "pretty" version based on previous known tag
* `persist-credentials: false`, small security improvement
* `ref: ${{ github.event.pull_request.head.sha }}`, see https://github.com/actions/checkout/issues/299
* switch go versions to `1.15.x` instead of fixed patch version
 