### PR TITLE
feat: refactor account and contact group init

### DIFF
--- a/go/pkg/bertyprotocol/orbitdb.go
+++ b/go/pkg/bertyprotocol/orbitdb.go
@@ -179,7 +179,7 @@ func (s *BertyOrbitDB) openAccountGroup(ctx context.Context, options *orbitdb.Cr
 		return nil, errcode.TODO.Wrap(err)
 	}
 
-	if err := ActivateGroupContext(ctx, gc); err != nil {
+	if err := ActivateGroupContext(ctx, gc, nil); err != nil {
 		return nil, errcode.TODO.Wrap(err)
 	}
 

--- a/go/pkg/bertyprotocol/orbitdb_many_adds_berty_test.go
+++ b/go/pkg/bertyprotocol/orbitdb_many_adds_berty_test.go
@@ -69,7 +69,7 @@ func testAddBerty(ctx context.Context, t *testing.T, node ipfsutil.CoreAPIMock, 
 
 	defer gc.Close()
 
-	err = ActivateGroupContext(ctx, gc)
+	err = ActivateGroupContext(ctx, gc, nil)
 	require.NoError(t, err)
 
 	wg := sync.WaitGroup{}

--- a/go/pkg/bertyprotocol/orbitdb_test.go
+++ b/go/pkg/bertyprotocol/orbitdb_test.go
@@ -123,10 +123,10 @@ func TestDifferentStores(t *testing.T) {
 	g2b, err := odb2.openGroup(ctx, gB, nil)
 	require.NoError(t, err)
 
-	require.NoError(t, ActivateGroupContext(ctx, g1a))
-	require.NoError(t, ActivateGroupContext(ctx, g2a))
-	require.NoError(t, ActivateGroupContext(ctx, g1b))
-	require.NoError(t, ActivateGroupContext(ctx, g2b))
+	require.NoError(t, ActivateGroupContext(ctx, g1a, nil))
+	require.NoError(t, ActivateGroupContext(ctx, g2a, nil))
+	require.NoError(t, ActivateGroupContext(ctx, g1b, nil))
+	require.NoError(t, ActivateGroupContext(ctx, g2b, nil))
 
 	assert.Equal(t, g1a.MetadataStore().Address().String(), g2a.MetadataStore().Address().String())
 	assert.Equal(t, g1b.MetadataStore().Address().String(), g2b.MetadataStore().Address().String())

--- a/go/pkg/bertyprotocol/service.go
+++ b/go/pkg/bertyprotocol/service.go
@@ -21,6 +21,7 @@ import (
 	"berty.tech/berty/v2/go/pkg/bertyversion"
 	"berty.tech/berty/v2/go/pkg/errcode"
 	"berty.tech/go-orbit-db/baseorbitdb"
+	"berty.tech/go-orbit-db/iface"
 )
 
 var _ Service = (*service)(nil)
@@ -62,6 +63,7 @@ type Opts struct {
 	RendezvousRotationBase time.Duration
 	Host                   host.Host
 	PubSub                 *pubsub.PubSub
+	LocalOnly              bool
 	close                  func() error
 }
 
@@ -151,7 +153,9 @@ func New(ctx context.Context, opts Opts) (Service, error) {
 	opts.Logger = opts.Logger.Named("pt")
 	opts.Logger.Debug("initializing protocol", zap.String("version", bertyversion.Version))
 
-	acc, err := opts.OrbitDB.openAccountGroup(ctx, nil)
+	dbOpts := &iface.CreateDBOptions{LocalOnly: &opts.LocalOnly}
+
+	acc, err := opts.OrbitDB.openAccountGroup(ctx, dbOpts, opts.IpfsCoreAPI)
 	if err != nil {
 		return nil, errcode.TODO.Wrap(err)
 	}

--- a/go/pkg/bertyprotocol/service_group.go
+++ b/go/pkg/bertyprotocol/service_group.go
@@ -157,8 +157,18 @@ func (s *service) activateGroup(pk crypto.PubKey, localOnly bool) error {
 			return errcode.TODO.Wrap(err)
 		}
 
-		err = ActivateGroupContext(s.ctx, cg)
-		if err != nil {
+		var contactPK crypto.PubKey
+		if g.GroupType == bertytypes.GroupTypeContact {
+			contact := s.accountGroup.metadataStore.GetContactFromGroupPK(id)
+			if contact != nil {
+				contactPK, err = contact.GetPubKey()
+				if err != nil {
+					return errcode.TODO.Wrap(err)
+				}
+			}
+		}
+
+		if err := ActivateGroupContext(s.ctx, gc, contactPK); err != nil {
 			return errcode.TODO.Wrap(err)
 		}
 

--- a/go/pkg/bertyprotocol/services_replication_test.go
+++ b/go/pkg/bertyprotocol/services_replication_test.go
@@ -192,8 +192,8 @@ func TestReplicationService_Flow(t *testing.T) {
 	g2a, err := odb2.openGroup(ctx, gA, nil)
 	require.NoError(t, err)
 
-	require.NoError(t, ActivateGroupContext(ctx, g1a))
-	require.NoError(t, ActivateGroupContext(ctx, g2a))
+	require.NoError(t, ActivateGroupContext(ctx, g1a, nil))
+	require.NoError(t, ActivateGroupContext(ctx, g2a, nil))
 
 	groupReplicable, err := gA.FilterForReplication()
 	require.NoError(t, err)

--- a/go/pkg/bertyprotocol/store_metadata.go
+++ b/go/pkg/bertyprotocol/store_metadata.go
@@ -335,15 +335,7 @@ func (m *metadataStore) GetIncomingContactRequestsStatus() (bool, *bertytypes.Sh
 }
 
 func (m *metadataStore) ListMembers() []crypto.PubKey {
-	if m.typeChecker(isAccountGroup) {
-		return nil
-	}
-
-	if m.typeChecker(isContactGroup) {
-		return nil
-	}
-
-	if m.typeChecker(isMultiMemberGroup) {
+	if m.typeChecker(isAccountGroup, isContactGroup, isMultiMemberGroup) {
 		return m.Index().(*metadataStoreIndex).listMembers()
 	}
 

--- a/go/pkg/bertyprotocol/store_metadata.go
+++ b/go/pkg/bertyprotocol/store_metadata.go
@@ -419,6 +419,26 @@ func (m *metadataStore) ListContactsByStatus(states ...bertytypes.ContactState) 
 	return contacts
 }
 
+func (m *metadataStore) GetContactFromGroupPK(groupPK []byte) *bertytypes.ShareableContact {
+	if !m.typeChecker(isAccountGroup) {
+		return nil
+	}
+
+	idx, ok := m.Index().(*metadataStoreIndex)
+	if !ok {
+		return nil
+	}
+	idx.lock.Lock()
+	defer idx.lock.Unlock()
+
+	contact, ok := idx.contactsFromGroupPK[string(groupPK)]
+	if !ok || contact == nil {
+		return nil
+	}
+
+	return contact.contact
+}
+
 func (m *metadataStore) checkIfInGroup(pk []byte) bool {
 	idx, ok := m.Index().(*metadataStoreIndex)
 	if !ok {
@@ -962,7 +982,7 @@ func constructorFactoryGroupMetadata(s *BertyOrbitDB) iface.StoreConstructor {
 			}
 		}()
 
-		options.Index = newMetadataIndex(ctx, store, g, md.Public())
+		options.Index = newMetadataIndex(ctx, store, g, md.Public(), s.deviceKeystore)
 
 		if err := store.InitBaseStore(ctx, ipfs, identity, addr, options); err != nil {
 			return nil, errcode.ErrOrbitDBInit.Wrap(err)


### PR DESCRIPTION
- allow the account group to be launched in local only mode (orbit-db will not sync store with other peers)
- send secrets and tag peers on account group
- force sending memberDevice and secrets during contact group init