### PR TITLE
fix(messenger): hotfix remove stickydate + add multimember date dividers

### DIFF
--- a/js/packages/components/chat/MultiMember.tsx
+++ b/js/packages/components/chat/MultiMember.tsx
@@ -351,7 +351,7 @@ const MessageList: React.FC<{
 			onViewableItemsChanged={updateStickyDate}
 			initialNumToRender={20}
 			onScrollBeginDrag={(e) => {
-				setShowStickyDate(true) // TODO: Not if start of conversation is visible
+				setShowStickyDate(false) // TODO: tmp until hide if start of conversation is visible
 			}}
 			onScrollEndDrag={(e) => {
 				setTimeout(() => setShowStickyDate(false), 2000)

--- a/js/packages/components/chat/OneToOne.tsx
+++ b/js/packages/components/chat/OneToOne.tsx
@@ -101,7 +101,7 @@ export const ChatHeader: React.FC<any> = ({ convPk, stickyDate, showStickyDate }
 
 	const persistOpts = usePersistentOptions()
 	const isBetabot =
-		persistOpts && conv.contactPublicKey.toString() === persistOpts.betabot.convPk.toString()
+		persistOpts && conv?.contactPublicKey?.toString() === persistOpts?.betabot?.convPk?.toString()
 
 	if (!conv || !contact) {
 		goBack()
@@ -685,7 +685,7 @@ const MessageList: React.FC<{
 			onViewableItemsChanged={updateStickyDate}
 			initialNumToRender={20}
 			onScrollBeginDrag={(e) => {
-				setShowStickyDate(true) // TODO: Not if start of conversation is visible
+				setShowStickyDate(true) // TODO: tmp
 			}}
 			onScrollEndDrag={(e) => {
 				setTimeout(() => setShowStickyDate(false), 2000)
@@ -709,7 +709,7 @@ export const OneToOne: React.FC<ScreenProps.Chat.OneToOne> = ({ route: { params 
 	const persistOpts = usePersistentOptions()
 	const isBetabot =
 		persistOpts && conv?.contactPublicKey?.toString() === persistOpts?.betabot?.convPk?.toString()
-	const isBetabotAdded = persistOpts && persistOpts.betabot.added
+	const isBetabotAdded = persistOpts && persistOpts?.betabot?.added
 	const isFooterDisable = isIncoming || (isBetabot && !isBetabotAdded)
 	const placeholder = isFooterDisable
 		? isBetabot


### PR DESCRIPTION
Related to #2463 and #2465 – since I won't have time to test the fix to remove sticky headers when conversation start is visible, this removes the headers (but keeps dividers in 1-1 and adds them to multimember.)

![image](https://user-images.githubusercontent.com/24300177/95689102-98d8fc80-0bdc-11eb-93ce-4117b446a610.png)