### PR TITLE
feat: pkg/bertybot + cmd/testbot

### DIFF
--- a/go/cmd/betabot/main.go
+++ b/go/cmd/betabot/main.go
@@ -626,7 +626,7 @@ func safeDefaultDisplayName() string {
 	if name == "" {
 		name = "Anonymous4242"
 	}
-	return fmt.Sprintf("%s (bot)", name)
+	return fmt.Sprintf("%s (betabot)", name)
 }
 
 func getRandomReply() string {

--- a/go/cmd/testbot/main.go
+++ b/go/cmd/testbot/main.go
@@ -15,6 +15,7 @@ import (
 	"moul.io/zapconfig"
 
 	"berty.tech/berty/v2/go/pkg/bertybot"
+	"berty.tech/berty/v2/go/pkg/bertyversion"
 )
 
 var (
@@ -52,6 +53,9 @@ func Main() error {
 		bertybot.WithRecipe(bertybot.AutoAcceptIncomingContactRequestRecipe()),   // accept incoming contact requests
 		bertybot.WithRecipe(bertybot.WelcomeMessageRecipe("welcome to testbot")), // send welcome message to new contacts and new conversations
 		bertybot.WithRecipe(bertybot.EchoRecipe("you said: ")),                   // reply to messages with the same message
+		bertybot.WithCommand("version", "show version", func(ctx bertybot.Context) {
+			_ = ctx.ReplyString("version: " + bertyversion.Version)
+		}),
 	)
 	if *skipReplay {
 		opts = append(opts, bertybot.WithSkipReplay()) // skip old events, only consume fresh ones

--- a/go/cmd/testbot/main.go
+++ b/go/cmd/testbot/main.go
@@ -1,0 +1,96 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"math/rand"
+	"os"
+	"os/user"
+
+	qrterminal "github.com/mdp/qrterminal/v3"
+	"go.uber.org/zap"
+	"moul.io/srand"
+	"moul.io/u"
+	"moul.io/zapconfig"
+
+	"berty.tech/berty/v2/go/pkg/bertybot"
+)
+
+var (
+	nodeAddr    = flag.String("addr", "127.0.0.1:9091", "remote 'berty daemon' address")
+	displayName = flag.String("display-name", safeDefaultDisplayName(), "bot's display name")
+	debug       = flag.Bool("debug", false, "debug mode")
+	skipReplay  = flag.Bool("skip-replay", true, "skip replay")
+	replyDelay  = flag.Duration("reply-delay", 0, "reply delay")
+)
+
+func main() {
+	flag.Parse()
+	rand.Seed(srand.MustSecure())
+	if err := Main(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %+v\n", err)
+		os.Exit(1)
+	}
+}
+
+func Main() error {
+	rootLogger := zapconfig.Configurator{}.MustBuildLogger()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	logger := rootLogger.Named("testbot")
+
+	// init bot
+	opts := []bertybot.NewOption{}
+	opts = append(opts,
+		bertybot.WithLogger(logger.Named("botlib")),                              // configure a logger
+		bertybot.WithDisplayName(*displayName),                                   // bot name
+		bertybot.WithInsecureMessengerGRPCAddr(*nodeAddr),                        // connect to running berty messenger daemon
+		bertybot.WithSkipAcknowledge(),                                           // skip acknowledge events
+		bertybot.WithSkipMyself(),                                                // skip my own interactions
+		bertybot.WithRecipe(bertybot.DelayResponseRecipe(*replyDelay)),           // add a delay before sending replies
+		bertybot.WithRecipe(bertybot.AutoAcceptIncomingContactRequestRecipe()),   // accept incoming contact requests
+		bertybot.WithRecipe(bertybot.WelcomeMessageRecipe("welcome to testbot")), // send welcome message to new contacts and new conversations
+		bertybot.WithRecipe(bertybot.EchoRecipe("you said: ")),                   // reply to messages with the same message
+	)
+	if *skipReplay {
+		opts = append(opts, bertybot.WithSkipReplay()) // skip old events, only consume fresh ones
+	}
+	if *debug {
+		opts = append(opts, bertybot.WithRecipe(bertybot.DebugEventRecipe(rootLogger.Named("debug")))) // debug events
+	}
+	bot, err := bertybot.New(opts...)
+	if err != nil {
+		return fmt.Errorf("bot initialization failed: %w", err)
+	}
+	// display link and qr code
+	logger.Info("retrieve instance Berty ID",
+		zap.String("pk", bot.PublicKey()),
+		zap.String("link", bot.BertyIDURL()),
+	)
+	qrterminal.GenerateHalfBlock(bot.BertyIDURL(), qrterminal.L, os.Stdout)
+
+	// signal handling
+	go func() {
+		u.WaitForCtrlC()
+		cancel()
+	}()
+
+	// start bot
+	return bot.Start(ctx)
+}
+
+func safeDefaultDisplayName() string {
+	var name string
+	current, err := user.Current()
+	if err == nil {
+		name = current.Username
+	}
+	if name == "" {
+		name = os.Getenv("USER")
+	}
+	if name == "" {
+		name = "anon"
+	}
+	return fmt.Sprintf("%s (testbot)", name)
+}

--- a/go/pkg/bertybot/bot.go
+++ b/go/pkg/bertybot/bot.go
@@ -1,0 +1,116 @@
+package bertybot
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"go.uber.org/zap"
+	"moul.io/u"
+
+	"berty.tech/berty/v2/go/pkg/bertymessenger"
+)
+
+type Bot struct {
+	client          bertymessenger.MessengerServiceClient
+	logger          *zap.Logger
+	displayName     string
+	bertyID         *bertymessenger.InstanceShareableBertyID_Reply
+	skipReplay      bool
+	skipAcknowledge bool
+	skipMyself      bool
+	handlers        map[HandlerType][]Handler
+	isReplaying     bool
+	handledEvents   uint
+	store           struct {
+		conversations map[string]*bertymessenger.Conversation
+		mutex         sync.Mutex
+	}
+}
+
+// New initializes a new Bot.
+// The order of the passed options may have an impact.
+func New(opts ...NewOption) (*Bot, error) {
+	b := Bot{
+		logger:   zap.NewNop(),
+		handlers: make(map[HandlerType][]Handler),
+	}
+	b.store.conversations = make(map[string]*bertymessenger.Conversation)
+
+	// configure bot with options
+	for _, opt := range opts {
+		if err := opt(&b); err != nil {
+			return nil, fmt.Errorf("bot: opt failed: %w", err)
+		}
+	}
+
+	// check minimal requirements
+	if b.client == nil {
+		return nil, fmt.Errorf("bot: missing messenger client")
+	}
+
+	// apply defaults
+	if b.displayName == "" {
+		b.displayName = "My Berty Bot"
+	}
+
+	// retrieve Berty ID to check if everything is well configured, and cache it for easy access
+	{
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		req := &bertymessenger.InstanceShareableBertyID_Request{
+			DisplayName: b.displayName,
+		}
+		ret, err := b.client.InstanceShareableBertyID(ctx, req)
+		if err != nil {
+			return nil, fmt.Errorf("bot: cannot retrieve berty ID: %w", err)
+		}
+		b.bertyID = ret
+	}
+
+	return &b, nil
+}
+
+// BertyIDURL returns the shareable Berty ID in the form of `https://berty.tech/id#xxx`.
+func (b *Bot) BertyIDURL() string {
+	return b.bertyID.HTMLURL
+}
+
+// PublicKey returns the public key of the messenger node.
+func (b *Bot) PublicKey() string {
+	return u.B64Encode(b.bertyID.BertyID.AccountPK)
+}
+
+// Start starts the main event loop and can be stopped by canceling the passed context.
+func (b *Bot) Start(ctx context.Context) error {
+	b.logger.Info("connecting to the event stream")
+	s, err := b.client.EventStream(ctx, &bertymessenger.EventStream_Request{})
+	if err != nil {
+		return fmt.Errorf("failed to listen to EventStream: %w", err)
+	}
+
+	b.isReplaying = true
+	for {
+		gme, err := s.Recv()
+		if err != nil {
+			return fmt.Errorf("stream error: %w", err)
+		}
+
+		if b.isReplaying {
+			if gme.Event.Type == bertymessenger.StreamEvent_TypeListEnd {
+				b.logger.Info("finished replaying logs from the previous sessions", zap.Uint("count", b.handledEvents))
+				b.isReplaying = false
+			}
+			b.handledEvents++
+
+			if b.skipReplay {
+				continue
+			}
+		}
+
+		if err := b.handleEvent(ctx, gme.Event); err != nil {
+			b.logger.Error("bot.handleEvent failed", zap.Error(err))
+		}
+	}
+}

--- a/go/pkg/bertybot/bot.go
+++ b/go/pkg/bertybot/bot.go
@@ -23,6 +23,7 @@ type Bot struct {
 	handlers        map[HandlerType][]Handler
 	isReplaying     bool
 	handledEvents   uint
+	commands        map[string]command
 	store           struct {
 		conversations map[string]*bertymessenger.Conversation
 		mutex         sync.Mutex
@@ -35,6 +36,7 @@ func New(opts ...NewOption) (*Bot, error) {
 	b := Bot{
 		logger:   zap.NewNop(),
 		handlers: make(map[HandlerType][]Handler),
+		commands: make(map[string]command),
 	}
 	b.store.conversations = make(map[string]*bertymessenger.Conversation)
 

--- a/go/pkg/bertybot/bot_test.go
+++ b/go/pkg/bertybot/bot_test.go
@@ -1,0 +1,111 @@
+package bertybot
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/stretchr/testify/require"
+
+	"berty.tech/berty/v2/go/internal/testutil"
+	"berty.tech/berty/v2/go/pkg/bertymessenger"
+)
+
+func TestUnstableBotCommunication(t *testing.T) {
+	testutil.FilterStability(t, testutil.Unstable)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	logger, cleanup := testutil.Logger(t)
+	defer cleanup()
+	clients, cleanup := bertymessenger.TestingInfra(ctx, t, 2, logger)
+	defer cleanup()
+
+	botClient, userClient := clients[0], clients[1]
+
+	var commandCalled bool
+
+	// create bot
+	var bot *Bot
+	{
+		botLogger := logger.Named("botlib")
+		var err error
+		bot, err = New(
+			WithLogger(botLogger),
+			WithMessengerClient(botClient),
+			WithRecipe(DebugEventRecipe(botLogger)),
+			WithRecipe(AutoAcceptIncomingContactRequestRecipe()),
+			WithRecipe(EchoRecipe("hello ")),
+			WithCommand("ping", "reply pong", func(ctx Context) {
+				ctx.ReplyString("pong")
+				commandCalled = true
+			}),
+		)
+		require.NoError(t, err)
+	}
+
+	go func() {
+		err := bot.Start(ctx)
+		if err != nil {
+			require.Contains(t, err.Error(), "is closing") // FIXME: better closing handling
+		}
+	}()
+
+	// enable contact request on client
+	{
+		_, err := userClient.InstanceShareableBertyID(ctx, &bertymessenger.InstanceShareableBertyID_Request{})
+		require.NoError(t, err)
+		time.Sleep(200 * time.Millisecond) // FIXME: replace with dynamic waiting
+	}
+
+	// send contact request
+	{
+		parsed, err := botClient.ParseDeepLink(ctx, &bertymessenger.ParseDeepLink_Request{Link: bot.BertyIDURL()})
+		require.NoError(t, err)
+		_, err = userClient.SendContactRequest(ctx, &bertymessenger.SendContactRequest_Request{
+			BertyID: parsed.BertyID,
+		})
+		require.NoError(t, err)
+		time.Sleep(200 * time.Millisecond) // FIXME: replace with dynamic waiting
+	}
+
+	require.Len(t, bot.store.conversations, 1)
+
+	// get the conversation
+	var theConv *bertymessenger.Conversation
+	{
+		for _, conv := range bot.store.conversations {
+			theConv = conv
+		}
+	}
+
+	// send 'world!'
+	{
+		userMessage, err := proto.Marshal(&bertymessenger.AppMessage_UserMessage{Body: "world!"})
+		require.NoError(t, err)
+		req := &bertymessenger.Interact_Request{
+			Type:                  bertymessenger.AppMessage_TypeUserMessage,
+			Payload:               userMessage,
+			ConversationPublicKey: theConv.PublicKey,
+		}
+		_, err = userClient.Interact(ctx, req)
+		require.NoError(t, err)
+		time.Sleep(200 * time.Millisecond) // FIXME: replace with dynamic waiting
+	}
+
+	// send /ping
+	{
+		userMessage, err := proto.Marshal(&bertymessenger.AppMessage_UserMessage{Body: "/ping"})
+		require.NoError(t, err)
+		req := &bertymessenger.Interact_Request{
+			Type:                  bertymessenger.AppMessage_TypeUserMessage,
+			Payload:               userMessage,
+			ConversationPublicKey: theConv.PublicKey,
+		}
+		_, err = userClient.Interact(ctx, req)
+		require.NoError(t, err)
+		time.Sleep(200 * time.Millisecond) // FIXME: replace with dynamic waiting
+	}
+
+	require.True(t, commandCalled)
+}

--- a/go/pkg/bertybot/commands.go
+++ b/go/pkg/bertybot/commands.go
@@ -1,3 +1,9 @@
 package bertybot
 
-type Command struct{}
+type CommandFn func(ctx Context)
+
+type command struct {
+	name        string
+	description string
+	handler     CommandFn
+}

--- a/go/pkg/bertybot/commands.go
+++ b/go/pkg/bertybot/commands.go
@@ -1,0 +1,3 @@
+package bertybot
+
+type Command struct{}

--- a/go/pkg/bertybot/context.go
+++ b/go/pkg/bertybot/context.go
@@ -1,0 +1,60 @@
+package bertybot
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gogo/protobuf/proto"
+	"go.uber.org/zap"
+
+	"berty.tech/berty/v2/go/pkg/bertymessenger"
+)
+
+// Context is the main argument passed to handlers.
+type Context struct {
+	// common
+	HandlerType  HandlerType
+	EventPayload proto.Message `json:"-"` // content of the payload is already available in the parsed payloads
+	EventType    bertymessenger.StreamEvent_Type
+	Context      context.Context
+	Client       bertymessenger.MessengerServiceClient
+	Logger       *zap.Logger
+	IsReplay     bool // whether the event is a replayed or a fresh event
+	IsMe         bool // whether the bot is the author
+	IsAck        bool // whether the event is an ack
+
+	// parsed payloads, depending on the context
+	Contact        *bertymessenger.Contact      `json:"Contact,omitempty"`
+	Conversation   *bertymessenger.Conversation `json:"Conversation,omitempty"`
+	Interaction    *bertymessenger.Interaction  `json:"Interaction,omitempty"`
+	Member         *bertymessenger.Member       `json:"Member,omitempty"`
+	Account        *bertymessenger.Account      `json:"Account,omitempty"`
+	Device         *bertymessenger.Device       `json:"Device,omitempty"`
+	ConversationPK string                       `json:"ConversationPK,omitempty"`
+	UserMessage    string                       `json:"UserMessage,omitempty"`
+
+	// internal
+	initialized bool
+}
+
+// ReplyString sends a text message on the conversation related to the context.
+// The conversation can be 1-1 or multi-member.
+func (ctx *Context) ReplyString(text string) error {
+	if ctx.ConversationPK == "" {
+		return fmt.Errorf("unknown conversation PK, cannot reply")
+	}
+	// FIXME: support group conversation
+	userMessage, err := proto.Marshal(&bertymessenger.AppMessage_UserMessage{Body: text})
+	if err != nil {
+		return fmt.Errorf("marshal user message failed: %w", err)
+	}
+	_, err = ctx.Client.Interact(ctx.Context, &bertymessenger.Interact_Request{
+		Type:                  bertymessenger.AppMessage_TypeUserMessage,
+		Payload:               userMessage,
+		ConversationPublicKey: ctx.ConversationPK,
+	})
+	if err != nil {
+		return fmt.Errorf("interact failed: %w", err)
+	}
+	return nil
+}

--- a/go/pkg/bertybot/context.go
+++ b/go/pkg/bertybot/context.go
@@ -32,6 +32,7 @@ type Context struct {
 	Device         *bertymessenger.Device       `json:"Device,omitempty"`
 	ConversationPK string                       `json:"ConversationPK,omitempty"`
 	UserMessage    string                       `json:"UserMessage,omitempty"`
+	CommandArgs    []string
 
 	// internal
 	initialized bool

--- a/go/pkg/bertybot/example_test.go
+++ b/go/pkg/bertybot/example_test.go
@@ -1,0 +1,50 @@
+package bertybot_test
+
+import (
+	"context"
+	"os"
+	"time"
+
+	qrterminal "github.com/mdp/qrterminal/v3"
+	"go.uber.org/zap"
+	"moul.io/u"
+
+	"berty.tech/berty/v2/go/pkg/bertybot"
+)
+
+func Example() {
+	logger, _ := zap.NewDevelopment()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// init bot
+	bot, _ := bertybot.New(
+		bertybot.WithLogger(logger.Named("botlib")),                                  // configure a logger
+		bertybot.WithDisplayName("example bot"),                                      // bot name
+		bertybot.WithInsecureMessengerGRPCAddr("127.0.0.1:9091"),                     // connect to running berty messenger daemon
+		bertybot.WithSkipReplay(),                                                    // skip old events, only consume fresh ones
+		bertybot.WithSkipAcknowledge(),                                               // skip acknowledge events
+		bertybot.WithSkipMyself(),                                                    // skip my own interactions
+		bertybot.WithRecipe(bertybot.DebugEventRecipe(logger.Named("debug"))),        // debug events
+		bertybot.WithRecipe(bertybot.DelayResponseRecipe(time.Second)),               // add a delay before sending replies
+		bertybot.WithRecipe(bertybot.AutoAcceptIncomingContactRequestRecipe()),       // accept incoming contact requests
+		bertybot.WithRecipe(bertybot.WelcomeMessageRecipe("welcome to example bot")), // send welcome message to new contacts and new conversations
+		bertybot.WithRecipe(bertybot.EchoRecipe("you said: ")),                       // reply to messages with the same message
+		bertybot.WithHandler(bertybot.UserMessageHandler, func(ctx bertybot.Context) { // custom handler
+			ctx.ReplyString("hello world!")
+		}),
+	)
+
+	// display link and qr code
+	logger.Info("retrieve instance Berty ID", zap.String("pk", bot.PublicKey()), zap.String("link", bot.BertyIDURL()))
+	qrterminal.GenerateHalfBlock(bot.BertyIDURL(), qrterminal.L, os.Stdout)
+
+	// signal handling
+	go func() {
+		u.WaitForCtrlC()
+		cancel()
+	}()
+
+	// start bot
+	bot.Start(ctx)
+}

--- a/go/pkg/bertybot/handlers.go
+++ b/go/pkg/bertybot/handlers.go
@@ -1,0 +1,165 @@
+package bertybot
+
+import (
+	"context"
+	"fmt"
+
+	"berty.tech/berty/v2/go/pkg/bertymessenger"
+)
+
+type HandlerType uint
+
+const (
+	UnknownHandler HandlerType = iota
+
+	// general events
+
+	ErrorHandler
+	PreAnythingHandler
+	PostAnythingHandler
+	EndOfReplayHandler
+
+	// raw messenger events
+
+	ContactUpdatedHandler
+	InteractionUpdatedHandler
+	ConversationUpdatedHandler
+	AccountUpdatedHandler
+	MemberUpdatedHandler
+	DeviceUpdatedHandler
+	NotificationHandler
+
+	// specialized events
+
+	IncomingContactRequestHandler
+	AcceptedContactHandler
+	UserMessageHandler
+	NewConversationHandler
+)
+
+type Handler func(ctx Context)
+
+func (b *Bot) handleEvent(ctx context.Context, event *bertymessenger.StreamEvent) error {
+	payload, err := event.UnmarshalPayload()
+	if err != nil {
+		return fmt.Errorf("unmarshal event payload failed: %w", err)
+	}
+	context := &Context{
+		Context:      ctx,
+		EventPayload: payload,
+		EventType:    event.Type,
+		IsReplay:     b.isReplaying,
+		Client:       b.client,
+		Logger:       b.logger,
+	}
+
+	// raw messenger events
+	switch event.Type {
+	case bertymessenger.StreamEvent_TypeContactUpdated:
+		context.Contact = payload.(*bertymessenger.StreamEvent_ContactUpdated).Contact
+		context.ConversationPK = context.Contact.ConversationPublicKey
+
+		// specialized events
+		switch context.Contact.State {
+		case bertymessenger.Contact_IncomingRequest:
+			b.callHandlers(context, IncomingContactRequestHandler)
+		case bertymessenger.Contact_Accepted:
+			b.callHandlers(context, AcceptedContactHandler)
+		default:
+			return fmt.Errorf("unsupported contact state: %q", context.Contact.State)
+		}
+		b.callHandlers(context, ContactUpdatedHandler)
+
+	case bertymessenger.StreamEvent_TypeInteractionUpdated:
+		context.Interaction = payload.(*bertymessenger.StreamEvent_InteractionUpdated).Interaction
+		context.IsMe = context.Interaction.IsMe
+		context.ConversationPK = context.Interaction.ConversationPublicKey
+		context.IsAck = context.Interaction.Acknowledged
+		payload, err := context.Interaction.UnmarshalPayload()
+		if err != nil {
+			return fmt.Errorf("unmarshal interaction payload failed: %w", err)
+		}
+
+		// specialized events
+		switch context.Interaction.Type {
+		case bertymessenger.AppMessage_TypeUserMessage:
+			receivedMessage := payload.(*bertymessenger.AppMessage_UserMessage)
+			context.UserMessage = receivedMessage.GetBody()
+			b.callHandlers(context, UserMessageHandler)
+		default:
+			return fmt.Errorf("unsupported interaction type: %q", context.Interaction.Type)
+		}
+		b.callHandlers(context, InteractionUpdatedHandler)
+
+	case bertymessenger.StreamEvent_TypeConversationUpdated:
+		context.Conversation = payload.(*bertymessenger.StreamEvent_ConversationUpdated).Conversation
+		context.ConversationPK = context.Conversation.PublicKey
+		b.store.mutex.Lock()
+		_, found := b.store.conversations[context.ConversationPK]
+		if !found {
+			b.store.conversations[context.ConversationPK] = context.Conversation
+		}
+		b.store.mutex.Unlock()
+		if !found {
+			b.callHandlers(context, NewConversationHandler)
+		}
+		b.callHandlers(context, ConversationUpdatedHandler)
+
+	case bertymessenger.StreamEvent_TypeDeviceUpdated:
+		context.Device = payload.(*bertymessenger.StreamEvent_DeviceUpdated).Device
+		b.callHandlers(context, DeviceUpdatedHandler)
+
+	case bertymessenger.StreamEvent_TypeAccountUpdated:
+		context.Account = payload.(*bertymessenger.StreamEvent_AccountUpdated).Account
+		context.IsMe = true
+		b.callHandlers(context, AccountUpdatedHandler)
+
+	case bertymessenger.StreamEvent_TypeMemberUpdated:
+		context.Member = payload.(*bertymessenger.StreamEvent_MemberUpdated).Member
+		b.callHandlers(context, MemberUpdatedHandler)
+
+	case bertymessenger.StreamEvent_TypeListEnd:
+		b.callHandlers(context, EndOfReplayHandler)
+
+	case bertymessenger.StreamEvent_TypeNotified:
+		b.callHandlers(context, NotificationHandler)
+
+	default:
+		return fmt.Errorf("unsupported event type: %q", event.Type)
+	}
+
+	b.callHandlers(context, PostAnythingHandler)
+	return nil
+}
+
+func (b *Bot) callHandlers(context *Context, typ HandlerType) {
+	if b.skipMyself && context.IsMe {
+		return
+	}
+	if b.skipAcknowledge && !context.IsReplay && context.IsAck {
+		return
+	}
+
+	if !context.initialized {
+		context.initialized = true
+		b.callHandlers(context, PreAnythingHandler)
+	}
+
+	handlers, found := b.handlers[typ]
+	if !found {
+		return
+	}
+
+	copy := *context
+	for _, handler := range handlers {
+		copy.HandlerType = typ
+		handler(copy)
+	}
+}
+
+func (b *Bot) addHandler(typ HandlerType, handler Handler) {
+	if _, found := b.handlers[typ]; !found {
+		b.handlers[typ] = make([]Handler, 0)
+	}
+	b.handlers[typ] = append(b.handlers[typ], handler)
+}

--- a/go/pkg/bertybot/opts.go
+++ b/go/pkg/bertybot/opts.go
@@ -1,0 +1,102 @@
+package bertybot
+
+import (
+	"fmt"
+
+	"go.uber.org/zap"
+	"google.golang.org/grpc"
+
+	"berty.tech/berty/v2/go/pkg/bertymessenger"
+)
+
+// NewOption can be passed to the `New` function to configure the bot.
+type NewOption func(*Bot) error
+
+// WithMessengerClient passes an already initialized messenger client.
+func WithMessengerClient(client bertymessenger.MessengerServiceClient) NewOption {
+	return func(b *Bot) error {
+		b.client = client
+		return nil
+	}
+}
+
+// WithMessengerGRPCConn configures a new Messenger client from an already initialized gRPC connection.
+func WithMessengerGRPCConn(cc *grpc.ClientConn) NewOption {
+	return func(b *Bot) error {
+		b.client = bertymessenger.NewMessengerServiceClient(cc)
+		return nil
+	}
+}
+
+// WithInsecureMessengerGRPCAddr tries to open a new gRPC connection against the passed TCP address.
+// It uses grpc.WithInsecure as dialer option and won't check any certificate.
+func WithInsecureMessengerGRPCAddr(addr string) NewOption {
+	return func(b *Bot) error {
+		cc, err := grpc.Dial(addr, grpc.WithInsecure())
+		if err != nil {
+			return fmt.Errorf("dial error: %w", err)
+		}
+		b.client = bertymessenger.NewMessengerServiceClient(cc)
+		return nil
+	}
+}
+
+// WithLogger passes a configured zap Logger.
+func WithLogger(logger *zap.Logger) NewOption {
+	return func(b *Bot) error {
+		b.logger = logger
+		return nil
+	}
+}
+
+// WithDisplayName sets the name of the bot, by default, the name will be named "My Berty Bot".
+func WithDisplayName(name string) NewOption {
+	return func(b *Bot) error {
+		b.displayName = name
+		return nil
+	}
+}
+
+// WithSkipReplay will ignore all events that were already processed before starting to listen to Messenger events.
+func WithSkipReplay() NewOption {
+	return func(b *Bot) error {
+		b.skipReplay = true
+		return nil
+	}
+}
+
+// WithHandler append a new Handler for the specified HandlerType.
+func WithHandler(typ HandlerType, handler Handler) NewOption {
+	return func(b *Bot) error {
+		b.addHandler(typ, handler)
+		return nil
+	}
+}
+
+// WithRecipe
+func WithRecipe(recipe Recipe) NewOption {
+	return func(b *Bot) error {
+		for typ, handlers := range recipe {
+			for _, handler := range handlers {
+				b.addHandler(typ, handler)
+			}
+		}
+		return nil
+	}
+}
+
+// WithSkipAcknowledge
+func WithSkipAcknowledge() NewOption {
+	return func(b *Bot) error {
+		b.skipAcknowledge = true
+		return nil
+	}
+}
+
+// WithSkipMyself
+func WithSkipMyself() NewOption {
+	return func(b *Bot) error {
+		b.skipMyself = true
+		return nil
+	}
+}

--- a/go/pkg/bertybot/recipes.go
+++ b/go/pkg/bertybot/recipes.go
@@ -141,8 +141,3 @@ func AutoAcceptIncomingGroupInviteRecipe() Recipe {
 func SendErrorToClientRecipe() Recipe {
 	panic("not implemented")
 }
-
-// CommandVersionRecipe registers a command that replies bot & protocol versions on '/version'.
-func CommandVersionRecipe(botVersion string) Recipe {
-	panic("not implemented")
-}

--- a/go/pkg/bertybot/recipes.go
+++ b/go/pkg/bertybot/recipes.go
@@ -1,0 +1,148 @@
+package bertybot
+
+import (
+	"strings"
+	"time"
+
+	"go.uber.org/zap"
+
+	"berty.tech/berty/v2/go/pkg/bertymessenger"
+)
+
+// Recipe is a set of handlers that performs common behaviors.
+type Recipe map[HandlerType][]Handler
+
+// AutoAcceptIncomingContactRequestRecipe makes the bot "click" on the "accept" button automatically.
+func AutoAcceptIncomingContactRequestRecipe() Recipe {
+	recipe := map[HandlerType][]Handler{}
+	recipe[IncomingContactRequestHandler] = []Handler{
+		func(ctx Context) {
+			ctx.Logger.Info("auto-accepting incoming contact request", zap.Any("contact", ctx.Contact))
+			req := &bertymessenger.ContactAccept_Request{
+				PublicKey: ctx.Contact.PublicKey,
+			}
+			_, err := ctx.Client.ContactAccept(ctx.Context, req)
+			if err != nil {
+				ctx.Logger.Error("contact accept failed", zap.Error(err))
+			}
+		},
+	}
+	return recipe
+}
+
+// DebugEventRecipe logs every event using zap.DebugLevel.
+func DebugEventRecipe(logger *zap.Logger) Recipe {
+	recipe := map[HandlerType][]Handler{}
+	recipe[PreAnythingHandler] = []Handler{
+		func(ctx Context) {
+			if logger == nil { // if no logger is passed, use the bot's one
+				logger = ctx.Logger
+			}
+			logger.Debug("new event",
+				zap.Stringer("type", ctx.EventType),
+				zap.Any("context", ctx),
+			)
+		},
+	}
+	return recipe
+}
+
+// WelcomeMessageRecipe automatically sends a text message to new contacts.
+func WelcomeMessageRecipe(text string) Recipe {
+	recipe := map[HandlerType][]Handler{}
+	if text == "" {
+		return recipe
+	}
+	// send welcome message to new contacts
+	recipe[NewConversationHandler] = []Handler{
+		func(ctx Context) {
+			// skip old events
+			if ctx.IsReplay {
+				return
+			}
+			time.Sleep(time.Second) // I don't know why, but this is required :/
+			ctx.Logger.Info("sending welcome message",
+				zap.String("text", text),
+				zap.String("conversation", ctx.ConversationPK),
+			)
+			err := ctx.ReplyString(text)
+			if err != nil {
+				ctx.Logger.Error("reply failed", zap.Error(err))
+			}
+		},
+	}
+	// FIXME: send welcome message to new conversations
+	return recipe
+}
+
+// EchoRecipe configures the bot to automatically reply any message with the same message.
+// If a prefix is specified, the bot will prefix its response.
+// If a prefix is specified, the bot will ignore incoming messages with that prefix (i.e., a conversation with multiple echo bots).
+// The bot will skip incoming commands (messages starting with a '/').
+func EchoRecipe(prefix string) Recipe {
+	recipe := map[HandlerType][]Handler{}
+	recipe[UserMessageHandler] = []Handler{
+		func(ctx Context) {
+			// skip old events
+			if ctx.IsReplay {
+				return
+			}
+			// do not reply to myself
+			if ctx.IsMe {
+				return
+			}
+			// avoid bot loops
+			if strings.HasPrefix(ctx.UserMessage, prefix) {
+				return
+			}
+			// ignore commands
+			if strings.HasPrefix(ctx.UserMessage, "/") {
+				return
+			}
+			// to avoid replying twice, only reply on the unacked message
+			if ctx.Interaction.Acknowledged {
+				return
+			}
+
+			msg := prefix + ctx.UserMessage
+			ctx.Logger.Info("echo replying", zap.String("text", msg), zap.String("conversation", ctx.ConversationPK))
+			err := ctx.ReplyString(msg)
+			if err != nil {
+				ctx.Logger.Error("reply failed", zap.Error(err))
+			}
+		},
+	}
+	return recipe
+}
+
+// DelayResponseRecipe will wait for the specified duration before handling an event.
+func DelayResponseRecipe(duration time.Duration) Recipe {
+	recipe := map[HandlerType][]Handler{}
+	recipe[PreAnythingHandler] = []Handler{
+		func(ctx Context) {
+			// skip old events
+			if ctx.IsReplay {
+				return
+			}
+			time.Sleep(duration)
+		},
+	}
+	return recipe
+}
+
+// AutoAcceptIncomingContactRequestRecipe makes the bot "click" on the "accept" button automatically.
+// NOT YET IMPLEMENTED.
+func AutoAcceptIncomingGroupInviteRecipe() Recipe {
+	panic("not implemented.")
+}
+
+// SendErrorToClientRecipe will send internal errors to the related context (a contact or a conversation).
+// NOT YET IMPLEMENTED.
+func SendErrorToClientRecipe() Recipe {
+	panic("not implemented")
+}
+
+// CommandVersionRecipe registers a command that replies bot & protocol versions on '/version'.
+func CommandVersionRecipe(botVersion string) Recipe {
+	panic("not implemented")
+}

--- a/go/pkg/bertymessenger/service_test.go
+++ b/go/pkg/bertymessenger/service_test.go
@@ -313,7 +313,7 @@ func TestBroken1To1AddContact(t *testing.T) {
 	defer cleanup()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	clients, cleanup := testingInfra(ctx, t, 2, logger)
+	clients, cleanup := TestingInfra(ctx, t, 2, logger)
 	defer cleanup()
 
 	// Init accounts
@@ -360,7 +360,7 @@ func TestBroken1To1Exchange(t *testing.T) {
 	defer cleanup()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	clients, cleanup := testingInfra(ctx, t, 2, logger)
+	clients, cleanup := TestingInfra(ctx, t, 2, logger)
 	defer cleanup()
 
 	// Init accounts
@@ -415,7 +415,7 @@ func TestBrokenPeersCreateJoinConversation(t *testing.T) {
 	logger, cleanup := testutil.Logger(t)
 	defer cleanup()
 	accountsAmount := 3
-	clients, cleanup := testingInfra(ctx, t, accountsAmount, logger)
+	clients, cleanup := TestingInfra(ctx, t, accountsAmount, logger)
 	defer cleanup()
 
 	// create nodes
@@ -499,7 +499,7 @@ func TestBroken3PeersExchange(t *testing.T) {
 	defer cancel()
 	logger, cleanup := testutil.Logger(t)
 	defer cleanup()
-	clients, cleanup := testingInfra(ctx, t, 3, logger)
+	clients, cleanup := TestingInfra(ctx, t, 3, logger)
 	defer cleanup()
 
 	// create nodes
@@ -558,7 +558,7 @@ func TestBrokenConversationInvitation(t *testing.T) {
 	defer cancel()
 	logger, cleanup := testutil.Logger(t)
 	defer cleanup()
-	clients, cleanup := testingInfra(ctx, t, 3, logger)
+	clients, cleanup := TestingInfra(ctx, t, 3, logger)
 	defer cleanup()
 
 	// create nodes
@@ -624,7 +624,7 @@ func TestBrokenConversationInvitationAndExchange(t *testing.T) {
 	defer cancel()
 	logger, cleanup := testutil.Logger(t)
 	defer cleanup()
-	clients, cleanup := testingInfra(ctx, t, 3, logger)
+	clients, cleanup := TestingInfra(ctx, t, 3, logger)
 	defer cleanup()
 
 	// create nodes
@@ -698,7 +698,7 @@ func TestBrokenConversationOpenClose(t *testing.T) {
 	defer cleanup()
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	clients, cleanup := testingInfra(ctx, t, 2, logger)
+	clients, cleanup := TestingInfra(ctx, t, 2, logger)
 	defer cleanup()
 
 	// Init accounts

--- a/go/pkg/bertymessenger/testing_test.go
+++ b/go/pkg/bertymessenger/testing_test.go
@@ -2,32 +2,17 @@ package bertymessenger
 
 import (
 	"context"
-	"net"
 	"testing"
 
-	libp2p_mocknet "github.com/libp2p/go-libp2p/p2p/net/mock"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
-	grpc "google.golang.org/grpc"
-	"google.golang.org/grpc/test/bufconn"
-	"moul.io/u"
-
 	"berty.tech/berty/v2/go/internal/testutil"
-	"berty.tech/berty/v2/go/pkg/bertyprotocol"
 )
-
-func mkBufDialer(l *bufconn.Listener) func(context.Context, string) (net.Conn, error) {
-	return func(context.Context, string) (net.Conn, error) {
-		return l.Dial()
-	}
-}
 
 func testingNode(ctx context.Context, t *testing.T) (*TestingAccount, func()) {
 	t.Helper()
 
 	logger, loggerCleanup := testutil.Logger(t)
 	ctx, ctxCancel := context.WithCancel(ctx)
-	clients, infraCleanup := testingInfra(ctx, t, 1, logger)
+	clients, infraCleanup := TestingInfra(ctx, t, 1, logger)
 	node := NewTestingAccount(ctx, t, clients[0], logger)
 	cleanup := func() {
 		node.Close()
@@ -36,37 +21,4 @@ func testingNode(ctx context.Context, t *testing.T) (*TestingAccount, func()) {
 		loggerCleanup()
 	}
 	return node, cleanup
-}
-
-func testingInfra(ctx context.Context, t *testing.T, amount int, logger *zap.Logger) ([]MessengerServiceClient, func()) {
-	t.Helper()
-	mocknet := libp2p_mocknet.New(ctx)
-
-	protocols, cleanup := bertyprotocol.NewTestingProtocolWithMockedPeers(ctx, t, &bertyprotocol.TestingOpts{Logger: logger, Mocknet: mocknet}, nil, amount)
-	clients := make([]MessengerServiceClient, amount)
-
-	for i, p := range protocols {
-		// new messenger service
-		svc, cleanupMessengerService := TestingService(ctx, t, &TestingServiceOpts{Logger: logger, Client: p.Client, Index: i})
-
-		// new messenger client
-		lis := bufconn.Listen(1024 * 1024)
-		s := grpc.NewServer()
-		RegisterMessengerServiceServer(s, svc)
-		go func() {
-			err := s.Serve(lis)
-			require.NoError(t, err)
-		}()
-		conn, err := grpc.DialContext(ctx, "bufnet", grpc.WithContextDialer(mkBufDialer(lis)), grpc.WithInsecure())
-		require.NoError(t, err)
-		cleanup = u.CombineFuncs(func() {
-			require.NoError(t, conn.Close())
-			cleanupMessengerService()
-		}, cleanup)
-		clients[i] = NewMessengerServiceClient(conn)
-	}
-
-	require.NoError(t, mocknet.ConnectAllButSelf())
-
-	return clients, cleanup
 }

--- a/go/pkg/bertymessenger/types.go
+++ b/go/pkg/bertymessenger/types.go
@@ -106,6 +106,8 @@ func (event *StreamEvent) UnmarshalPayload() (proto.Message, error) {
 		message = &StreamEvent_DeviceUpdated{}
 	case StreamEvent_TypeNotified:
 		message = &StreamEvent_Notified{}
+	case StreamEvent_TypeListEnd:
+		message = &StreamEvent_ListEnd{}
 	default:
 		return nil, errcode.TODO.Wrap(fmt.Errorf("unsupported StreamEvent type: %q", event.GetType()))
 	}


### PR DESCRIPTION
* add a new `cmd/testbot` binary with a target of being used in unit tests, and maybe by developers (humans)
* add a new `pkg/bertybot` helper package
  * only used by `cmd/testbot` for now, but there is plan to migrate `cmd/betabot` on it
* export some bertymessenger's testing helper to allow easier bertymessenger testing in other packages