### PR TITLE
feat(messenger): sticky date dividers in 1-1 chatrooms

### DIFF
--- a/js/packages/components/chat/shared-components/Chat.tsx
+++ b/js/packages/components/chat/shared-components/Chat.tsx
@@ -7,6 +7,7 @@ import BlurView from '../../shared-components/BlurView'
 
 import { messenger as messengerpb } from '@berty-tech/api/index.js'
 import { useMsgrContext } from '@berty-tech/store/hooks'
+import { timeFormat } from '../../helpers'
 
 // import { SafeAreaView } from 'react-native-safe-area-context'
 //
@@ -162,10 +163,10 @@ const useStylesChatDate = () => {
 	}
 }
 
-const formatTimestamp = (date: Date) => {
-	const arr = date.toString().split(' ')
-	return arr[1] + ' ' + arr[2] + ' ' + arr[3]
-}
+// const formatTimestamp = (date: Date) => {
+// 	const arr = date.toString().split(' ')
+// 	return arr[1] + ' ' + arr[2] + ' ' + arr[3]
+// }
 
 export const ChatDate: React.FC<ChatDateProps> = ({ date }) => {
 	const _styles = useStylesChatDate()
@@ -175,7 +176,8 @@ export const ChatDate: React.FC<ChatDateProps> = ({ date }) => {
 	return (
 		<View style={[row.item.justify, border.radius.medium, _styles.date, { backgroundColor }]}>
 			<Text style={[_styles.dateText, { color: textColor }]}>
-				{formatTimestamp(new Date(date))}
+				{/* {formatTimestamp(new Date(date))} */}
+				{timeFormat.fmtTimestamp2(date)}
 			</Text>
 		</View>
 	)

--- a/js/packages/components/helpers.ts
+++ b/js/packages/components/helpers.ts
@@ -39,7 +39,13 @@ const fmtTimestamp1 = (date: number | Date): string => {
 }
 
 const fmtTimestamp2 = (date: number | Date): string => {
+	const now = moment()
 	const mDate = getValidDateMoment(date)
+	if (now.isSame(mDate, 'day')) {
+		return 'Today'
+	} else if (now.subtract(1, 'day').isSame(mDate, 'day')) {
+		return 'Yesterday'
+	}
 	return mDate.format('MMM D YYYY')
 }
 

--- a/js/packages/components/main/Home.tsx
+++ b/js/packages/components/main/Home.tsx
@@ -411,7 +411,7 @@ const ConversationsItem: React.FC<ConversationsItemProps> = (props) => {
 											{/* {Date.now() - new Date(sentDate).getTime() > 86400000
 											? moment(sentDate).format('DD/MM/YYYY')
 											: moment(sentDate).format('hh:mm')} */}
-											{timeFormat.fmtTimestamp1(strToTimestamp(displayDate))}
+											{timeFormat.fmtTimestamp1(displayDate)}
 										</Text>
 									)}
 								</>


### PR DESCRIPTION
In 1-1 chatrooms:

- re-add chat header date format
- add sticky date header on scroll (Today, Yesterday, DD/MM/YYYY)
- add date dividers between messages on different days (same format as above)
- **does not** add date headers/dividers to multimember chatrooms yet; it will be the same implementation so I'm making sure it's smooth in 1-1 first