### PR TITLE
chore: add new functions to ignore list of goleak

### DIFF
--- a/go/internal/initutil/manager_test.go
+++ b/go/internal/initutil/manager_test.go
@@ -26,36 +26,36 @@ func verifySetupLeakDetection(t *testing.T) {
 
 func verifyRunningLeakDetection(t *testing.T) {
 	// waiting for some go routines finished
+	// sometimes if timeout is quite short - not enough for below functions to finished
 	time.Sleep(5 * time.Second)
 	goleak.VerifyNone(t,
-		goleak.IgnoreTopFunction("github.com/ipfs/go-log/writer.(*MirrorWriter).logRoutine"),    // global writer created at github.com/ipfs/go-log@v1.0.4/writer/option.go, refer by github.com/ipfs/, like go-bitswap
-		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),                 // called by init() in berty/go/internal/grpcutil/server.go
-		goleak.IgnoreTopFunction("github.com/desertbit/timer.timerRoutine"),                     // called by init() in github.com/desertbit/timer/timers.go, refer in grpc-web
-		goleak.IgnoreTopFunction("github.com/whyrusleeping/mdns.(*client).query"),               // the closing routine has big timeout
-		goleak.IgnoreTopFunction("github.com/lucas-clemente/quic-go.(*closedLocalSession).run"), // the closing routine has big timeout
-		goleak.IgnoreTopFunction("github.com/lucas-clemente/quic-go.(*sendQueue).Run"),          // the closing routine has big timeout
-		// Sometime if timeout is quite short - not enough for below functions to finished
+		goleak.IgnoreTopFunction("github.com/desertbit/timer.timerRoutine"),                                                  // called by init() in github.com/desertbit/timer/timers.go, refer in grpc-web
+		goleak.IgnoreTopFunction("github.com/ipfs/go-log/writer.(*MirrorWriter).logRoutine"),                                 // global writer created at github.com/ipfs/go-log@v1.0.4/writer/option.go, refer by github.com/ipfs/, like go-bitswap
+		goleak.IgnoreTopFunction("github.com/jbenet/goprocess/periodic.callOnTicker.func1"),                                  // FIXME - upstream code - is used in many code of libp2p + go-ipfs
+		goleak.IgnoreTopFunction("github.com/libp2p/go-flow-metrics.(*sweeper).run"),                                         // this goroutine has run alway without stop
+		goleak.IgnoreTopFunction("github.com/libp2p/go-flow-metrics.(*sweeper).runActive"),                                   // this goroutine has run alway without stop
 		goleak.IgnoreTopFunction("github.com/libp2p/go-libp2p-noise.newSecureSession"),                                       // upstream issue
+		goleak.IgnoreTopFunction("github.com/libp2p/go-libp2p-peerstore/pstoremem.(*memoryAddrBook).background"),             // upstream issue, no store close in upstream code
+		goleak.IgnoreTopFunction("github.com/libp2p/go-libp2p-quic-transport.(*reuse).runGarbageCollector"),                  // upstream issue of mdns, go wakeup periodiclly to do action before check exist, timeout about 30 seconds
+		goleak.IgnoreTopFunction("github.com/libp2p/go-libp2p-swarm.(*Swarm).dialAddrs"),                                     // the closing routine has big timeout
+		goleak.IgnoreTopFunction("github.com/libp2p/go-libp2p-swarm.(*activeDial).wait"),                                     // the closing routine has big timeout
 		goleak.IgnoreTopFunction("github.com/libp2p/go-libp2p-transport-upgrader.(*Upgrader).setupMuxer"),                    // the closing routine has big timeout
+		goleak.IgnoreTopFunction("github.com/libp2p/go-libp2p/p2p/discovery.(*mdnsService).pollForEntries.func1"),            // upstream issue of mdns, go wakeup periodiclly to do action before check exist, timeout about 10 seconds
+		goleak.IgnoreTopFunction("github.com/libp2p/go-nat.DiscoverGateway"),                                                 // upstream code - DiscoverGateway() using context.Background() with timeout is 10s
+		goleak.IgnoreTopFunction("github.com/libp2p/go-nat.DiscoverNATs.func1"),                                              // upstream code - DiscoverGateway() using context.Background() with timeout is 10s
+		goleak.IgnoreTopFunction("github.com/libp2p/go-nat.discoverNATPMP.func1"),                                            // upstream code
+		goleak.IgnoreTopFunction("github.com/lucas-clemente/quic-go.(*client).dial"),                                         // the closing routine has big timeout
+		goleak.IgnoreTopFunction("github.com/lucas-clemente/quic-go.(*closedLocalSession).run"),                              // the closing routine has big timeout
+		goleak.IgnoreTopFunction("github.com/lucas-clemente/quic-go.(*receiveStream).readImpl"),                              // upstream code - the closing is did in go routine
+		goleak.IgnoreTopFunction("github.com/lucas-clemente/quic-go.(*sendQueue).Run"),                                       // the closing routine has big timeout
+		goleak.IgnoreTopFunction("github.com/lucas-clemente/quic-go.(*session).run"),                                         // sometimes happening on CI
 		goleak.IgnoreTopFunction("github.com/lucas-clemente/quic-go/internal/handshake.(*cryptoSetup).ReadHandshakeMessage"), // the closing routine has big timeout
 		goleak.IgnoreTopFunction("github.com/lucas-clemente/quic-go/internal/handshake.(*cryptoSetup).RunHandshake"),         // the closing routine has big timeout
-		goleak.IgnoreTopFunction("github.com/libp2p/go-libp2p-swarm.(*activeDial).wait"),                                     // the closing routine has big timeout
-		goleak.IgnoreTopFunction("sync.runtime_Semacquire"),                                                                  // the closing routine has big timeout
-		goleak.IgnoreTopFunction("github.com/lucas-clemente/quic-go.(*client).dial"),                                         // the closing routine has big timeout
-		goleak.IgnoreTopFunction("github.com/libp2p/go-libp2p-swarm.(*Swarm).dialAddrs"),                                     // the closing routine has big timeout
-		goleak.IgnoreTopFunction("github.com/libp2p/go-libp2p-quic-transport.(*reuse).runGarbageCollector"),                  // upstream issue of mdns, go wakeup periodiclly to do action before check exist, timeout about 30 seconds
-		goleak.IgnoreTopFunction("github.com/libp2p/go-libp2p-peerstore/pstoremem.(*memoryAddrBook).background"),             // upstream issue, no store close in upstream code
-		goleak.IgnoreTopFunction("github.com/libp2p/go-libp2p/p2p/discovery.(*mdnsService).pollForEntries.func1"),            // upstream issue of mdns, go wakeup periodiclly to do action before check exist, timeout about 10 seconds
+		goleak.IgnoreTopFunction("github.com/whyrusleeping/mdns.(*client).query"),                                            // the closing routine has big timeout
+		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),                                              // called by init() in berty/go/internal/grpcutil/server.go
 		goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"),                                                           // upstream issue of mdns, go wakeup periodiclly to do action before check exist, timeout about 10 seconds
-		goleak.IgnoreTopFunction("github.com/libp2p/go-flow-metrics.(*sweeper).runActive"),                                   // this goroutine has run alway without stop
-		goleak.IgnoreTopFunction("github.com/libp2p/go-flow-metrics.(*sweeper).run"),                                         // this goroutine has run alway without stop
-		goleak.IgnoreTopFunction("github.com/jbenet/goprocess/periodic.callOnTicker.func1"),                                  // FIXME - upstream code - is used in many code of libp2p + go-ipfs
-		goleak.IgnoreTopFunction("github.com/lucas-clemente/quic-go.(*receiveStream).readImpl"),                              // upstream code - the closing is did in go routine
-		goleak.IgnoreTopFunction("github.com/libp2p/go-nat.DiscoverNATs.func1"),                                              // upstream code - DiscoverGateway() using context.Background() with timeout is 10s
-		goleak.IgnoreTopFunction("github.com/libp2p/go-nat.DiscoverGateway"),                                                 // upstream code - DiscoverGateway() using context.Background() with timeout is 10s
 		goleak.IgnoreTopFunction("net.(*netFD).connect.func2"),                                                               // FIXME - many libraries used this code
-		goleak.IgnoreTopFunction("github.com/libp2p/go-nat.discoverNATPMP.func1"),                                            // upstream code
-		goleak.IgnoreTopFunction("github.com/lucas-clemente/quic-go.(*session).run"),                                         // sometimes happening on CI
+		goleak.IgnoreTopFunction("sync.runtime_Semacquire"),                                                                  // the closing routine has big timeout
 	)
 }
 

--- a/go/internal/initutil/manager_test.go
+++ b/go/internal/initutil/manager_test.go
@@ -31,31 +31,49 @@ func verifyRunningLeakDetection(t *testing.T) {
 	goleak.VerifyNone(t,
 		goleak.IgnoreTopFunction("github.com/desertbit/timer.timerRoutine"),                                                  // called by init() in github.com/desertbit/timer/timers.go, refer in grpc-web
 		goleak.IgnoreTopFunction("github.com/ipfs/go-log/writer.(*MirrorWriter).logRoutine"),                                 // global writer created at github.com/ipfs/go-log@v1.0.4/writer/option.go, refer by github.com/ipfs/, like go-bitswap
+		goleak.IgnoreTopFunction("github.com/jbenet/goprocess/context.CloseAfterContext.func1"),                              // sometimes happening on CI, need more investigation
 		goleak.IgnoreTopFunction("github.com/jbenet/goprocess/periodic.callOnTicker.func1"),                                  // FIXME - upstream code - is used in many code of libp2p + go-ipfs
 		goleak.IgnoreTopFunction("github.com/libp2p/go-flow-metrics.(*sweeper).run"),                                         // this goroutine has run alway without stop
 		goleak.IgnoreTopFunction("github.com/libp2p/go-flow-metrics.(*sweeper).runActive"),                                   // this goroutine has run alway without stop
+		goleak.IgnoreTopFunction("github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).background"),                         // sometimes happening on CI, need more investigation
+		goleak.IgnoreTopFunction("github.com/libp2p/go-libp2p-autonat.(*autoNATService).background"),                         // sometimes happening on CI, need more investigation
+		goleak.IgnoreTopFunction("github.com/libp2p/go-libp2p-circuit.(*RelayListener).Accept"),                              // sometimes happening on CI, need more investigation
 		goleak.IgnoreTopFunction("github.com/libp2p/go-libp2p-noise.newSecureSession"),                                       // upstream issue
 		goleak.IgnoreTopFunction("github.com/libp2p/go-libp2p-peerstore/pstoremem.(*memoryAddrBook).background"),             // upstream issue, no store close in upstream code
 		goleak.IgnoreTopFunction("github.com/libp2p/go-libp2p-quic-transport.(*reuse).runGarbageCollector"),                  // upstream issue of mdns, go wakeup periodiclly to do action before check exist, timeout about 30 seconds
+		goleak.IgnoreTopFunction("github.com/libp2p/go-libp2p-quic-transport.(*transport).Dial.func1"),                       // sometimes happening on CI, need more investigation
+		goleak.IgnoreTopFunction("github.com/libp2p/go-libp2p-swarm.(*DialBackoff).background"),                              // sometimes happening on CI, need more investigation
 		goleak.IgnoreTopFunction("github.com/libp2p/go-libp2p-swarm.(*Swarm).dialAddrs"),                                     // the closing routine has big timeout
 		goleak.IgnoreTopFunction("github.com/libp2p/go-libp2p-swarm.(*activeDial).wait"),                                     // the closing routine has big timeout
 		goleak.IgnoreTopFunction("github.com/libp2p/go-libp2p-transport-upgrader.(*Upgrader).setupMuxer"),                    // the closing routine has big timeout
+		goleak.IgnoreTopFunction("github.com/libp2p/go-libp2p-transport-upgrader.(*listener).Accept"),                        // sometimes happening on CI, need more investigation
 		goleak.IgnoreTopFunction("github.com/libp2p/go-libp2p/p2p/discovery.(*mdnsService).pollForEntries.func1"),            // upstream issue of mdns, go wakeup periodiclly to do action before check exist, timeout about 10 seconds
+		goleak.IgnoreTopFunction("github.com/libp2p/go-libp2p/p2p/host/basic.(*BasicHost).dialPeer"),                         // sometimes happening on CI, need more investigation
+		goleak.IgnoreTopFunction("github.com/libp2p/go-libp2p/p2p/host/relay.(*AutoRelay).background"),                       // sometimes happening on CI, need more investigation
+		goleak.IgnoreTopFunction("github.com/libp2p/go-libp2p/p2p/protocol/identify.(*IDService).loop.func1"),                // sometimes happening on CI, need more investigation
+		goleak.IgnoreTopFunction("github.com/libp2p/go-mplex.(*Multiplex).Accept"),                                           // sometimes happening on CI, need more investigation
+		goleak.IgnoreTopFunction("github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing"),                                   // sometimes happening on CI, need more investigation
+		goleak.IgnoreTopFunction("github.com/libp2p/go-mplex.(*Stream).waitForData"),                                         // sometimes happening on CI, need more investigation
 		goleak.IgnoreTopFunction("github.com/libp2p/go-nat.DiscoverGateway"),                                                 // upstream code - DiscoverGateway() using context.Background() with timeout is 10s
 		goleak.IgnoreTopFunction("github.com/libp2p/go-nat.DiscoverNATs.func1"),                                              // upstream code - DiscoverGateway() using context.Background() with timeout is 10s
 		goleak.IgnoreTopFunction("github.com/libp2p/go-nat.discoverNATPMP.func1"),                                            // upstream code
+		goleak.IgnoreTopFunction("github.com/lucas-clemente/quic-go.(*baseServer).accept"),                                   // sometimes happening on CI, need more investigation
+		goleak.IgnoreTopFunction("github.com/lucas-clemente/quic-go.(*baseServer).run"),                                      // sometimes happening on CI, need more investigation
 		goleak.IgnoreTopFunction("github.com/lucas-clemente/quic-go.(*client).dial"),                                         // the closing routine has big timeout
 		goleak.IgnoreTopFunction("github.com/lucas-clemente/quic-go.(*closedLocalSession).run"),                              // the closing routine has big timeout
+		goleak.IgnoreTopFunction("github.com/lucas-clemente/quic-go.(*incomingBidiStreamsMap).AcceptStream"),                 // sometimes happening on CI, need more investigation
 		goleak.IgnoreTopFunction("github.com/lucas-clemente/quic-go.(*receiveStream).readImpl"),                              // upstream code - the closing is did in go routine
 		goleak.IgnoreTopFunction("github.com/lucas-clemente/quic-go.(*sendQueue).Run"),                                       // the closing routine has big timeout
-		goleak.IgnoreTopFunction("github.com/lucas-clemente/quic-go.(*session).run"),                                         // sometimes happening on CI
+		goleak.IgnoreTopFunction("github.com/lucas-clemente/quic-go.(*session).run"),                                         // sometimes happening on CI, need more investigation
 		goleak.IgnoreTopFunction("github.com/lucas-clemente/quic-go/internal/handshake.(*cryptoSetup).ReadHandshakeMessage"), // the closing routine has big timeout
 		goleak.IgnoreTopFunction("github.com/lucas-clemente/quic-go/internal/handshake.(*cryptoSetup).RunHandshake"),         // the closing routine has big timeout
 		goleak.IgnoreTopFunction("github.com/whyrusleeping/mdns.(*client).query"),                                            // the closing routine has big timeout
 		goleak.IgnoreTopFunction("go.opencensus.io/stats/view.(*worker).start"),                                              // called by init() in berty/go/internal/grpcutil/server.go
+		goleak.IgnoreTopFunction("go.uber.org/fx.withTimeout"),                                                               // sometimes happening on CI, need more investigation
 		goleak.IgnoreTopFunction("internal/poll.runtime_pollWait"),                                                           // upstream issue of mdns, go wakeup periodiclly to do action before check exist, timeout about 10 seconds
 		goleak.IgnoreTopFunction("net.(*netFD).connect.func2"),                                                               // FIXME - many libraries used this code
 		goleak.IgnoreTopFunction("sync.runtime_Semacquire"),                                                                  // the closing routine has big timeout
+		goleak.IgnoreTopFunction("sync.runtime_SemacquireMutex"),                                                             // sometimes happening on CI, need more investigation
 	)
 }
 


### PR DESCRIPTION
Recently the CI started to somtimes fail with these new detected leaks

```
2020-10-13T09:18:55.3352905Z === RUN   TestCloseByContext
2020-10-13T09:18:55.3353356Z     leaks.go:78: found unexpected goroutines:
2020-10-13T09:18:55.3354194Z         [Goroutine 10467 in state select, with github.com/libp2p/go-mplex.(*Multiplex).Accept on top of the stack:
2020-10-13T09:18:55.3354774Z         goroutine 10467 [select]:
2020-10-13T09:18:55.3355481Z         github.com/libp2p/go-mplex.(*Multiplex).Accept(0xc002798680, 0xc001722600, 0x100000000, 0x2700000000)
2020-10-13T09:18:55.3356471Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:129 +0x129
2020-10-13T09:18:55.3358095Z         github.com/libp2p/go-libp2p-mplex.(*conn).AcceptStream(0xc002798680, 0x0, 0xdb7e6e, 0xc0016b2e98, 0xddf600)
2020-10-13T09:18:55.3359184Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-mplex@v0.2.4/conn.go:25 +0x3d
2020-10-13T09:18:55.3360132Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc002798700)
2020-10-13T09:18:55.3361552Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.3362376Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.3363260Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.3363747Z         
2020-10-13T09:18:55.3364532Z          Goroutine 8476 in state select, with github.com/jbenet/goprocess/context.CloseAfterContext.func1 on top of the stack:
2020-10-13T09:18:55.3365271Z         goroutine 8476 [select]:
2020-10-13T09:18:55.3365965Z         github.com/jbenet/goprocess/context.CloseAfterContext.func1(0x3a4c6e0, 0xc003899100, 0x3a6c900, 0xc0039a7b60)
2020-10-13T09:18:55.3367039Z         	/home/runner/go/pkg/mod/github.com/jbenet/goprocess@v0.1.4/context/context.go:65 +0x10f
2020-10-13T09:18:55.3368189Z         created by github.com/jbenet/goprocess/context.CloseAfterContext
2020-10-13T09:18:55.3369001Z         	/home/runner/go/pkg/mod/github.com/jbenet/goprocess@v0.1.4/context/context.go:64 +0xba
2020-10-13T09:18:55.3369431Z         
2020-10-13T09:18:55.3375212Z          Goroutine 9975 in state select, with github.com/lucas-clemente/quic-go.(*incomingBidiStreamsMap).AcceptStream on top of the stack:
2020-10-13T09:18:55.3377542Z         goroutine 9975 [select]:
2020-10-13T09:18:55.3378543Z         github.com/lucas-clemente/quic-go.(*incomingBidiStreamsMap).AcceptStream(0xc003a69ab0, 0x3a4c720, 0xc00011c010, 0x0, 0x0, 0xc002540ff0, 0x10)
2020-10-13T09:18:55.3379887Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/streams_map_incoming_bidi.go:71 +0x239
2020-10-13T09:18:55.3381381Z         github.com/lucas-clemente/quic-go.(*streamsMap).AcceptStream(0xc00254af80, 0x3a4c720, 0xc00011c010, 0xc0024d4e28, 0xdfd305, 0xe018a6, 0xc0024d4ec8)
2020-10-13T09:18:55.3382298Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/streams_map.go:127 +0x78
2020-10-13T09:18:55.3383165Z         github.com/lucas-clemente/quic-go.(*session).AcceptStream(0xc0039f7080, 0x3a4c720, 0xc00011c010, 0xe017ce, 0x0, 0xdb7e6e, 0xc0024d4e98)
2020-10-13T09:18:55.3384021Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/session.go:1635 +0x6e
2020-10-13T09:18:55.3384898Z         github.com/libp2p/go-libp2p-quic-transport.(*conn).AcceptStream(0xc00258f280, 0x36b8990, 0xc00258f300, 0x3a624c0, 0xc002540ff0)
2020-10-13T09:18:55.3389379Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-quic-transport@v0.8.1/conn.go:47 +0x87
2020-10-13T09:18:55.3392565Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc00258f300)
2020-10-13T09:18:55.3393739Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.3394687Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.3397917Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.3398549Z         
2020-10-13T09:18:55.3399233Z          Goroutine 10852 in state select, with github.com/libp2p/go-mplex.(*Multiplex).Accept on top of the stack:
2020-10-13T09:18:55.3399760Z         goroutine 10852 [select]:
2020-10-13T09:18:55.3400432Z         github.com/libp2p/go-mplex.(*Multiplex).Accept(0xc002808780, 0xc001722600, 0x100000000, 0x4200000000)
2020-10-13T09:18:55.3401901Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:129 +0x129
2020-10-13T09:18:55.3402678Z         github.com/libp2p/go-libp2p-mplex.(*conn).AcceptStream(0xc002808780, 0x0, 0xdb7e6e, 0xc00168e698, 0xddf600)
2020-10-13T09:18:55.3403468Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-mplex@v0.2.4/conn.go:25 +0x3d
2020-10-13T09:18:55.3404140Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc0026ee380)
2020-10-13T09:18:55.3404880Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.3405538Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.3406246Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.3406604Z         
2020-10-13T09:18:55.3407646Z          Goroutine 12957 in state select, with github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing on top of the stack:
2020-10-13T09:18:55.3408181Z         goroutine 12957 [select]:
2020-10-13T09:18:55.3408786Z         github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing(0xc003d3c100)
2020-10-13T09:18:55.3409593Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:191 +0x158
2020-10-13T09:18:55.3410318Z         created by github.com/libp2p/go-mplex.NewMultiplex
2020-10-13T09:18:55.3411377Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:107 +0x3a2
2020-10-13T09:18:55.3411869Z         
2020-10-13T09:18:55.3412621Z          Goroutine 9959 in state chan receive, with github.com/libp2p/go-libp2p-quic-transport.(*transport).Dial.func1 on top of the stack:
2020-10-13T09:18:55.3413197Z         goroutine 9959 [chan receive]:
2020-10-13T09:18:55.3413886Z         github.com/libp2p/go-libp2p-quic-transport.(*transport).Dial.func1(0x7fab883e9a48, 0xc0039f7080, 0xc003872400)
2020-10-13T09:18:55.3414834Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-quic-transport@v0.8.1/transport.go:175 +0x6a
2020-10-13T09:18:55.3415648Z         created by github.com/libp2p/go-libp2p-quic-transport.(*transport).Dial
2020-10-13T09:18:55.3416658Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-quic-transport@v0.8.1/transport.go:174 +0x397
2020-10-13T09:18:55.3446457Z         
2020-10-13T09:18:55.3447605Z          Goroutine 11136 in state select, with github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing on top of the stack:
2020-10-13T09:18:55.3448191Z         goroutine 11136 [select]:
2020-10-13T09:18:55.3448847Z         github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing(0xc00284f300)
2020-10-13T09:18:55.3449736Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:191 +0x158
2020-10-13T09:18:55.3450827Z         created by github.com/libp2p/go-mplex.NewMultiplex
2020-10-13T09:18:55.3452423Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:107 +0x3a2
2020-10-13T09:18:55.3452756Z         
2020-10-13T09:18:55.3453384Z          Goroutine 11274 in state select, with github.com/libp2p/go-mplex.(*Multiplex).Accept on top of the stack:
2020-10-13T09:18:55.3453823Z         goroutine 11274 [select]:
2020-10-13T09:18:55.3454402Z         github.com/libp2p/go-mplex.(*Multiplex).Accept(0xc0028bdf80, 0xc001722600, 0x100000000, 0x4800000000)
2020-10-13T09:18:55.3455340Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:129 +0x129
2020-10-13T09:18:55.3456111Z         github.com/libp2p/go-libp2p-mplex.(*conn).AcceptStream(0xc0028bdf80, 0x0, 0xdb7e6e, 0xc002085698, 0xddf600)
2020-10-13T09:18:55.3457093Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-mplex@v0.2.4/conn.go:25 +0x3d
2020-10-13T09:18:55.3458064Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc0028fa000)
2020-10-13T09:18:55.3458921Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.3459678Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.3460648Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.3461010Z         
2020-10-13T09:18:55.3461633Z          Goroutine 8585 in state select, with github.com/lucas-clemente/quic-go.(*baseServer).accept on top of the stack:
2020-10-13T09:18:55.3462115Z         goroutine 8585 [select]:
2020-10-13T09:18:55.3462815Z         github.com/lucas-clemente/quic-go.(*baseServer).accept(0xc001f191e0, 0x3a4c720, 0xc00011c010, 0xc00153c780, 0x5, 0xc001517e00, 0xdc271f)
2020-10-13T09:18:55.3463649Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/server.go:259 +0x1a1
2020-10-13T09:18:55.3464505Z         github.com/lucas-clemente/quic-go.(*baseServer).Accept(0xc001f191e0, 0x3a4c720, 0xc00011c010, 0xdbdf35, 0x2b43c80, 0x7fab45eb0008, 0x0)
2020-10-13T09:18:55.3465345Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/server.go:255 +0x51
2020-10-13T09:18:55.3466396Z         github.com/libp2p/go-libp2p-quic-transport.(*listener).Accept(0xc0039602d0, 0x100000000, 0xc002083db0, 0xc001517f48, 0x0)
2020-10-13T09:18:55.3467995Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-quic-transport@v0.8.1/listener.go:63 +0xca
2020-10-13T09:18:55.3469318Z         github.com/libp2p/go-libp2p-swarm.(*Swarm).AddListenAddr.func2(0x3a4d360, 0xc0039602d0, 0xc001722600, 0x3a74900, 0xc003a8e100)
2020-10-13T09:18:55.3470316Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_listen.go:84 +0x1a7
2020-10-13T09:18:55.3471371Z         created by github.com/libp2p/go-libp2p-swarm.(*Swarm).AddListenAddr
2020-10-13T09:18:55.3472587Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_listen.go:69 +0x328
2020-10-13T09:18:55.3472982Z         
2020-10-13T09:18:55.3473612Z          Goroutine 11001 in state select, with github.com/libp2p/go-mplex.(*Stream).waitForData on top of the stack:
2020-10-13T09:18:55.3474100Z         goroutine 11001 [select]:
2020-10-13T09:18:55.3474698Z         github.com/libp2p/go-mplex.(*Stream).waitForData(0xc002795440, 0xc0027efec0, 0x0)
2020-10-13T09:18:55.3475713Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:76 +0x1a9
2020-10-13T09:18:55.3476465Z         github.com/libp2p/go-mplex.(*Stream).Read(0xc002795440, 0xc002848000, 0x1000, 0x1000, 0xc0027757a8, 0xdff823, 0x0)
2020-10-13T09:18:55.3477622Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:122 +0x3f5
2020-10-13T09:18:55.3478493Z         github.com/libp2p/go-libp2p-swarm.(*Stream).Read(0xc002827b90, 0xc002848000, 0x1000, 0x1000, 0xde431c, 0xdff55f, 0xc002827c24)
2020-10-13T09:18:55.3479405Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_stream.go:71 +0x98
2020-10-13T09:18:55.3480324Z         github.com/multiformats/go-multistream.(*lazyClientConn).Read(0xc002827c00, 0xc002848000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.3481765Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-multistream@v0.1.2/lazyClient.go:75 +0x107
2020-10-13T09:18:55.3482609Z         github.com/libp2p/go-libp2p/p2p/host/basic.(*streamWrapper).Read(0xc002836fc0, 0xc002848000, 0x1000, 0x1000, 0x0, 0xc002827c20, 0x1)
2020-10-13T09:18:55.3484153Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p@v0.11.0/p2p/host/basic/basic_host.go:1008 +0x78
2020-10-13T09:18:55.3484618Z         bufio.(*Reader).fill(0xc0028079e0)
2020-10-13T09:18:55.3485036Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/bufio/bufio.go:100 +0x19a
2020-10-13T09:18:55.3485497Z         bufio.(*Reader).ReadByte(0xc0028079e0, 0xc002827c00, 0xc0027f9780, 0x74)
2020-10-13T09:18:55.3486360Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/bufio/bufio.go:252 +0x5b
2020-10-13T09:18:55.3487897Z         github.com/multiformats/go-varint.ReadUvarint(0x39ff360, 0xc0028079e0, 0x7c, 0x74, 0xc002815b40)
2020-10-13T09:18:55.3488855Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-varint@v0.0.6/varint.go:80 +0x85
2020-10-13T09:18:55.3489791Z         github.com/libp2p/go-msgio/protoio.(*uvarintReader).ReadMsg(0xc002815940, 0x3a3ffe0, 0xc002815b40, 0x0, 0x0)
2020-10-13T09:18:55.3491447Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-msgio@v0.0.6/protoio/uvarint_reader.go:60 +0x73
2020-10-13T09:18:55.3506941Z         github.com/libp2p/go-libp2p-autonat.(*client).DialBack(0xc002836f20, 0x3a4c760, 0xc0028078c0, 0xc0027ae8d0, 0x22, 0x0, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.3508105Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/client.go:58 +0x4e8
2020-10-13T09:18:55.3508999Z         github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).probe(0xc003bee000, 0xc00282aa80)
2020-10-13T09:18:55.3509929Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:371 +0x23d
2020-10-13T09:18:55.3511093Z         created by github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).tryProbe
2020-10-13T09:18:55.3512109Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:360 +0x457
2020-10-13T09:18:55.3512500Z         
2020-10-13T09:18:55.3513160Z          Goroutine 11194 in state select, with github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing on top of the stack:
2020-10-13T09:18:55.3513862Z         goroutine 11194 [select]:
2020-10-13T09:18:55.3514625Z         github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing(0xc0028bdf80)
2020-10-13T09:18:55.3515352Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:191 +0x158
2020-10-13T09:18:55.3516024Z         created by github.com/libp2p/go-mplex.NewMultiplex
2020-10-13T09:18:55.3516928Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:107 +0x3a2
2020-10-13T09:18:55.3517298Z         
2020-10-13T09:18:55.3521190Z          Goroutine 10959 in state select, with github.com/libp2p/go-mplex.(*Stream).waitForData on top of the stack:
2020-10-13T09:18:55.3521680Z         goroutine 10959 [select]:
2020-10-13T09:18:55.3522332Z         github.com/libp2p/go-mplex.(*Stream).waitForData(0xc0026f12c0, 0xc002896900, 0x0)
2020-10-13T09:18:55.3523023Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:76 +0x1a9
2020-10-13T09:18:55.3523884Z         github.com/libp2p/go-mplex.(*Stream).Read(0xc0026f12c0, 0xc00285d000, 0x1000, 0x1000, 0xc00239f7a8, 0xdff823, 0x0)
2020-10-13T09:18:55.3524658Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:122 +0x3f5
2020-10-13T09:18:55.3525427Z         github.com/libp2p/go-libp2p-swarm.(*Stream).Read(0xc002881030, 0xc00285d000, 0x1000, 0x1000, 0xde431c, 0xdff55f, 0xc00284acd4)
2020-10-13T09:18:55.3526208Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_stream.go:71 +0x98
2020-10-13T09:18:55.3527233Z         github.com/multiformats/go-multistream.(*lazyClientConn).Read(0xc00284acb0, 0xc00285d000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.3528658Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-multistream@v0.1.2/lazyClient.go:75 +0x107
2020-10-13T09:18:55.3529665Z         github.com/libp2p/go-libp2p/p2p/host/basic.(*streamWrapper).Read(0xc0028582e0, 0xc00285d000, 0x1000, 0x1000, 0x0, 0xc00284acd0, 0x1)
2020-10-13T09:18:55.3530808Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p@v0.11.0/p2p/host/basic/basic_host.go:1008 +0x78
2020-10-13T09:18:55.3541846Z         bufio.(*Reader).fill(0xc002807f80)
2020-10-13T09:18:55.3542281Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/bufio/bufio.go:100 +0x19a
2020-10-13T09:18:55.3542700Z         bufio.(*Reader).ReadByte(0xc002807f80, 0xc00284acb0, 0xc0027f9880, 0x74)
2020-10-13T09:18:55.3543143Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/bufio/bufio.go:252 +0x5b
2020-10-13T09:18:55.3543983Z         github.com/multiformats/go-varint.ReadUvarint(0x39ff360, 0xc002807f80, 0x7c, 0x74, 0xc00285a3c0)
2020-10-13T09:18:55.3544776Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-varint@v0.0.6/varint.go:80 +0x85
2020-10-13T09:18:55.3545528Z         github.com/libp2p/go-msgio/protoio.(*uvarintReader).ReadMsg(0xc00285a1c0, 0x3a3ffe0, 0xc00285a3c0, 0x0, 0x0)
2020-10-13T09:18:55.3546338Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-msgio@v0.0.6/protoio/uvarint_reader.go:60 +0x73
2020-10-13T09:18:55.3547602Z         github.com/libp2p/go-libp2p-autonat.(*client).DialBack(0xc0028858e0, 0x3a4c760, 0xc002899380, 0xc0027aedb0, 0x22, 0x0, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.3548549Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/client.go:58 +0x4e8
2020-10-13T09:18:55.3549434Z         github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).probe(0xc003bee000, 0xc0026f5fb0)
2020-10-13T09:18:55.3550359Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:371 +0x23d
2020-10-13T09:18:55.3551639Z         created by github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).tryProbe
2020-10-13T09:18:55.3552426Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:360 +0x457
2020-10-13T09:18:55.3552799Z         
2020-10-13T09:18:55.3553431Z          Goroutine 8478 in state select, with github.com/libp2p/go-libp2p-swarm.(*DialBackoff).background on top of the stack:
2020-10-13T09:18:55.3553933Z         goroutine 8478 [select]:
2020-10-13T09:18:55.3554548Z         github.com/libp2p/go-libp2p-swarm.(*DialBackoff).background(0xc001722710, 0x3a4c6e0, 0xc003899380)
2020-10-13T09:18:55.3555316Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_dial.go:126 +0x1a1
2020-10-13T09:18:55.3555991Z         created by github.com/libp2p/go-libp2p-swarm.(*DialBackoff).init
2020-10-13T09:18:55.3556716Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_dial.go:119 +0x7b
2020-10-13T09:18:55.3557277Z         
2020-10-13T09:18:55.3558251Z          Goroutine 8484 in state select, with github.com/libp2p/go-libp2p-circuit.(*RelayListener).Accept on top of the stack:
2020-10-13T09:18:55.3558830Z         goroutine 8484 [select]:
2020-10-13T09:18:55.3559572Z         github.com/libp2p/go-libp2p-circuit.(*RelayListener).Accept(0xc0039a7f80, 0x0, 0x0, 0xc000652658, 0xdc2b75)
2020-10-13T09:18:55.3560971Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-circuit@v0.3.1/listen.go:27 +0x26a
2020-10-13T09:18:55.3561853Z         github.com/libp2p/go-libp2p-transport-upgrader.(*listener).handleIncoming(0xc003934000)
2020-10-13T09:18:55.3562835Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-transport-upgrader@v0.3.0/listener.go:77 +0x158
2020-10-13T09:18:55.3563947Z         created by github.com/libp2p/go-libp2p-transport-upgrader.(*Upgrader).UpgradeListener
2020-10-13T09:18:55.3564979Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-transport-upgrader@v0.3.0/upgrader.go:49 +0x336
2020-10-13T09:18:55.3565659Z         
2020-10-13T09:18:55.3566447Z          Goroutine 8572 in state chan receive, with github.com/libp2p/go-libp2p-transport-upgrader.(*listener).Accept on top of the stack:
2020-10-13T09:18:55.3567469Z         goroutine 8572 [chan receive]:
2020-10-13T09:18:55.3568384Z         github.com/libp2p/go-libp2p-transport-upgrader.(*listener).Accept(0xc003999620, 0x100000000, 0xc0020e7d50, 0xc001e0e748, 0x0)
2020-10-13T09:18:55.3569763Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-transport-upgrader@v0.3.0/listener.go:155 +0x73
2020-10-13T09:18:55.3571472Z         github.com/libp2p/go-libp2p-swarm.(*Swarm).AddListenAddr.func2(0x3a4d3e0, 0xc003999620, 0xc001722600, 0x3a74900, 0xc00384bf20)
2020-10-13T09:18:55.3576134Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_listen.go:84 +0x1a7
2020-10-13T09:18:55.3577055Z         created by github.com/libp2p/go-libp2p-swarm.(*Swarm).AddListenAddr
2020-10-13T09:18:55.3578327Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_listen.go:69 +0x328
2020-10-13T09:18:55.3578748Z         
2020-10-13T09:18:55.3579435Z          Goroutine 9727 in state select, with github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing on top of the stack:
2020-10-13T09:18:55.3579989Z         goroutine 9727 [select]:
2020-10-13T09:18:55.3580817Z         github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing(0xc003d16400)
2020-10-13T09:18:55.3581895Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:191 +0x158
2020-10-13T09:18:55.3582537Z         created by github.com/libp2p/go-mplex.NewMultiplex
2020-10-13T09:18:55.3583218Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:107 +0x3a2
2020-10-13T09:18:55.3583555Z         
2020-10-13T09:18:55.3584166Z          Goroutine 11427 in state select, with github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing on top of the stack:
2020-10-13T09:18:55.3585231Z         goroutine 11427 [select]:
2020-10-13T09:18:55.3586528Z         github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing(0xc002920100)
2020-10-13T09:18:55.3587514Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:191 +0x158
2020-10-13T09:18:55.3588386Z         created by github.com/libp2p/go-mplex.NewMultiplex
2020-10-13T09:18:55.3589775Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:107 +0x3a2
2020-10-13T09:18:55.3590513Z         
2020-10-13T09:18:55.3591170Z          Goroutine 11566 in state select, with github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing on top of the stack:
2020-10-13T09:18:55.3591680Z         goroutine 11566 [select]:
2020-10-13T09:18:55.3592498Z         github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing(0xc0028fa600)
2020-10-13T09:18:55.3593261Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:191 +0x158
2020-10-13T09:18:55.3593949Z         created by github.com/libp2p/go-mplex.NewMultiplex
2020-10-13T09:18:55.3594836Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:107 +0x3a2
2020-10-13T09:18:55.3595350Z         
2020-10-13T09:18:55.3595743Z          Goroutine 11899 in state semacquire, with sync.runtime_SemacquireMutex on top of the stack:
2020-10-13T09:18:55.3596199Z         goroutine 11899 [semacquire]:
2020-10-13T09:18:55.3596561Z         sync.runtime_SemacquireMutex(0xc002962f58, 0x900000000, 0x1)
2020-10-13T09:18:55.3597602Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/runtime/sema.go:71 +0x47
2020-10-13T09:18:55.3598018Z         sync.(*Mutex).lockSlow(0xc002962f54)
2020-10-13T09:18:55.3598434Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/sync/mutex.go:138 +0x1c1
2020-10-13T09:18:55.3598785Z         sync.(*Mutex).Lock(0xc002962f54)
2020-10-13T09:18:55.3599181Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/sync/mutex.go:81 +0x7d
2020-10-13T09:18:55.3599574Z         sync.(*Once).doSlow(0xc002962f50, 0xc0029508d0)
2020-10-13T09:18:55.3599992Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/sync/once.go:62 +0x5f
2020-10-13T09:18:55.3600529Z         sync.(*Once).Do(0xc002962f50, 0xc0029508d0)
2020-10-13T09:18:55.3601061Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/sync/once.go:57 +0x69
2020-10-13T09:18:55.3601797Z         created by github.com/multiformats/go-multistream.(*lazyClientConn).Write.func1
2020-10-13T09:18:55.3602649Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-multistream@v0.1.2/lazyClient.go:131 +0xce
2020-10-13T09:18:55.3603058Z         
2020-10-13T09:18:55.3603798Z          Goroutine 10296 in state select, with github.com/lucas-clemente/quic-go.(*incomingBidiStreamsMap).AcceptStream on top of the stack:
2020-10-13T09:18:55.3604472Z         goroutine 10296 [select]:
2020-10-13T09:18:55.3605283Z         github.com/lucas-clemente/quic-go.(*incomingBidiStreamsMap).AcceptStream(0xc003c98fc0, 0x3a4c720, 0xc00011c010, 0x0, 0x0, 0xc00274eb90, 0x10)
2020-10-13T09:18:55.3606260Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/streams_map_incoming_bidi.go:71 +0x239
2020-10-13T09:18:55.3607663Z         github.com/lucas-clemente/quic-go.(*streamsMap).AcceptStream(0xc00272a5c0, 0x3a4c720, 0xc00011c010, 0xc0014ade28, 0xdfd305, 0xe018a6, 0xc0014adec8)
2020-10-13T09:18:55.3608623Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/streams_map.go:127 +0x78
2020-10-13T09:18:55.3609558Z         github.com/lucas-clemente/quic-go.(*session).AcceptStream(0xc00302c840, 0x3a4c720, 0xc00011c010, 0xe017ce, 0x0, 0xdb7e6e, 0xc0014ade98)
2020-10-13T09:18:55.3610817Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/session.go:1635 +0x6e
2020-10-13T09:18:55.3616203Z         github.com/libp2p/go-libp2p-quic-transport.(*conn).AcceptStream(0xc0026b6180, 0x36b8990, 0xc0026b6200, 0x3a624c0, 0xc00274eb90)
2020-10-13T09:18:55.3618363Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-quic-transport@v0.8.1/conn.go:47 +0x87
2020-10-13T09:18:55.3619446Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc0026b6200)
2020-10-13T09:18:55.3620358Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.3621574Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.3622279Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.3622622Z         
2020-10-13T09:18:55.3623199Z          Goroutine 11173 in state select, with github.com/libp2p/go-mplex.(*Multiplex).Accept on top of the stack:
2020-10-13T09:18:55.3623648Z         goroutine 11173 [select]:
2020-10-13T09:18:55.3624214Z         github.com/libp2p/go-mplex.(*Multiplex).Accept(0xc00284f300, 0xc001722600, 0x100000000, 0x4300000000)
2020-10-13T09:18:55.3624908Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:129 +0x129
2020-10-13T09:18:55.3625668Z         github.com/libp2p/go-libp2p-mplex.(*conn).AcceptStream(0xc00284f300, 0x0, 0xdb7e6e, 0xc001316e98, 0xddf600)
2020-10-13T09:18:55.3626438Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-mplex@v0.2.4/conn.go:25 +0x3d
2020-10-13T09:18:55.3627538Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc0028bd700)
2020-10-13T09:18:55.3628723Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.3630957Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.3632940Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.3635012Z         
2020-10-13T09:18:55.3635404Z          Goroutine 8782 in state select, with go.uber.org/fx.withTimeout on top of the stack:
2020-10-13T09:18:55.3635831Z         goroutine 8782 [select]:
2020-10-13T09:18:55.3636212Z         go.uber.org/fx.withTimeout(0x3a4c720, 0xc00011c010, 0xc002cc4280, 0x0, 0x0)
2020-10-13T09:18:55.3636706Z         	/home/runner/go/pkg/mod/go.uber.org/fx@v1.13.1/app.go:747 +0x161
2020-10-13T09:18:55.3637716Z         go.uber.org/fx.(*App).Stop(0xc003c02180, 0x3a4c720, 0xc00011c010, 0x0, 0xc0020331a0)
2020-10-13T09:18:55.3638187Z         	/home/runner/go/pkg/mod/go.uber.org/fx@v1.13.1/app.go:572 +0xe6
2020-10-13T09:18:55.3638919Z         github.com/ipfs/go-ipfs/core.NewNode.func1.1()
2020-10-13T09:18:55.3640069Z         	/home/runner/go/pkg/mod/github.com/ipfs/go-ipfs@v0.7.0/core/builder.go:52 +0xa4
2020-10-13T09:18:55.3640554Z         sync.(*Once).doSlow(0xc00084d470, 0xc002085e88)
2020-10-13T09:18:55.3641337Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/sync/once.go:66 +0x104
2020-10-13T09:18:55.3641876Z         sync.(*Once).Do(0xc00084d470, 0xc002085e88)
2020-10-13T09:18:55.3642279Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/sync/once.go:57 +0x69
2020-10-13T09:18:55.3643308Z         github.com/ipfs/go-ipfs/core.NewNode.func1(0xc0013591d0, 0xc002085f10)
2020-10-13T09:18:55.3644013Z         	/home/runner/go/pkg/mod/github.com/ipfs/go-ipfs@v0.7.0/core/builder.go:51 +0x89
2020-10-13T09:18:55.3644767Z         github.com/ipfs/go-ipfs/core.NewNode.func2(0x3a4c6e0, 0xc003127640, 0xc001358fc0, 0x3a4c7a0, 0xc00301f680)
2020-10-13T09:18:55.3645524Z         	/home/runner/go/pkg/mod/github.com/ipfs/go-ipfs@v0.7.0/core/builder.go:69 +0x17e
2020-10-13T09:18:55.3646122Z         created by github.com/ipfs/go-ipfs/core.NewNode
2020-10-13T09:18:55.3646745Z         	/home/runner/go/pkg/mod/github.com/ipfs/go-ipfs@v0.7.0/core/builder.go:63 +0x577
2020-10-13T09:18:55.3647276Z         
2020-10-13T09:18:55.3648328Z          Goroutine 10624 in state select, with github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing on top of the stack:
2020-10-13T09:18:55.3648871Z         goroutine 10624 [select]:
2020-10-13T09:18:55.3649475Z         github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing(0xc002799f80)
2020-10-13T09:18:55.3650258Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:191 +0x158
2020-10-13T09:18:55.3651302Z         created by github.com/libp2p/go-mplex.NewMultiplex
2020-10-13T09:18:55.3652175Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:107 +0x3a2
2020-10-13T09:18:55.3652517Z         
2020-10-13T09:18:55.3653140Z          Goroutine 10441 in state select, with github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing on top of the stack:
2020-10-13T09:18:55.3653599Z         goroutine 10441 [select]:
2020-10-13T09:18:55.3654131Z         github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing(0xc002798680)
2020-10-13T09:18:55.3654829Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:191 +0x158
2020-10-13T09:18:55.3655475Z         created by github.com/libp2p/go-mplex.NewMultiplex
2020-10-13T09:18:55.3656158Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:107 +0x3a2
2020-10-13T09:18:55.3656496Z         
2020-10-13T09:18:55.3657576Z          Goroutine 8550 in state select, with github.com/libp2p/go-libp2p-swarm.(*DialBackoff).background on top of the stack:
2020-10-13T09:18:55.3658115Z         goroutine 8550 [select]:
2020-10-13T09:18:55.3658789Z         github.com/libp2p/go-libp2p-swarm.(*DialBackoff).background(0xc001722d10, 0x3a4c6e0, 0xc0038e0c80)
2020-10-13T09:18:55.3659651Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_dial.go:126 +0x1a1
2020-10-13T09:18:55.3660538Z         created by github.com/libp2p/go-libp2p-swarm.(*DialBackoff).init
2020-10-13T09:18:55.3661540Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_dial.go:119 +0x7b
2020-10-13T09:18:55.3661916Z         
2020-10-13T09:18:55.3662652Z          Goroutine 10284 in state chan receive, with github.com/libp2p/go-libp2p-quic-transport.(*transport).Dial.func1 on top of the stack:
2020-10-13T09:18:55.3663230Z         goroutine 10284 [chan receive]:
2020-10-13T09:18:55.3663941Z         github.com/libp2p/go-libp2p-quic-transport.(*transport).Dial.func1(0x7fab883e9a48, 0xc00302c840, 0xc003872400)
2020-10-13T09:18:55.3664869Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-quic-transport@v0.8.1/transport.go:175 +0x6a
2020-10-13T09:18:55.3665673Z         created by github.com/libp2p/go-libp2p-quic-transport.(*transport).Dial
2020-10-13T09:18:55.3666530Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-quic-transport@v0.8.1/transport.go:174 +0x397
2020-10-13T09:18:55.3667154Z         
2020-10-13T09:18:55.3668110Z          Goroutine 8480 in state chan receive, with github.com/libp2p/go-libp2p/p2p/protocol/identify.(*IDService).loop.func1 on top of the stack:
2020-10-13T09:18:55.3669026Z         goroutine 8480 [chan receive]:
2020-10-13T09:18:55.3669848Z         github.com/libp2p/go-libp2p/p2p/protocol/identify.(*IDService).loop.func1(0x3a1be20, 0xc002f85da0, 0xc0039bdda0, 0xc003cda420)
2020-10-13T09:18:55.3670969Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p@v0.11.0/p2p/protocol/identify/id.go:193 +0xae
2020-10-13T09:18:55.3671718Z         github.com/libp2p/go-libp2p/p2p/protocol/identify.(*IDService).loop(0xc003ab9790)
2020-10-13T09:18:55.3672657Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p@v0.11.0/p2p/protocol/identify/id.go:269 +0xd2b
2020-10-13T09:18:55.3673394Z         created by github.com/libp2p/go-libp2p/p2p/protocol/identify.NewIDService
2020-10-13T09:18:55.3674182Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p@v0.11.0/p2p/protocol/identify/id.go:151 +0x504
2020-10-13T09:18:55.3674541Z         
2020-10-13T09:18:55.3675156Z          Goroutine 10691 in state select, with github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing on top of the stack:
2020-10-13T09:18:55.3675639Z         goroutine 10691 [select]:
2020-10-13T09:18:55.3676359Z         github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing(0xc0026ee200)
2020-10-13T09:18:55.3677740Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:191 +0x158
2020-10-13T09:18:55.3678471Z         created by github.com/libp2p/go-mplex.NewMultiplex
2020-10-13T09:18:55.3679259Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:107 +0x3a2
2020-10-13T09:18:55.3679649Z         
2020-10-13T09:18:55.3680757Z          Goroutine 8551 in state select, with github.com/libp2p/go-libp2p-autonat.(*autoNATService).background on top of the stack:
2020-10-13T09:18:55.3681467Z         goroutine 8551 [select]:
2020-10-13T09:18:55.3682126Z         github.com/libp2p/go-libp2p-autonat.(*autoNATService).background(0xc003a955e0, 0x3a4c6e0, 0xc0038e0f80)
2020-10-13T09:18:55.3682947Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/svc.go:218 +0x3c4
2020-10-13T09:18:55.3683671Z         created by github.com/libp2p/go-libp2p-autonat.(*autoNATService).Enable
2020-10-13T09:18:55.3684404Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/svc.go:198 +0x172
2020-10-13T09:18:55.3684756Z         
2020-10-13T09:18:55.3685463Z          Goroutine 9266 in state chan receive, with github.com/libp2p/go-libp2p-quic-transport.(*transport).Dial.func1 on top of the stack:
2020-10-13T09:18:55.3686083Z         goroutine 9266 [chan receive]:
2020-10-13T09:18:55.3686997Z         github.com/libp2p/go-libp2p-quic-transport.(*transport).Dial.func1(0x7fab883e9a48, 0xc002d82dc0, 0xc003872400)
2020-10-13T09:18:55.3688463Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-quic-transport@v0.8.1/transport.go:175 +0x6a
2020-10-13T09:18:55.3689360Z         created by github.com/libp2p/go-libp2p-quic-transport.(*transport).Dial
2020-10-13T09:18:55.3690406Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-quic-transport@v0.8.1/transport.go:174 +0x397
2020-10-13T09:18:55.3691075Z         
2020-10-13T09:18:55.3703854Z          Goroutine 11577 in state select, with github.com/libp2p/go-mplex.(*Multiplex).Accept on top of the stack:
2020-10-13T09:18:55.3704483Z         goroutine 11577 [select]:
2020-10-13T09:18:55.3705162Z         github.com/libp2p/go-mplex.(*Multiplex).Accept(0xc0028fa600, 0xc001722600, 0x100000000, 0x4d00000000)
2020-10-13T09:18:55.3706269Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:129 +0x129
2020-10-13T09:18:55.3707514Z         github.com/libp2p/go-libp2p-mplex.(*conn).AcceptStream(0xc0028fa600, 0x0, 0xdb7e6e, 0xc002118e98, 0xddf600)
2020-10-13T09:18:55.3708414Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-mplex@v0.2.4/conn.go:25 +0x3d
2020-10-13T09:18:55.3709325Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc002920780)
2020-10-13T09:18:55.3710317Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.3711346Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.3712050Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.3712412Z         
2020-10-13T09:18:55.3712977Z          Goroutine 9495 in state select, with github.com/libp2p/go-mplex.(*Stream).waitForData on top of the stack:
2020-10-13T09:18:55.3713428Z         goroutine 9495 [select]:
2020-10-13T09:18:55.3713981Z         github.com/libp2p/go-mplex.(*Stream).waitForData(0xc003b77b00, 0xc0023cb380, 0x0)
2020-10-13T09:18:55.3714666Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:76 +0x1a9
2020-10-13T09:18:55.3715394Z         github.com/libp2p/go-mplex.(*Stream).Read(0xc003b77b00, 0xc003c37c30, 0x1, 0x1, 0xc00231d8b0, 0xd8b543, 0xc00231d8b0)
2020-10-13T09:18:55.3716329Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:122 +0x3f5
2020-10-13T09:18:55.3717307Z         github.com/libp2p/go-libp2p-swarm.(*Stream).Read(0xc0038ca5b0, 0xc003c37c30, 0x1, 0x1, 0x3, 0xc003d24480, 0xc0024062f8)
2020-10-13T09:18:55.3718681Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_stream.go:71 +0x98
2020-10-13T09:18:55.3720205Z         github.com/multiformats/go-multistream.(*lazyServerConn).Read(0xc00235cc60, 0xc003c37c30, 0x1, 0x1, 0xc0000709e8, 0x1ee3ed4, 0xc0000709a8)
2020-10-13T09:18:55.3722125Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-multistream@v0.1.2/lazyServer.go:32 +0xa8
2020-10-13T09:18:55.3722984Z         github.com/libp2p/go-libp2p/p2p/host/basic.(*streamWrapper).Read(0xc003c37b80, 0xc003c37c30, 0x1, 0x1, 0x1, 0xc00231da68, 0x2ce72c0)
2020-10-13T09:18:55.3723802Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p@v0.11.0/p2p/host/basic/basic_host.go:1008 +0x78
2020-10-13T09:18:55.3724355Z         io.ReadAtLeast(0x7fab883923a0, 0xc003c37b80, 0xc003c37c30, 0x1, 0x1, 0x1, 0x2ce72c0, 0x39c8490, 0x2f76280)
2020-10-13T09:18:55.3724818Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/io/io.go:310 +0x99
2020-10-13T09:18:55.3725128Z         io.ReadFull(...)
2020-10-13T09:18:55.3725454Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/io/io.go:329
2020-10-13T09:18:55.3726171Z         github.com/libp2p/go-msgio.(*simpleByteReader).ReadByte(0xc003c37c20, 0x2ce2ec0, 0xc00231dad8, 0xdc6c3c)
2020-10-13T09:18:55.3727132Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-msgio@v0.0.6/varint.go:185 +0x82
2020-10-13T09:18:55.3728238Z         github.com/multiformats/go-varint.ReadUvarint(0x3a00860, 0xc003c37c20, 0xdbddba, 0xc0020e8480, 0xc003bbccf0)
2020-10-13T09:18:55.3729180Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-varint@v0.0.6/varint.go:80 +0x85
2020-10-13T09:18:55.3730063Z         github.com/libp2p/go-msgio.(*varintReader).nextMsgLen(0xc003bbccc0, 0x597ec40, 0x597ec40, 0xc0023e9fb0)
2020-10-13T09:18:55.3731355Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-msgio@v0.0.6/varint.go:119 +0xb9
2020-10-13T09:18:55.3732405Z         github.com/libp2p/go-msgio.(*varintReader).ReadMsg(0xc003bbccc0, 0x0, 0x0, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.3733161Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-msgio@v0.0.6/varint.go:149 +0xcc
2020-10-13T09:18:55.3734213Z         github.com/ipfs/go-bitswap/message.FromMsgReader(0x7fab477205c8, 0xc003bbccc0, 0xc003bbccc0, 0x7fab477205c8, 0xc003bbccc0, 0x3a7c220)
2020-10-13T09:18:55.3735107Z         	/home/runner/go/pkg/mod/github.com/ipfs/go-bitswap@v0.2.20/message/message.go:404 +0x5d
2020-10-13T09:18:55.3735857Z         github.com/ipfs/go-bitswap/network.(*impl).handleNewStream(0xc0014a70e0, 0x3a72700, 0xc003c37b80)
2020-10-13T09:18:55.3736625Z         	/home/runner/go/pkg/mod/github.com/ipfs/go-bitswap@v0.2.20/network/ipfs_impl.go:391 +0x5a8
2020-10-13T09:18:55.3738217Z         github.com/libp2p/go-libp2p/p2p/host/basic.(*BasicHost).SetStreamHandler.func1(0xc003ac1040, 0x13, 0x7fab883e9b88, 0xc003c37b80, 0x1, 0x0)
2020-10-13T09:18:55.3739272Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p@v0.11.0/p2p/host/basic/basic_host.go:566 +0xb5
2020-10-13T09:18:55.3740267Z         created by github.com/libp2p/go-libp2p/p2p/host/basic.(*BasicHost).newStreamHandler
2020-10-13T09:18:55.3749478Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p@v0.11.0/p2p/host/basic/basic_host.go:416 +0x799
2020-10-13T09:18:55.3749920Z         
2020-10-13T09:18:55.3750678Z          Goroutine 10573 in state select, with github.com/libp2p/go-mplex.(*Multiplex).Accept on top of the stack:
2020-10-13T09:18:55.3751852Z         goroutine 10573 [select]:
2020-10-13T09:18:55.3752439Z         github.com/libp2p/go-mplex.(*Multiplex).Accept(0xc0026b7d00, 0xc001722600, 0x100000000, 0x2c00000000)
2020-10-13T09:18:55.3753357Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:129 +0x129
2020-10-13T09:18:55.3754132Z         github.com/libp2p/go-libp2p-mplex.(*conn).AcceptStream(0xc0026b7d00, 0x0, 0xdb7e6e, 0xc0020f1e98, 0xddf600)
2020-10-13T09:18:55.3754916Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-mplex@v0.2.4/conn.go:25 +0x3d
2020-10-13T09:18:55.3755779Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc0026b7d80)
2020-10-13T09:18:55.3757952Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.3758866Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.3759868Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.3760282Z         
2020-10-13T09:18:55.3761223Z          Goroutine 9524 in state select, with github.com/lucas-clemente/quic-go.(*incomingBidiStreamsMap).AcceptStream on top of the stack:
2020-10-13T09:18:55.3761813Z         goroutine 9524 [select]:
2020-10-13T09:18:55.3762589Z         github.com/lucas-clemente/quic-go.(*incomingBidiStreamsMap).AcceptStream(0xc0037f5c70, 0x3a4c720, 0xc00011c010, 0x0, 0x0, 0xc003bc41d0, 0x10)
2020-10-13T09:18:55.3763566Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/streams_map_incoming_bidi.go:71 +0x239
2020-10-13T09:18:55.3764505Z         github.com/lucas-clemente/quic-go.(*streamsMap).AcceptStream(0xc003b50140, 0x3a4c720, 0xc00011c010, 0xc002b40e28, 0xdfd305, 0xe018a6, 0xc002b40ec8)
2020-10-13T09:18:55.3765385Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/streams_map.go:127 +0x78
2020-10-13T09:18:55.3766243Z         github.com/lucas-clemente/quic-go.(*session).AcceptStream(0xc002d83080, 0x3a4c720, 0xc00011c010, 0xe017ce, 0x0, 0xdb7e6e, 0xc002b40e98)
2020-10-13T09:18:55.3767511Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/session.go:1635 +0x6e
2020-10-13T09:18:55.3768527Z         github.com/libp2p/go-libp2p-quic-transport.(*conn).AcceptStream(0xc003c2e800, 0x36b8990, 0xc003c2e880, 0x3a624c0, 0xc003bc41d0)
2020-10-13T09:18:55.3769912Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-quic-transport@v0.8.1/conn.go:47 +0x87
2020-10-13T09:18:55.3771159Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc003c2e880)
2020-10-13T09:18:55.3794024Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.3795234Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.3796423Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.3796996Z         
2020-10-13T09:18:55.3797885Z          Goroutine 8575 in state select, with github.com/lucas-clemente/quic-go.(*baseServer).run on top of the stack:
2020-10-13T09:18:55.3798464Z         goroutine 8575 [select]:
2020-10-13T09:18:55.3799272Z         github.com/lucas-clemente/quic-go.(*baseServer).run(0xc001f191e0)
2020-10-13T09:18:55.3800107Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/server.go:221 +0x1e5
2020-10-13T09:18:55.3801355Z         created by github.com/lucas-clemente/quic-go.listen
2020-10-13T09:18:55.3802080Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/server.go:207 +0x8b9
2020-10-13T09:18:55.3802595Z         
2020-10-13T09:18:55.3803215Z          Goroutine 10764 in state select, with github.com/libp2p/go-mplex.(*Multiplex).Accept on top of the stack:
2020-10-13T09:18:55.3803665Z         goroutine 10764 [select]:
2020-10-13T09:18:55.3804229Z         github.com/libp2p/go-mplex.(*Multiplex).Accept(0xc002799f80, 0xc001722600, 0x100000000, 0x3b00000000)
2020-10-13T09:18:55.3804951Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:129 +0x129
2020-10-13T09:18:55.3805727Z         github.com/libp2p/go-libp2p-mplex.(*conn).AcceptStream(0xc002799f80, 0x0, 0xdb7e6e, 0xc001310698, 0xddf600)
2020-10-13T09:18:55.3806514Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-mplex@v0.2.4/conn.go:25 +0x3d
2020-10-13T09:18:55.3807627Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc002808000)
2020-10-13T09:18:55.3808467Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.3809232Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.3810038Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.3810614Z         
2020-10-13T09:18:55.3811448Z          Goroutine 8546 in state select, with github.com/libp2p/go-libp2p/p2p/host/relay.(*AutoRelay).background on top of the stack:
2020-10-13T09:18:55.3812173Z         goroutine 8546 [select]:
2020-10-13T09:18:55.3812838Z         github.com/libp2p/go-libp2p/p2p/host/relay.(*AutoRelay).background(0xc001e5adc0, 0x3a4c6e0, 0xc003899380)
2020-10-13T09:18:55.3813667Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p@v0.11.0/p2p/host/relay/autorelay.go:88 +0x2b4
2020-10-13T09:18:55.3814384Z         created by github.com/libp2p/go-libp2p/p2p/host/relay.NewAutoRelay
2020-10-13T09:18:55.3815166Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p@v0.11.0/p2p/host/relay/autorelay.go:72 +0x390
2020-10-13T09:18:55.3815548Z         
2020-10-13T09:18:55.3816135Z          Goroutine 10651 in state select, with github.com/libp2p/go-mplex.(*Multiplex).Accept on top of the stack:
2020-10-13T09:18:55.3816583Z         goroutine 10651 [select]:
2020-10-13T09:18:55.3817586Z         github.com/libp2p/go-mplex.(*Multiplex).Accept(0xc0026ee000, 0xc001722600, 0x100000000, 0x3100000000)
2020-10-13T09:18:55.3818395Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:129 +0x129
2020-10-13T09:18:55.3819274Z         github.com/libp2p/go-libp2p-mplex.(*conn).AcceptStream(0xc0026ee000, 0x0, 0xdb7e6e, 0xc00208b698, 0xddf600)
2020-10-13T09:18:55.3820163Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-mplex@v0.2.4/conn.go:25 +0x3d
2020-10-13T09:18:55.3821472Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc0026ee080)
2020-10-13T09:18:55.3822332Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.3823043Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.3823745Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.3824104Z         
2020-10-13T09:18:55.3824680Z          Goroutine 9831 in state select, with github.com/libp2p/go-mplex.(*Stream).waitForData on top of the stack:
2020-10-13T09:18:55.3825130Z         goroutine 9831 [select]:
2020-10-13T09:18:55.3825688Z         github.com/libp2p/go-mplex.(*Stream).waitForData(0xc003cfd380, 0xc00243ad80, 0x0)
2020-10-13T09:18:55.3826372Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:76 +0x1a9
2020-10-13T09:18:55.3827522Z         github.com/libp2p/go-mplex.(*Stream).Read(0xc003cfd380, 0xc0024e9000, 0x1000, 0x1000, 0xc001fbf7a8, 0xdff823, 0x0)
2020-10-13T09:18:55.3828334Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:122 +0x3f5
2020-10-13T09:18:55.3829362Z         github.com/libp2p/go-libp2p-swarm.(*Stream).Read(0xc003955260, 0xc0024e9000, 0x1000, 0x1000, 0xde431c, 0xdff55f, 0xc003a68db4)
2020-10-13T09:18:55.3830287Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_stream.go:71 +0x98
2020-10-13T09:18:55.3831672Z         github.com/multiformats/go-multistream.(*lazyClientConn).Read(0xc003a68d90, 0xc0024e9000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.3832581Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-multistream@v0.1.2/lazyClient.go:75 +0x107
2020-10-13T09:18:55.3833482Z         github.com/libp2p/go-libp2p/p2p/host/basic.(*streamWrapper).Read(0xc003dd2640, 0xc0024e9000, 0x1000, 0x1000, 0x0, 0xc003a68db0, 0x1)
2020-10-13T09:18:55.3834340Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p@v0.11.0/p2p/host/basic/basic_host.go:1008 +0x78
2020-10-13T09:18:55.3834958Z         bufio.(*Reader).fill(0xc003df1620)
2020-10-13T09:18:55.3835345Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/bufio/bufio.go:100 +0x19a
2020-10-13T09:18:55.3835775Z         bufio.(*Reader).ReadByte(0xc003df1620, 0xc003a68d90, 0xc0037b9b90, 0x5d)
2020-10-13T09:18:55.3836223Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/bufio/bufio.go:252 +0x5b
2020-10-13T09:18:55.3837174Z         github.com/multiformats/go-varint.ReadUvarint(0x39ff360, 0xc003df1620, 0xc003d8b340, 0x5d, 0xc003d8b340)
2020-10-13T09:18:55.3838499Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-varint@v0.0.6/varint.go:80 +0x85
2020-10-13T09:18:55.3839393Z         github.com/libp2p/go-msgio/protoio.(*uvarintReader).ReadMsg(0xc003d8b100, 0x3a3ffe0, 0xc003d8b340, 0x0, 0x0)
2020-10-13T09:18:55.3840316Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-msgio@v0.0.6/protoio/uvarint_reader.go:60 +0x73
2020-10-13T09:18:55.3841526Z         github.com/libp2p/go-libp2p-autonat.(*client).DialBack(0xc00243dee0, 0x3a4c760, 0xc002439c80, 0xc002425b60, 0x22, 0x0, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.3842342Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/client.go:58 +0x4e8
2020-10-13T09:18:55.3843110Z         github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).probe(0xc003bee000, 0xc002446930)
2020-10-13T09:18:55.3843905Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:371 +0x23d
2020-10-13T09:18:55.3844645Z         created by github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).tryProbe
2020-10-13T09:18:55.3845425Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:360 +0x457
2020-10-13T09:18:55.3845794Z         
2020-10-13T09:18:55.3846500Z          Goroutine 9095 in state chan receive, with github.com/libp2p/go-libp2p-quic-transport.(*transport).Dial.func1 on top of the stack:
2020-10-13T09:18:55.3847261Z         goroutine 9095 [chan receive]:
2020-10-13T09:18:55.3848487Z         github.com/libp2p/go-libp2p-quic-transport.(*transport).Dial.func1(0x7fab883e9a48, 0xc0039f6000, 0xc003872400)
2020-10-13T09:18:55.3849654Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-quic-transport@v0.8.1/transport.go:175 +0x6a
2020-10-13T09:18:55.3850812Z         created by github.com/libp2p/go-libp2p-quic-transport.(*transport).Dial
2020-10-13T09:18:55.3852237Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-quic-transport@v0.8.1/transport.go:174 +0x397
2020-10-13T09:18:55.3852676Z         
2020-10-13T09:18:55.3853271Z          Goroutine 9751 in state select, with github.com/libp2p/go-mplex.(*Multiplex).Accept on top of the stack:
2020-10-13T09:18:55.3853708Z         goroutine 9751 [select]:
2020-10-13T09:18:55.3854273Z         github.com/libp2p/go-mplex.(*Multiplex).Accept(0xc003d16400, 0xc001722600, 0x100000000, 0x1a00000000)
2020-10-13T09:18:55.3854973Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:129 +0x129
2020-10-13T09:18:55.3855723Z         github.com/libp2p/go-libp2p-mplex.(*conn).AcceptStream(0xc003d16400, 0x0, 0xdb7e6e, 0xc001311698, 0xddf600)
2020-10-13T09:18:55.3856473Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-mplex@v0.2.4/conn.go:25 +0x3d
2020-10-13T09:18:55.3857932Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc003d16480)
2020-10-13T09:18:55.3858775Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.3859522Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.3860325Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.3861077Z         
2020-10-13T09:18:55.3861924Z          Goroutine 8554 in state select, with github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).background on top of the stack:
2020-10-13T09:18:55.3862452Z         goroutine 8554 [select]:
2020-10-13T09:18:55.3863050Z         github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).background(0xc003bee000)
2020-10-13T09:18:55.3863854Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:175 +0x48b
2020-10-13T09:18:55.3864508Z         created by github.com/libp2p/go-libp2p-autonat.New
2020-10-13T09:18:55.3865229Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:125 +0xa7f
2020-10-13T09:18:55.3865601Z         
2020-10-13T09:18:55.3866180Z          Goroutine 10964 in state select, with github.com/libp2p/go-mplex.(*Stream).waitForData on top of the stack:
2020-10-13T09:18:55.3866629Z         goroutine 10964 [select]:
2020-10-13T09:18:55.3867637Z         github.com/libp2p/go-mplex.(*Stream).waitForData(0xc0027952c0, 0xc0027efc80, 0x0)
2020-10-13T09:18:55.3868423Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:76 +0x1a9
2020-10-13T09:18:55.3869230Z         github.com/libp2p/go-mplex.(*Stream).Read(0xc0027952c0, 0xc002838000, 0x1000, 0x1000, 0xc0025f37b0, 0x1a0ec1c, 0x0)
2020-10-13T09:18:55.3870031Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:122 +0x3f5
2020-10-13T09:18:55.3871570Z         github.com/libp2p/go-libp2p-swarm.(*Stream).Read(0xc002826ee0, 0xc002838000, 0x1000, 0x1000, 0xde431c, 0xdff55f, 0xc002826fe4)
2020-10-13T09:18:55.3872418Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_stream.go:71 +0x98
2020-10-13T09:18:55.3873256Z         github.com/multiformats/go-multistream.(*lazyClientConn).Read(0xc002826fc0, 0xc002838000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.3874155Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-multistream@v0.1.2/lazyClient.go:75 +0x107
2020-10-13T09:18:55.3875180Z         github.com/libp2p/go-libp2p/p2p/host/basic.(*streamWrapper).Read(0xc002836080, 0xc002838000, 0x1000, 0x1000, 0x0, 0xc002826fe0, 0x1)
2020-10-13T09:18:55.3875978Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p@v0.11.0/p2p/host/basic/basic_host.go:1008 +0x78
2020-10-13T09:18:55.3876397Z         bufio.(*Reader).fill(0xc0028075c0)
2020-10-13T09:18:55.3877057Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/bufio/bufio.go:100 +0x19a
2020-10-13T09:18:55.3877746Z         bufio.(*Reader).ReadByte(0xc0028075c0, 0xc002826fc0, 0xc0027f9700, 0x74)
2020-10-13T09:18:55.3878249Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/bufio/bufio.go:252 +0x5b
2020-10-13T09:18:55.3879097Z         github.com/multiformats/go-varint.ReadUvarint(0x39ff360, 0xc0028075c0, 0x7c, 0x74, 0xc002815500)
2020-10-13T09:18:55.3879990Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-varint@v0.0.6/varint.go:80 +0x85
2020-10-13T09:18:55.3881159Z         github.com/libp2p/go-msgio/protoio.(*uvarintReader).ReadMsg(0xc002815300, 0x3a3ffe0, 0xc002815500, 0x0, 0x0)
2020-10-13T09:18:55.3881920Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-msgio@v0.0.6/protoio/uvarint_reader.go:60 +0x73
2020-10-13T09:18:55.3884363Z         github.com/libp2p/go-libp2p-autonat.(*client).DialBack(0xc00281ffe0, 0x3a4c760, 0xc0028073e0, 0xc0027ae660, 0x22, 0x0, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.3885221Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/client.go:58 +0x4e8
2020-10-13T09:18:55.3886202Z         github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).probe(0xc003bee000, 0xc00282a540)
2020-10-13T09:18:55.3887204Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:371 +0x23d
2020-10-13T09:18:55.3888551Z         created by github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).tryProbe
2020-10-13T09:18:55.3889462Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:360 +0x457
2020-10-13T09:18:55.3889892Z         
2020-10-13T09:18:55.3890603Z          Goroutine 10834 in state select, with github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing on top of the stack:
2020-10-13T09:18:55.3891610Z         goroutine 10834 [select]:
2020-10-13T09:18:55.3892340Z         github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing(0xc002808780)
2020-10-13T09:18:55.3893033Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:191 +0x158
2020-10-13T09:18:55.3893675Z         created by github.com/libp2p/go-mplex.NewMultiplex
2020-10-13T09:18:55.3894369Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:107 +0x3a2
2020-10-13T09:18:55.3894709Z         
2020-10-13T09:18:55.3895270Z          Goroutine 9445 in state select, with github.com/libp2p/go-mplex.(*Multiplex).Accept on top of the stack:
2020-10-13T09:18:55.3895710Z         goroutine 9445 [select]:
2020-10-13T09:18:55.3896283Z         github.com/libp2p/go-mplex.(*Multiplex).Accept(0xc003c2e580, 0xc001722600, 0x100000000, 0x1b00000000)
2020-10-13T09:18:55.3897187Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:129 +0x129
2020-10-13T09:18:55.3899391Z         github.com/libp2p/go-libp2p-mplex.(*conn).AcceptStream(0xc003c2e580, 0x0, 0xdb7e6e, 0xc003c87e98, 0xddf600)
2020-10-13T09:18:55.3900483Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-mplex@v0.2.4/conn.go:25 +0x3d
2020-10-13T09:18:55.3901695Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc003c2e600)
2020-10-13T09:18:55.3902608Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.3903260Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.3903956Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.3904319Z         
2020-10-13T09:18:55.3905054Z          Goroutine 9306 in state select, with github.com/lucas-clemente/quic-go.(*incomingBidiStreamsMap).AcceptStream on top of the stack:
2020-10-13T09:18:55.3905649Z         goroutine 9306 [select]:
2020-10-13T09:18:55.3906437Z         github.com/lucas-clemente/quic-go.(*incomingBidiStreamsMap).AcceptStream(0xc00326df10, 0x3a4c720, 0xc00011c010, 0x0, 0x0, 0xc003aaa980, 0x10)
2020-10-13T09:18:55.3907898Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/streams_map_incoming_bidi.go:71 +0x239
2020-10-13T09:18:55.3909115Z         github.com/lucas-clemente/quic-go.(*streamsMap).AcceptStream(0xc003ade740, 0x3a4c720, 0xc00011c010, 0xc00006fe28, 0xdfd305, 0xe018a6, 0xc00006fec8)
2020-10-13T09:18:55.3910198Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/streams_map.go:127 +0x78
2020-10-13T09:18:55.3911492Z         github.com/lucas-clemente/quic-go.(*session).AcceptStream(0xc002d82dc0, 0x3a4c720, 0xc00011c010, 0xe017ce, 0x0, 0xdb7e6e, 0xc00006fe98)
2020-10-13T09:18:55.3912620Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/session.go:1635 +0x6e
2020-10-13T09:18:55.3913575Z         github.com/libp2p/go-libp2p-quic-transport.(*conn).AcceptStream(0xc003b90c00, 0x36b8990, 0xc003b90c80, 0x3a624c0, 0xc003aaa980)
2020-10-13T09:18:55.3914903Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-quic-transport@v0.8.1/conn.go:47 +0x87
2020-10-13T09:18:55.3915635Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc003b90c80)
2020-10-13T09:18:55.3916370Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.3917571Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.3918381Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.3918792Z         
2020-10-13T09:18:55.3919641Z          Goroutine 9129 in state select, with github.com/lucas-clemente/quic-go.(*incomingBidiStreamsMap).AcceptStream on top of the stack:
2020-10-13T09:18:55.3920323Z         goroutine 9129 [select]:
2020-10-13T09:18:55.3932447Z         github.com/lucas-clemente/quic-go.(*incomingBidiStreamsMap).AcceptStream(0xc003043ce0, 0x3a4c720, 0xc00011c010, 0x0, 0x0, 0xc003827f20, 0x10)
2020-10-13T09:18:55.3933766Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/streams_map_incoming_bidi.go:71 +0x239
2020-10-13T09:18:55.3934952Z         github.com/lucas-clemente/quic-go.(*streamsMap).AcceptStream(0xc003a0b440, 0x3a4c720, 0xc00011c010, 0xc00380fe28, 0xdfd305, 0xe018a6, 0xc00380fec8)
2020-10-13T09:18:55.3936088Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/streams_map.go:127 +0x78
2020-10-13T09:18:55.3937180Z         github.com/lucas-clemente/quic-go.(*session).AcceptStream(0xc0039f6000, 0x3a4c720, 0xc00011c010, 0xe017ce, 0x0, 0xdb7e6e, 0xc00380fe98)
2020-10-13T09:18:55.3938601Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/session.go:1635 +0x6e
2020-10-13T09:18:55.3939574Z         github.com/libp2p/go-libp2p-quic-transport.(*conn).AcceptStream(0xc003966e00, 0x36b8990, 0xc003a19180, 0x3a624c0, 0xc003827f20)
2020-10-13T09:18:55.3940960Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-quic-transport@v0.8.1/conn.go:47 +0x87
2020-10-13T09:18:55.3941974Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc003a19180)
2020-10-13T09:18:55.3942763Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.3943476Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.3944424Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.3945182Z         
2020-10-13T09:18:55.3945928Z          Goroutine 9506 in state chan receive, with github.com/libp2p/go-libp2p-quic-transport.(*transport).Dial.func1 on top of the stack:
2020-10-13T09:18:55.3946520Z         goroutine 9506 [chan receive]:
2020-10-13T09:18:55.3947839Z         github.com/libp2p/go-libp2p-quic-transport.(*transport).Dial.func1(0x7fab883e9a48, 0xc002d83080, 0xc003872400)
2020-10-13T09:18:55.3949088Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-quic-transport@v0.8.1/transport.go:175 +0x6a
2020-10-13T09:18:55.3950014Z         created by github.com/libp2p/go-libp2p-quic-transport.(*transport).Dial
2020-10-13T09:18:55.3951661Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-quic-transport@v0.8.1/transport.go:174 +0x397
2020-10-13T09:18:55.3952450Z         
2020-10-13T09:18:55.3953113Z          Goroutine 13023 in state select, with github.com/libp2p/go-mplex.(*Multiplex).Accept on top of the stack:
2020-10-13T09:18:55.3953577Z         goroutine 13023 [select]:
2020-10-13T09:18:55.3954178Z         github.com/libp2p/go-mplex.(*Multiplex).Accept(0xc003d3c100, 0xc001722600, 0x100000000, 0x5100000000)
2020-10-13T09:18:55.3955085Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:129 +0x129
2020-10-13T09:18:55.3955853Z         github.com/libp2p/go-libp2p-mplex.(*conn).AcceptStream(0xc003d3c100, 0x0, 0xdb7e6e, 0xc003be5698, 0xddf600)
2020-10-13T09:18:55.3956649Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-mplex@v0.2.4/conn.go:25 +0x3d
2020-10-13T09:18:55.3957791Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc003d3c200)
2020-10-13T09:18:55.3958582Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.3959294Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.3960196Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.3960954Z         
2020-10-13T09:18:55.3961538Z          Goroutine 11462 in state select, with github.com/libp2p/go-mplex.(*Multiplex).Accept on top of the stack:
2020-10-13T09:18:55.3961986Z         goroutine 11462 [select]:
2020-10-13T09:18:55.3962557Z         github.com/libp2p/go-mplex.(*Multiplex).Accept(0xc002920100, 0xc001722600, 0x100000000, 0x4800000000)
2020-10-13T09:18:55.3963267Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:129 +0x129
2020-10-13T09:18:55.3964023Z         github.com/libp2p/go-libp2p-mplex.(*conn).AcceptStream(0xc002920100, 0x0, 0xdb7e6e, 0xc00155f698, 0xddf600)
2020-10-13T09:18:55.3964811Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-mplex@v0.2.4/conn.go:25 +0x3d
2020-10-13T09:18:55.3965504Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc0028fa300)
2020-10-13T09:18:55.3966262Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.3967117Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.3968056Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.3968448Z         
2020-10-13T09:18:55.3969080Z          Goroutine 11045 in state select, with github.com/libp2p/go-mplex.(*Stream).waitForData on top of the stack:
2020-10-13T09:18:55.3969571Z         goroutine 11045 [select]:
2020-10-13T09:18:55.3970158Z         github.com/libp2p/go-mplex.(*Stream).waitForData(0xc0027955c0, 0xc002846120, 0x0)
2020-10-13T09:18:55.3971165Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:76 +0x1a9
2020-10-13T09:18:55.3972045Z         github.com/libp2p/go-mplex.(*Stream).Read(0xc0027955c0, 0xc002849000, 0x1000, 0x1000, 0xc0027057a8, 0xdff823, 0x0)
2020-10-13T09:18:55.3972996Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:122 +0x3f5
2020-10-13T09:18:55.3973807Z         github.com/libp2p/go-libp2p-swarm.(*Stream).Read(0xc00284a380, 0xc002849000, 0x1000, 0x1000, 0xde431c, 0xdff55f, 0xc00284a954)
2020-10-13T09:18:55.3974645Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_stream.go:71 +0x98
2020-10-13T09:18:55.3975503Z         github.com/multiformats/go-multistream.(*lazyClientConn).Read(0xc00284a930, 0xc002849000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.3976544Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-multistream@v0.1.2/lazyClient.go:75 +0x107
2020-10-13T09:18:55.3977997Z         github.com/libp2p/go-libp2p/p2p/host/basic.(*streamWrapper).Read(0xc002837f80, 0xc002849000, 0x1000, 0x1000, 0x0, 0xc00284a950, 0x1)
2020-10-13T09:18:55.3978915Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p@v0.11.0/p2p/host/basic/basic_host.go:1008 +0x78
2020-10-13T09:18:55.3979499Z         bufio.(*Reader).fill(0xc002807e60)
2020-10-13T09:18:55.3979951Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/bufio/bufio.go:100 +0x19a
2020-10-13T09:18:55.3980428Z         bufio.(*Reader).ReadByte(0xc002807e60, 0xc00284a930, 0xc0027f9800, 0x74)
2020-10-13T09:18:55.3981420Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/bufio/bufio.go:252 +0x5b
2020-10-13T09:18:55.3982168Z         github.com/multiformats/go-varint.ReadUvarint(0x39ff360, 0xc002807e60, 0x7c, 0x74, 0xc00285a140)
2020-10-13T09:18:55.3982946Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-varint@v0.0.6/varint.go:80 +0x85
2020-10-13T09:18:55.3983714Z         github.com/libp2p/go-msgio/protoio.(*uvarintReader).ReadMsg(0xc002815f40, 0x3a3ffe0, 0xc00285a140, 0x0, 0x0)
2020-10-13T09:18:55.3984504Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-msgio@v0.0.6/protoio/uvarint_reader.go:60 +0x73
2020-10-13T09:18:55.3985377Z         github.com/libp2p/go-libp2p-autonat.(*client).DialBack(0xc002837ae0, 0x3a4c760, 0xc002807b60, 0xc0027aeb40, 0x22, 0x0, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.3986341Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/client.go:58 +0x4e8
2020-10-13T09:18:55.3987502Z         github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).probe(0xc003bee000, 0xc00282b230)
2020-10-13T09:18:55.3988392Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:371 +0x23d
2020-10-13T09:18:55.3989220Z         created by github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).tryProbe
2020-10-13T09:18:55.3990095Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:360 +0x457
2020-10-13T09:18:55.3990846Z         
2020-10-13T09:18:55.3991438Z          Goroutine 9430 in state select, with github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing on top of the stack:
2020-10-13T09:18:55.3991915Z         goroutine 9430 [select]:
2020-10-13T09:18:55.3992465Z         github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing(0xc003c2e580)
2020-10-13T09:18:55.3993176Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:191 +0x158
2020-10-13T09:18:55.3993818Z         created by github.com/libp2p/go-mplex.NewMultiplex
2020-10-13T09:18:55.3994499Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:107 +0x3a2
2020-10-13T09:18:55.3994838Z         
2020-10-13T09:18:55.3995400Z          Goroutine 10706 in state select, with github.com/libp2p/go-mplex.(*Multiplex).Accept on top of the stack:
2020-10-13T09:18:55.3995836Z         goroutine 10706 [select]:
2020-10-13T09:18:55.3996391Z         github.com/libp2p/go-mplex.(*Multiplex).Accept(0xc0026ee200, 0xc001722600, 0x100000000, 0x3e00000000)
2020-10-13T09:18:55.3997554Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:129 +0x129
2020-10-13T09:18:55.3998413Z         github.com/libp2p/go-libp2p-mplex.(*conn).AcceptStream(0xc0026ee200, 0x0, 0xdb7e6e, 0xc003b7c698, 0xddf600)
2020-10-13T09:18:55.3999289Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-mplex@v0.2.4/conn.go:25 +0x3d
2020-10-13T09:18:55.4000040Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc0026ee280)
2020-10-13T09:18:55.4001334Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.4001980Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.4002672Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.4003027Z         
2020-10-13T09:18:55.4003582Z          Goroutine 8548 in state select, with github.com/jbenet/goprocess/context.CloseAfterContext.func1 on top of the stack:
2020-10-13T09:18:55.4004179Z         goroutine 8548 [select]:
2020-10-13T09:18:55.4004717Z         github.com/jbenet/goprocess/context.CloseAfterContext.func1(0x3a4c6e0, 0xc003899380, 0x3a6c900, 0xc003935860)
2020-10-13T09:18:55.4005516Z         	/home/runner/go/pkg/mod/github.com/jbenet/goprocess@v0.1.4/context/context.go:65 +0x10f
2020-10-13T09:18:55.4006111Z         created by github.com/jbenet/goprocess/context.CloseAfterContext
2020-10-13T09:18:55.4006722Z         	/home/runner/go/pkg/mod/github.com/jbenet/goprocess@v0.1.4/context/context.go:64 +0xba
2020-10-13T09:18:55.4007269Z         
2020-10-13T09:18:55.4008178Z          Goroutine 11373 in state select, with github.com/libp2p/go-mplex.(*Stream).waitForData on top of the stack:
2020-10-13T09:18:55.4008678Z         goroutine 11373 [select]:
2020-10-13T09:18:55.4009285Z         github.com/libp2p/go-mplex.(*Stream).waitForData(0xc00287b380, 0xc002847260, 0x0)
2020-10-13T09:18:55.4010039Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:76 +0x1a9
2020-10-13T09:18:55.4011344Z         github.com/libp2p/go-mplex.(*Stream).Read(0xc00287b380, 0xc00291e000, 0x1000, 0x1000, 0xc0027077a8, 0xdff823, 0x0)
2020-10-13T09:18:55.4027173Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:122 +0x3f5
2020-10-13T09:18:55.4028313Z         github.com/libp2p/go-libp2p-swarm.(*Stream).Read(0xc0029190a0, 0xc00291e000, 0x1000, 0x1000, 0xde431c, 0xdff55f, 0xc002919134)
2020-10-13T09:18:55.4029407Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_stream.go:71 +0x98
2020-10-13T09:18:55.4030323Z         github.com/multiformats/go-multistream.(*lazyClientConn).Read(0xc002919110, 0xc00291e000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.4031539Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-multistream@v0.1.2/lazyClient.go:75 +0x107
2020-10-13T09:18:55.4032379Z         github.com/libp2p/go-libp2p/p2p/host/basic.(*streamWrapper).Read(0xc00290b8e0, 0xc00291e000, 0x1000, 0x1000, 0x0, 0xc002919130, 0x1)
2020-10-13T09:18:55.4033181Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p@v0.11.0/p2p/host/basic/basic_host.go:1008 +0x78
2020-10-13T09:18:55.4033601Z         bufio.(*Reader).fill(0xc00290f860)
2020-10-13T09:18:55.4034184Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/bufio/bufio.go:100 +0x19a
2020-10-13T09:18:55.4034617Z         bufio.(*Reader).ReadByte(0xc00290f860, 0xc002919110, 0xc002867600, 0x74)
2020-10-13T09:18:55.4035072Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/bufio/bufio.go:252 +0x5b
2020-10-13T09:18:55.4035833Z         github.com/multiformats/go-varint.ReadUvarint(0x39ff360, 0xc00290f860, 0x7c, 0x74, 0xc00285b500)
2020-10-13T09:18:55.4036642Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-varint@v0.0.6/varint.go:80 +0x85
2020-10-13T09:18:55.4038074Z         github.com/libp2p/go-msgio/protoio.(*uvarintReader).ReadMsg(0xc00285b2c0, 0x3a3ffe0, 0xc00285b500, 0x0, 0x0)
2020-10-13T09:18:55.4038963Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-msgio@v0.0.6/protoio/uvarint_reader.go:60 +0x73
2020-10-13T09:18:55.4039872Z         github.com/libp2p/go-libp2p-autonat.(*client).DialBack(0xc00290b880, 0x3a4c760, 0xc00290f740, 0xc002878840, 0x26, 0x0, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.4041103Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/client.go:58 +0x4e8
2020-10-13T09:18:55.4041916Z         github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).probe(0xc003bee000, 0xc002914480)
2020-10-13T09:18:55.4042752Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:371 +0x23d
2020-10-13T09:18:55.4043534Z         created by github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).tryProbe
2020-10-13T09:18:55.4044364Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:360 +0x457
2020-10-13T09:18:55.4044755Z         
2020-10-13T09:18:55.4045399Z          Goroutine 10609 in state select, with github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing on top of the stack:
2020-10-13T09:18:55.4045884Z         goroutine 10609 [select]:
2020-10-13T09:18:55.4046454Z         github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing(0xc0026ee000)
2020-10-13T09:18:55.4047798Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:191 +0x158
2020-10-13T09:18:55.4048626Z         created by github.com/libp2p/go-mplex.NewMultiplex
2020-10-13T09:18:55.4049465Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:107 +0x3a2
2020-10-13T09:18:55.4049859Z         
2020-10-13T09:18:55.4050943Z          Goroutine 11226 in state select, with github.com/libp2p/go-mplex.(*Stream).waitForData on top of the stack:
2020-10-13T09:18:55.4051620Z         goroutine 11226 [select]:
2020-10-13T09:18:55.4073483Z         github.com/libp2p/go-mplex.(*Stream).waitForData(0xc00287af00, 0xc002846ba0, 0x0)
2020-10-13T09:18:55.4075522Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:76 +0x1a9
2020-10-13T09:18:55.4079446Z         github.com/libp2p/go-mplex.(*Stream).Read(0xc00287af00, 0xc0028ec000, 0x1000, 0x1000, 0xc00265f7a8, 0xdff823, 0x0)
2020-10-13T09:18:55.4081238Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:122 +0x3f5
2020-10-13T09:18:55.4085276Z         github.com/libp2p/go-libp2p-swarm.(*Stream).Read(0xc00284bce0, 0xc0028ec000, 0x1000, 0x1000, 0xde431c, 0xdff55f, 0xc0028e2bf4)
2020-10-13T09:18:55.4088996Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_stream.go:71 +0x98
2020-10-13T09:18:55.4092865Z         github.com/multiformats/go-multistream.(*lazyClientConn).Read(0xc0028e2bd0, 0xc0028ec000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.4094806Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-multistream@v0.1.2/lazyClient.go:75 +0x107
2020-10-13T09:18:55.4097371Z         github.com/libp2p/go-libp2p/p2p/host/basic.(*streamWrapper).Read(0xc0028dfb40, 0xc0028ec000, 0x1000, 0x1000, 0x0, 0xc0028e2bf0, 0x1)
2020-10-13T09:18:55.4098920Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p@v0.11.0/p2p/host/basic/basic_host.go:1008 +0x78
2020-10-13T09:18:55.4099593Z         bufio.(*Reader).fill(0xc0028d5da0)
2020-10-13T09:18:55.4100193Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/bufio/bufio.go:100 +0x19a
2020-10-13T09:18:55.4101346Z         bufio.(*Reader).ReadByte(0xc0028d5da0, 0xc0028e2bd0, 0xc0028a1000, 0x74)
2020-10-13T09:18:55.4101907Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/bufio/bufio.go:252 +0x5b
2020-10-13T09:18:55.4102796Z         github.com/multiformats/go-varint.ReadUvarint(0x39ff360, 0xc0028d5da0, 0x7c, 0x74, 0xc0028f0040)
2020-10-13T09:18:55.4103893Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-varint@v0.0.6/varint.go:80 +0x85
2020-10-13T09:18:55.4104858Z         github.com/libp2p/go-msgio/protoio.(*uvarintReader).ReadMsg(0xc002895dc0, 0x3a3ffe0, 0xc0028f0040, 0x0, 0x0)
2020-10-13T09:18:55.4105860Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-msgio@v0.0.6/protoio/uvarint_reader.go:60 +0x73
2020-10-13T09:18:55.4107412Z         github.com/libp2p/go-libp2p-autonat.(*client).DialBack(0xc00290a9a0, 0x3a4c760, 0xc00290ec00, 0xc0027afbc0, 0x22, 0x0, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.4109167Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/client.go:58 +0x4e8
2020-10-13T09:18:55.4110786Z         github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).probe(0xc003bee000, 0xc00286be30)
2020-10-13T09:18:55.4112615Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:371 +0x23d
2020-10-13T09:18:55.4113567Z         created by github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).tryProbe
2020-10-13T09:18:55.4114427Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:360 +0x457
2020-10-13T09:18:55.4114957Z         
2020-10-13T09:18:55.4115580Z          Goroutine 10480 in state select, with github.com/libp2p/go-mplex.(*Stream).waitForData on top of the stack:
2020-10-13T09:18:55.4116045Z         goroutine 10480 [select]:
2020-10-13T09:18:55.4116600Z         github.com/libp2p/go-mplex.(*Stream).waitForData(0xc002794600, 0xc0027791a0, 0x0)
2020-10-13T09:18:55.4117959Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:76 +0x1a9
2020-10-13T09:18:55.4118898Z         github.com/libp2p/go-mplex.(*Stream).Read(0xc002794600, 0xc00279d000, 0x1000, 0x1000, 0xc0027417a8, 0xdff823, 0x0)
2020-10-13T09:18:55.4119746Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:122 +0x3f5
2020-10-13T09:18:55.4121111Z         github.com/libp2p/go-libp2p-swarm.(*Stream).Read(0xc003d8d960, 0xc00279d000, 0x1000, 0x1000, 0xde431c, 0xdff55f, 0xc003d8da64)
2020-10-13T09:18:55.4122012Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_stream.go:71 +0x98
2020-10-13T09:18:55.4123588Z         github.com/multiformats/go-multistream.(*lazyClientConn).Read(0xc003d8da40, 0xc00279d000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.4124586Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-multistream@v0.1.2/lazyClient.go:75 +0x107
2020-10-13T09:18:55.4125461Z         github.com/libp2p/go-libp2p/p2p/host/basic.(*streamWrapper).Read(0xc002797560, 0xc00279d000, 0x1000, 0x1000, 0x0, 0xc003d8da60, 0x1)
2020-10-13T09:18:55.4126301Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p@v0.11.0/p2p/host/basic/basic_host.go:1008 +0x78
2020-10-13T09:18:55.4127079Z         bufio.(*Reader).fill(0xc0027ac120)
2020-10-13T09:18:55.4127710Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/bufio/bufio.go:100 +0x19a
2020-10-13T09:18:55.4168241Z         bufio.(*Reader).ReadByte(0xc0027ac120, 0xc003d8da40, 0xc002738c00, 0x6a)
2020-10-13T09:18:55.4168776Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/bufio/bufio.go:252 +0x5b
2020-10-13T09:18:55.4169718Z         github.com/multiformats/go-varint.ReadUvarint(0x39ff360, 0xc0027ac120, 0x72, 0x6a, 0xc002788cc0)
2020-10-13T09:18:55.4170938Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-varint@v0.0.6/varint.go:80 +0x85
2020-10-13T09:18:55.4172150Z         github.com/libp2p/go-msgio/protoio.(*uvarintReader).ReadMsg(0xc002788a80, 0x3a3ffe0, 0xc002788cc0, 0x0, 0x0)
2020-10-13T09:18:55.4173060Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-msgio@v0.0.6/protoio/uvarint_reader.go:60 +0x73
2020-10-13T09:18:55.4173932Z         github.com/libp2p/go-libp2p-autonat.(*client).DialBack(0xc0027974a0, 0x3a4c760, 0xc002791f80, 0xc0026256b0, 0x22, 0x0, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.4174798Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/client.go:58 +0x4e8
2020-10-13T09:18:55.4175812Z         github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).probe(0xc003bee000, 0xc00278f590)
2020-10-13T09:18:55.4176677Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:371 +0x23d
2020-10-13T09:18:55.4177901Z         created by github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).tryProbe
2020-10-13T09:18:55.4178965Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:360 +0x457
2020-10-13T09:18:55.4179383Z         
2020-10-13T09:18:55.4180542Z          Goroutine 8489 in state chan receive, with github.com/libp2p/go-libp2p-transport-upgrader.(*listener).Accept on top of the stack:
2020-10-13T09:18:55.4181224Z         goroutine 8489 [chan receive]:
2020-10-13T09:18:55.4182032Z         github.com/libp2p/go-libp2p-transport-upgrader.(*listener).Accept(0xc003934000, 0x102dc0e01, 0xc00211ced0, 0x1a337f7, 0x0)
2020-10-13T09:18:55.4183089Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-transport-upgrader@v0.3.0/listener.go:155 +0x73
2020-10-13T09:18:55.4184100Z         github.com/libp2p/go-libp2p-swarm.(*Swarm).AddListenAddr.func2(0x3a4d3e0, 0xc003934000, 0xc001722600, 0x3a74900, 0xc00000f6e0)
2020-10-13T09:18:55.4185008Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_listen.go:84 +0x1a7
2020-10-13T09:18:55.4185747Z         created by github.com/libp2p/go-libp2p-swarm.(*Swarm).AddListenAddr
2020-10-13T09:18:55.4186539Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_listen.go:69 +0x328
2020-10-13T09:18:55.4187094Z         
2020-10-13T09:18:55.4188225Z          Goroutine 10510 in state select, with github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing on top of the stack:
2020-10-13T09:18:55.4188924Z         goroutine 10510 [select]:
2020-10-13T09:18:55.4189611Z         github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing(0xc0026b7d00)
2020-10-13T09:18:55.4190586Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:191 +0x158
2020-10-13T09:18:55.4191473Z         created by github.com/libp2p/go-mplex.NewMultiplex
2020-10-13T09:18:55.4192214Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:107 +0x3a2
2020-10-13T09:18:55.4192581Z         
2020-10-13T09:18:55.4193409Z          Goroutine 10917 in state select, with github.com/libp2p/go-mplex.(*Stream).waitForData on top of the stack:
2020-10-13T09:18:55.4194095Z         goroutine 10917 [select]:
2020-10-13T09:18:55.4194677Z         github.com/libp2p/go-mplex.(*Stream).waitForData(0xc002795140, 0xc0027ef9e0, 0x0)
2020-10-13T09:18:55.4195416Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:76 +0x1a9
2020-10-13T09:18:55.4196181Z         github.com/libp2p/go-mplex.(*Stream).Read(0xc002795140, 0xc00282c000, 0x1000, 0x1000, 0xc0027697a8, 0xdff823, 0x0)
2020-10-13T09:18:55.4197701Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:122 +0x3f5
2020-10-13T09:18:55.4198763Z         github.com/libp2p/go-libp2p-swarm.(*Stream).Read(0xc002826230, 0xc00282c000, 0x1000, 0x1000, 0xde431c, 0xdff55f, 0xc0028262c4)
2020-10-13T09:18:55.4199675Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_stream.go:71 +0x98
2020-10-13T09:18:55.4200618Z         github.com/multiformats/go-multistream.(*lazyClientConn).Read(0xc0028262a0, 0xc00282c000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.4201919Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-multistream@v0.1.2/lazyClient.go:75 +0x107
2020-10-13T09:18:55.4202980Z         github.com/libp2p/go-libp2p/p2p/host/basic.(*streamWrapper).Read(0xc00281f140, 0xc00282c000, 0x1000, 0x1000, 0x0, 0xc0028262c0, 0x1)
2020-10-13T09:18:55.4203834Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p@v0.11.0/p2p/host/basic/basic_host.go:1008 +0x78
2020-10-13T09:18:55.4204275Z         bufio.(*Reader).fill(0xc002807080)
2020-10-13T09:18:55.4204671Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/bufio/bufio.go:100 +0x19a
2020-10-13T09:18:55.4205084Z         bufio.(*Reader).ReadByte(0xc002807080, 0xc0028262a0, 0xc0027f9680, 0x74)
2020-10-13T09:18:55.4205539Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/bufio/bufio.go:252 +0x5b
2020-10-13T09:18:55.4206295Z         github.com/multiformats/go-varint.ReadUvarint(0x39ff360, 0xc002807080, 0x7c, 0x74, 0xc002814d40)
2020-10-13T09:18:55.4207502Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-varint@v0.0.6/varint.go:80 +0x85
2020-10-13T09:18:55.4208648Z         github.com/libp2p/go-msgio/protoio.(*uvarintReader).ReadMsg(0xc002814b40, 0x3a3ffe0, 0xc002814d40, 0x0, 0x0)
2020-10-13T09:18:55.4209557Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-msgio@v0.0.6/protoio/uvarint_reader.go:60 +0x73
2020-10-13T09:18:55.4255139Z         github.com/libp2p/go-libp2p-autonat.(*client).DialBack(0xc00281f080, 0x3a4c760, 0xc002806f60, 0xc0027ae3f0, 0x22, 0x0, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.4256442Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/client.go:58 +0x4e8
2020-10-13T09:18:55.4261866Z         github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).probe(0xc003bee000, 0xc0027c7e30)
2020-10-13T09:18:55.4263794Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:371 +0x23d
2020-10-13T09:18:55.4264760Z         created by github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).tryProbe
2020-10-13T09:18:55.4265577Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:360 +0x457
2020-10-13T09:18:55.4265972Z         ]
2020-10-13T09:18:55.4266390Z --- FAIL: TestCloseByContext (15.96s)
2020-10-13T09:18:55.4266727Z === RUN   TestFlagsLeak
2020-10-13T09:18:55.4267266Z     leaks.go:78: found unexpected goroutines:
2020-10-13T09:18:55.4268201Z         [Goroutine 10467 in state select, with github.com/libp2p/go-mplex.(*Multiplex).Accept on top of the stack:
2020-10-13T09:18:55.4268733Z         goroutine 10467 [select]:
2020-10-13T09:18:55.4269421Z         github.com/libp2p/go-mplex.(*Multiplex).Accept(0xc002798680, 0xc001722600, 0x100000000, 0x2700000000)
2020-10-13T09:18:55.4270405Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:129 +0x129
2020-10-13T09:18:55.4271213Z         github.com/libp2p/go-libp2p-mplex.(*conn).AcceptStream(0xc002798680, 0x0, 0xdb7e6e, 0xc0016b2e98, 0xddf600)
2020-10-13T09:18:55.4272160Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-mplex@v0.2.4/conn.go:25 +0x3d
2020-10-13T09:18:55.4272818Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc002798700)
2020-10-13T09:18:55.4273543Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.4274200Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.4274906Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.4275382Z         
2020-10-13T09:18:55.4275940Z          Goroutine 8476 in state select, with github.com/jbenet/goprocess/context.CloseAfterContext.func1 on top of the stack:
2020-10-13T09:18:55.4276934Z         goroutine 8476 [select]:
2020-10-13T09:18:55.4277928Z         github.com/jbenet/goprocess/context.CloseAfterContext.func1(0x3a4c6e0, 0xc003899100, 0x3a6c900, 0xc0039a7b60)
2020-10-13T09:18:55.4278851Z         	/home/runner/go/pkg/mod/github.com/jbenet/goprocess@v0.1.4/context/context.go:65 +0x10f
2020-10-13T09:18:55.4279531Z         created by github.com/jbenet/goprocess/context.CloseAfterContext
2020-10-13T09:18:55.4280422Z         	/home/runner/go/pkg/mod/github.com/jbenet/goprocess@v0.1.4/context/context.go:64 +0xba
2020-10-13T09:18:55.4281162Z         
2020-10-13T09:18:55.4281953Z          Goroutine 9975 in state select, with github.com/lucas-clemente/quic-go.(*incomingBidiStreamsMap).AcceptStream on top of the stack:
2020-10-13T09:18:55.4282551Z         goroutine 9975 [select]:
2020-10-13T09:18:55.4283338Z         github.com/lucas-clemente/quic-go.(*incomingBidiStreamsMap).AcceptStream(0xc003a69ab0, 0x3a4c720, 0xc00011c010, 0x0, 0x0, 0xc002540ff0, 0x10)
2020-10-13T09:18:55.4284312Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/streams_map_incoming_bidi.go:71 +0x239
2020-10-13T09:18:55.4285245Z         github.com/lucas-clemente/quic-go.(*streamsMap).AcceptStream(0xc00254af80, 0x3a4c720, 0xc00011c010, 0xc0024d4e28, 0xdfd305, 0xe018a6, 0xc0024d4ec8)
2020-10-13T09:18:55.4286128Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/streams_map.go:127 +0x78
2020-10-13T09:18:55.4287416Z         github.com/lucas-clemente/quic-go.(*session).AcceptStream(0xc0039f7080, 0x3a4c720, 0xc00011c010, 0xe017ce, 0x0, 0xdb7e6e, 0xc0024d4e98)
2020-10-13T09:18:55.4288570Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/session.go:1635 +0x6e
2020-10-13T09:18:55.4289579Z         github.com/libp2p/go-libp2p-quic-transport.(*conn).AcceptStream(0xc00258f280, 0x36b8990, 0xc00258f300, 0x3a624c0, 0xc002540ff0)
2020-10-13T09:18:55.4290966Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-quic-transport@v0.8.1/conn.go:47 +0x87
2020-10-13T09:18:55.4291966Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc00258f300)
2020-10-13T09:18:55.4292734Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.4293384Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.4294085Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.4294444Z         
2020-10-13T09:18:55.4295011Z          Goroutine 10852 in state select, with github.com/libp2p/go-mplex.(*Multiplex).Accept on top of the stack:
2020-10-13T09:18:55.4295553Z         goroutine 10852 [select]:
2020-10-13T09:18:55.4296159Z         github.com/libp2p/go-mplex.(*Multiplex).Accept(0xc002808780, 0xc001722600, 0x100000000, 0x4200000000)
2020-10-13T09:18:55.4297058Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:129 +0x129
2020-10-13T09:18:55.4298140Z         github.com/libp2p/go-libp2p-mplex.(*conn).AcceptStream(0xc002808780, 0x0, 0xdb7e6e, 0xc00168e698, 0xddf600)
2020-10-13T09:18:55.4299004Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-mplex@v0.2.4/conn.go:25 +0x3d
2020-10-13T09:18:55.4299771Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc0026ee380)
2020-10-13T09:18:55.4301106Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.4301759Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.4302458Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.4302822Z         
2020-10-13T09:18:55.4303438Z          Goroutine 12957 in state select, with github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing on top of the stack:
2020-10-13T09:18:55.4304015Z         goroutine 12957 [select]:
2020-10-13T09:18:55.4304587Z         github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing(0xc003d3c100)
2020-10-13T09:18:55.4305292Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:191 +0x158
2020-10-13T09:18:55.4305906Z         created by github.com/libp2p/go-mplex.NewMultiplex
2020-10-13T09:18:55.4306597Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:107 +0x3a2
2020-10-13T09:18:55.4307128Z         
2020-10-13T09:18:55.4308165Z          Goroutine 9959 in state chan receive, with github.com/libp2p/go-libp2p-quic-transport.(*transport).Dial.func1 on top of the stack:
2020-10-13T09:18:55.4308827Z         goroutine 9959 [chan receive]:
2020-10-13T09:18:55.4309645Z         github.com/libp2p/go-libp2p-quic-transport.(*transport).Dial.func1(0x7fab883e9a48, 0xc0039f7080, 0xc003872400)
2020-10-13T09:18:55.4311376Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-quic-transport@v0.8.1/transport.go:175 +0x6a
2020-10-13T09:18:55.4312178Z         created by github.com/libp2p/go-libp2p-quic-transport.(*transport).Dial
2020-10-13T09:18:55.4313035Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-quic-transport@v0.8.1/transport.go:174 +0x397
2020-10-13T09:18:55.4313459Z         
2020-10-13T09:18:55.4314054Z          Goroutine 11136 in state select, with github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing on top of the stack:
2020-10-13T09:18:55.4314530Z         goroutine 11136 [select]:
2020-10-13T09:18:55.4315067Z         github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing(0xc00284f300)
2020-10-13T09:18:55.4315761Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:191 +0x158
2020-10-13T09:18:55.4316398Z         created by github.com/libp2p/go-mplex.NewMultiplex
2020-10-13T09:18:55.4317524Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:107 +0x3a2
2020-10-13T09:18:55.4317915Z         
2020-10-13T09:18:55.4318573Z          Goroutine 11274 in state select, with github.com/libp2p/go-mplex.(*Multiplex).Accept on top of the stack:
2020-10-13T09:18:55.4319072Z         goroutine 11274 [select]:
2020-10-13T09:18:55.4319727Z         github.com/libp2p/go-mplex.(*Multiplex).Accept(0xc0028bdf80, 0xc001722600, 0x100000000, 0x4800000000)
2020-10-13T09:18:55.4321027Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:129 +0x129
2020-10-13T09:18:55.4321794Z         github.com/libp2p/go-libp2p-mplex.(*conn).AcceptStream(0xc0028bdf80, 0x0, 0xdb7e6e, 0xc002085698, 0xddf600)
2020-10-13T09:18:55.4322563Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-mplex@v0.2.4/conn.go:25 +0x3d
2020-10-13T09:18:55.4323226Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc0028fa000)
2020-10-13T09:18:55.4376031Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.4493117Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.4493861Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.4494225Z         
2020-10-13T09:18:55.4494846Z          Goroutine 8585 in state select, with github.com/lucas-clemente/quic-go.(*baseServer).accept on top of the stack:
2020-10-13T09:18:55.4495324Z         goroutine 8585 [select]:
2020-10-13T09:18:55.4496001Z         github.com/lucas-clemente/quic-go.(*baseServer).accept(0xc001f191e0, 0x3a4c720, 0xc00011c010, 0xc00153c780, 0x5, 0xc001517e00, 0xdc271f)
2020-10-13T09:18:55.4497021Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/server.go:259 +0x1a1
2020-10-13T09:18:55.4498233Z         github.com/lucas-clemente/quic-go.(*baseServer).Accept(0xc001f191e0, 0x3a4c720, 0xc00011c010, 0xdbdf35, 0x2b43c80, 0x7fab45eb0008, 0x0)
2020-10-13T09:18:55.4499206Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/server.go:255 +0x51
2020-10-13T09:18:55.4500740Z         github.com/libp2p/go-libp2p-quic-transport.(*listener).Accept(0xc0039602d0, 0x100000000, 0xc002083db0, 0xc001517f48, 0x0)
2020-10-13T09:18:55.4501672Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-quic-transport@v0.8.1/listener.go:63 +0xca
2020-10-13T09:18:55.4502617Z         github.com/libp2p/go-libp2p-swarm.(*Swarm).AddListenAddr.func2(0x3a4d360, 0xc0039602d0, 0xc001722600, 0x3a74900, 0xc003a8e100)
2020-10-13T09:18:55.4503504Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_listen.go:84 +0x1a7
2020-10-13T09:18:55.4504225Z         created by github.com/libp2p/go-libp2p-swarm.(*Swarm).AddListenAddr
2020-10-13T09:18:55.4504993Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_listen.go:69 +0x328
2020-10-13T09:18:55.4505363Z         
2020-10-13T09:18:55.4505965Z          Goroutine 11001 in state select, with github.com/libp2p/go-mplex.(*Stream).waitForData on top of the stack:
2020-10-13T09:18:55.4506417Z         goroutine 11001 [select]:
2020-10-13T09:18:55.4507421Z         github.com/libp2p/go-mplex.(*Stream).waitForData(0xc002795440, 0xc0027efec0, 0x0)
2020-10-13T09:18:55.4526595Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:76 +0x1a9
2020-10-13T09:18:55.4527992Z         github.com/libp2p/go-mplex.(*Stream).Read(0xc002795440, 0xc002848000, 0x1000, 0x1000, 0xc0027757a8, 0xdff823, 0x0)
2020-10-13T09:18:55.4528799Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:122 +0x3f5
2020-10-13T09:18:55.4529674Z         github.com/libp2p/go-libp2p-swarm.(*Stream).Read(0xc002827b90, 0xc002848000, 0x1000, 0x1000, 0xde431c, 0xdff55f, 0xc002827c24)
2020-10-13T09:18:55.4530757Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_stream.go:71 +0x98
2020-10-13T09:18:55.4570552Z         github.com/multiformats/go-multistream.(*lazyClientConn).Read(0xc002827c00, 0xc002848000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.4572096Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-multistream@v0.1.2/lazyClient.go:75 +0x107
2020-10-13T09:18:55.4573093Z         github.com/libp2p/go-libp2p/p2p/host/basic.(*streamWrapper).Read(0xc002836fc0, 0xc002848000, 0x1000, 0x1000, 0x0, 0xc002827c20, 0x1)
2020-10-13T09:18:55.4574177Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p@v0.11.0/p2p/host/basic/basic_host.go:1008 +0x78
2020-10-13T09:18:55.4574631Z         bufio.(*Reader).fill(0xc0028079e0)
2020-10-13T09:18:55.4575022Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/bufio/bufio.go:100 +0x19a
2020-10-13T09:18:55.4575765Z         bufio.(*Reader).ReadByte(0xc0028079e0, 0xc002827c00, 0xc0027f9780, 0x74)
2020-10-13T09:18:55.4576452Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/bufio/bufio.go:252 +0x5b
2020-10-13T09:18:55.4578234Z         github.com/multiformats/go-varint.ReadUvarint(0x39ff360, 0xc0028079e0, 0x7c, 0x74, 0xc002815b40)
2020-10-13T09:18:55.4579294Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-varint@v0.0.6/varint.go:80 +0x85
2020-10-13T09:18:55.4580266Z         github.com/libp2p/go-msgio/protoio.(*uvarintReader).ReadMsg(0xc002815940, 0x3a3ffe0, 0xc002815b40, 0x0, 0x0)
2020-10-13T09:18:55.4581442Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-msgio@v0.0.6/protoio/uvarint_reader.go:60 +0x73
2020-10-13T09:18:55.4582617Z         github.com/libp2p/go-libp2p-autonat.(*client).DialBack(0xc002836f20, 0x3a4c760, 0xc0028078c0, 0xc0027ae8d0, 0x22, 0x0, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.4583905Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/client.go:58 +0x4e8
2020-10-13T09:18:55.4585123Z         github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).probe(0xc003bee000, 0xc00282aa80)
2020-10-13T09:18:55.4586214Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:371 +0x23d
2020-10-13T09:18:55.4587446Z         created by github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).tryProbe
2020-10-13T09:18:55.4588820Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:360 +0x457
2020-10-13T09:18:55.4589481Z         
2020-10-13T09:18:55.4663178Z          Goroutine 11194 in state select, with github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing on top of the stack:
2020-10-13T09:18:55.4663793Z         goroutine 11194 [select]:
2020-10-13T09:18:55.4664908Z         github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing(0xc0028bdf80)
2020-10-13T09:18:55.4665759Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:191 +0x158
2020-10-13T09:18:55.4666475Z         created by github.com/libp2p/go-mplex.NewMultiplex
2020-10-13T09:18:55.4667493Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:107 +0x3a2
2020-10-13T09:18:55.4667883Z         
2020-10-13T09:18:55.4668546Z          Goroutine 10959 in state select, with github.com/libp2p/go-mplex.(*Stream).waitForData on top of the stack:
2020-10-13T09:18:55.4669075Z         goroutine 10959 [select]:
2020-10-13T09:18:55.4669706Z         github.com/libp2p/go-mplex.(*Stream).waitForData(0xc0026f12c0, 0xc002896900, 0x0)
2020-10-13T09:18:55.4670654Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:76 +0x1a9
2020-10-13T09:18:55.4671908Z         github.com/libp2p/go-mplex.(*Stream).Read(0xc0026f12c0, 0xc00285d000, 0x1000, 0x1000, 0xc00239f7a8, 0xdff823, 0x0)
2020-10-13T09:18:55.4672708Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:122 +0x3f5
2020-10-13T09:18:55.4674233Z         github.com/libp2p/go-libp2p-swarm.(*Stream).Read(0xc002881030, 0xc00285d000, 0x1000, 0x1000, 0xde431c, 0xdff55f, 0xc00284acd4)
2020-10-13T09:18:55.4675161Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_stream.go:71 +0x98
2020-10-13T09:18:55.4676095Z         github.com/multiformats/go-multistream.(*lazyClientConn).Read(0xc00284acb0, 0xc00285d000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.4677272Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-multistream@v0.1.2/lazyClient.go:75 +0x107
2020-10-13T09:18:55.4679236Z         github.com/libp2p/go-libp2p/p2p/host/basic.(*streamWrapper).Read(0xc0028582e0, 0xc00285d000, 0x1000, 0x1000, 0x0, 0xc00284acd0, 0x1)
2020-10-13T09:18:55.4680771Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p@v0.11.0/p2p/host/basic/basic_host.go:1008 +0x78
2020-10-13T09:18:55.4681350Z         bufio.(*Reader).fill(0xc002807f80)
2020-10-13T09:18:55.4681850Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/bufio/bufio.go:100 +0x19a
2020-10-13T09:18:55.4682423Z         bufio.(*Reader).ReadByte(0xc002807f80, 0xc00284acb0, 0xc0027f9880, 0x74)
2020-10-13T09:18:55.4683028Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/bufio/bufio.go:252 +0x5b
2020-10-13T09:18:55.4684521Z         github.com/multiformats/go-varint.ReadUvarint(0x39ff360, 0xc002807f80, 0x7c, 0x74, 0xc00285a3c0)
2020-10-13T09:18:55.4686494Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-varint@v0.0.6/varint.go:80 +0x85
2020-10-13T09:18:55.4687903Z         github.com/libp2p/go-msgio/protoio.(*uvarintReader).ReadMsg(0xc00285a1c0, 0x3a3ffe0, 0xc00285a3c0, 0x0, 0x0)
2020-10-13T09:18:55.4688916Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-msgio@v0.0.6/protoio/uvarint_reader.go:60 +0x73
2020-10-13T09:18:55.4689962Z         github.com/libp2p/go-libp2p-autonat.(*client).DialBack(0xc0028858e0, 0x3a4c760, 0xc002899380, 0xc0027aedb0, 0x22, 0x0, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.4691532Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/client.go:58 +0x4e8
2020-10-13T09:18:55.4695611Z         github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).probe(0xc003bee000, 0xc0026f5fb0)
2020-10-13T09:18:55.4699033Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:371 +0x23d
2020-10-13T09:18:55.4772735Z         created by github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).tryProbe
2020-10-13T09:18:55.4773903Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:360 +0x457
2020-10-13T09:18:55.4774514Z         
2020-10-13T09:18:55.4775262Z          Goroutine 8478 in state select, with github.com/libp2p/go-libp2p-swarm.(*DialBackoff).background on top of the stack:
2020-10-13T09:18:55.4775808Z         goroutine 8478 [select]:
2020-10-13T09:18:55.4776476Z         github.com/libp2p/go-libp2p-swarm.(*DialBackoff).background(0xc001722710, 0x3a4c6e0, 0xc003899380)
2020-10-13T09:18:55.4777766Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_dial.go:126 +0x1a1
2020-10-13T09:18:55.4778578Z         created by github.com/libp2p/go-libp2p-swarm.(*DialBackoff).init
2020-10-13T09:18:55.4779441Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_dial.go:119 +0x7b
2020-10-13T09:18:55.4779862Z         
2020-10-13T09:18:55.4780784Z          Goroutine 8484 in state select, with github.com/libp2p/go-libp2p-circuit.(*RelayListener).Accept on top of the stack:
2020-10-13T09:18:55.4781317Z         goroutine 8484 [select]:
2020-10-13T09:18:55.4782018Z         github.com/libp2p/go-libp2p-circuit.(*RelayListener).Accept(0xc0039a7f80, 0x0, 0x0, 0xc000652658, 0xdc2b75)
2020-10-13T09:18:55.4783087Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-circuit@v0.3.1/listen.go:27 +0x26a
2020-10-13T09:18:55.4784013Z         github.com/libp2p/go-libp2p-transport-upgrader.(*listener).handleIncoming(0xc003934000)
2020-10-13T09:18:55.4785096Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-transport-upgrader@v0.3.0/listener.go:77 +0x158
2020-10-13T09:18:55.4786497Z         created by github.com/libp2p/go-libp2p-transport-upgrader.(*Upgrader).UpgradeListener
2020-10-13T09:18:55.4788046Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-transport-upgrader@v0.3.0/upgrader.go:49 +0x336
2020-10-13T09:18:55.4788594Z         
2020-10-13T09:18:55.4789622Z          Goroutine 8572 in state chan receive, with github.com/libp2p/go-libp2p-transport-upgrader.(*listener).Accept on top of the stack:
2020-10-13T09:18:55.4790310Z         goroutine 8572 [chan receive]:
2020-10-13T09:18:55.4791299Z         github.com/libp2p/go-libp2p-transport-upgrader.(*listener).Accept(0xc003999620, 0x100000000, 0xc0020e7d50, 0xc001e0e748, 0x0)
2020-10-13T09:18:55.4792357Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-transport-upgrader@v0.3.0/listener.go:155 +0x73
2020-10-13T09:18:55.4793390Z         github.com/libp2p/go-libp2p-swarm.(*Swarm).AddListenAddr.func2(0x3a4d3e0, 0xc003999620, 0xc001722600, 0x3a74900, 0xc00384bf20)
2020-10-13T09:18:55.4794984Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_listen.go:84 +0x1a7
2020-10-13T09:18:55.4795845Z         created by github.com/libp2p/go-libp2p-swarm.(*Swarm).AddListenAddr
2020-10-13T09:18:55.4796763Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_listen.go:69 +0x328
2020-10-13T09:18:55.4797890Z         
2020-10-13T09:18:55.4799015Z          Goroutine 9727 in state select, with github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing on top of the stack:
2020-10-13T09:18:55.4799590Z         goroutine 9727 [select]:
2020-10-13T09:18:55.4800228Z         github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing(0xc003d16400)
2020-10-13T09:18:55.4801656Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:191 +0x158
2020-10-13T09:18:55.4802394Z         created by github.com/libp2p/go-mplex.NewMultiplex
2020-10-13T09:18:55.4803212Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:107 +0x3a2
2020-10-13T09:18:55.4803613Z         
2020-10-13T09:18:55.4804337Z          Goroutine 11427 in state select, with github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing on top of the stack:
2020-10-13T09:18:55.4805427Z         goroutine 11427 [select]:
2020-10-13T09:18:55.4806003Z         github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing(0xc002920100)
2020-10-13T09:18:55.4806949Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:191 +0x158
2020-10-13T09:18:55.4807980Z         created by github.com/libp2p/go-mplex.NewMultiplex
2020-10-13T09:18:55.4808770Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:107 +0x3a2
2020-10-13T09:18:55.4809155Z         
2020-10-13T09:18:55.4810217Z          Goroutine 11566 in state select, with github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing on top of the stack:
2020-10-13T09:18:55.4810765Z         goroutine 11566 [select]:
2020-10-13T09:18:55.4811381Z         github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing(0xc0028fa600)
2020-10-13T09:18:55.4853389Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:191 +0x158
2020-10-13T09:18:55.4854169Z         created by github.com/libp2p/go-mplex.NewMultiplex
2020-10-13T09:18:55.4855121Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:107 +0x3a2
2020-10-13T09:18:55.4855515Z         
2020-10-13T09:18:55.4855959Z          Goroutine 11899 in state semacquire, with sync.runtime_SemacquireMutex on top of the stack:
2020-10-13T09:18:55.4856476Z         goroutine 11899 [semacquire]:
2020-10-13T09:18:55.4856864Z         sync.runtime_SemacquireMutex(0xc002962f58, 0x900000000, 0x1)
2020-10-13T09:18:55.4857599Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/runtime/sema.go:71 +0x47
2020-10-13T09:18:55.4858027Z         sync.(*Mutex).lockSlow(0xc002962f54)
2020-10-13T09:18:55.4858479Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/sync/mutex.go:138 +0x1c1
2020-10-13T09:18:55.4859223Z         sync.(*Mutex).Lock(0xc002962f54)
2020-10-13T09:18:55.4859653Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/sync/mutex.go:81 +0x7d
2020-10-13T09:18:55.4860078Z         sync.(*Once).doSlow(0xc002962f50, 0xc0029508d0)
2020-10-13T09:18:55.4861169Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/sync/once.go:62 +0x5f
2020-10-13T09:18:55.4861565Z         sync.(*Once).Do(0xc002962f50, 0xc0029508d0)
2020-10-13T09:18:55.4862888Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/sync/once.go:57 +0x69
2020-10-13T09:18:55.4864716Z         created by github.com/multiformats/go-multistream.(*lazyClientConn).Write.func1
2020-10-13T09:18:55.4866587Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-multistream@v0.1.2/lazyClient.go:131 +0xce
2020-10-13T09:18:55.4867460Z         
2020-10-13T09:18:55.4869593Z          Goroutine 10296 in state select, with github.com/lucas-clemente/quic-go.(*incomingBidiStreamsMap).AcceptStream on top of the stack:
2020-10-13T09:18:55.4871706Z         goroutine 10296 [select]:
2020-10-13T09:18:55.4873093Z         github.com/lucas-clemente/quic-go.(*incomingBidiStreamsMap).AcceptStream(0xc003c98fc0, 0x3a4c720, 0xc00011c010, 0x0, 0x0, 0xc00274eb90, 0x10)
2020-10-13T09:18:55.4875087Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/streams_map_incoming_bidi.go:71 +0x239
2020-10-13T09:18:55.4876945Z         github.com/lucas-clemente/quic-go.(*streamsMap).AcceptStream(0xc00272a5c0, 0x3a4c720, 0xc00011c010, 0xc0014ade28, 0xdfd305, 0xe018a6, 0xc0014adec8)
2020-10-13T09:18:55.4878694Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/streams_map.go:127 +0x78
2020-10-13T09:18:55.4879784Z         github.com/lucas-clemente/quic-go.(*session).AcceptStream(0xc00302c840, 0x3a4c720, 0xc00011c010, 0xe017ce, 0x0, 0xdb7e6e, 0xc0014ade98)
2020-10-13T09:18:55.4884721Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/session.go:1635 +0x6e
2020-10-13T09:18:55.4886470Z         github.com/libp2p/go-libp2p-quic-transport.(*conn).AcceptStream(0xc0026b6180, 0x36b8990, 0xc0026b6200, 0x3a624c0, 0xc00274eb90)
2020-10-13T09:18:55.4888812Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-quic-transport@v0.8.1/conn.go:47 +0x87
2020-10-13T09:18:55.4892341Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc0026b6200)
2020-10-13T09:18:55.4893243Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.4894300Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.4895135Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.4895574Z         
2020-10-13T09:18:55.4896357Z          Goroutine 11173 in state select, with github.com/libp2p/go-mplex.(*Multiplex).Accept on top of the stack:
2020-10-13T09:18:55.4897063Z         goroutine 11173 [select]:
2020-10-13T09:18:55.4898162Z         github.com/libp2p/go-mplex.(*Multiplex).Accept(0xc00284f300, 0xc001722600, 0x100000000, 0x4300000000)
2020-10-13T09:18:55.4899397Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:129 +0x129
2020-10-13T09:18:55.4901705Z         github.com/libp2p/go-libp2p-mplex.(*conn).AcceptStream(0xc00284f300, 0x0, 0xdb7e6e, 0xc001316e98, 0xddf600)
2020-10-13T09:18:55.4902650Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-mplex@v0.2.4/conn.go:25 +0x3d
2020-10-13T09:18:55.4903444Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc0028bd700)
2020-10-13T09:18:55.4904516Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.4905314Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.4906173Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.4906612Z         
2020-10-13T09:18:55.4907047Z          Goroutine 8782 in state select, with go.uber.org/fx.withTimeout on top of the stack:
2020-10-13T09:18:55.4907576Z         goroutine 8782 [select]:
2020-10-13T09:18:55.4908022Z         go.uber.org/fx.withTimeout(0x3a4c720, 0xc00011c010, 0xc002cc4280, 0x0, 0x0)
2020-10-13T09:18:55.4908573Z         	/home/runner/go/pkg/mod/go.uber.org/fx@v1.13.1/app.go:747 +0x161
2020-10-13T09:18:55.4909074Z         go.uber.org/fx.(*App).Stop(0xc003c02180, 0x3a4c720, 0xc00011c010, 0x0, 0xc0020331a0)
2020-10-13T09:18:55.4909613Z         	/home/runner/go/pkg/mod/go.uber.org/fx@v1.13.1/app.go:572 +0xe6
2020-10-13T09:18:55.4910327Z         github.com/ipfs/go-ipfs/core.NewNode.func1.1()
2020-10-13T09:18:55.4911138Z         	/home/runner/go/pkg/mod/github.com/ipfs/go-ipfs@v0.7.0/core/builder.go:52 +0xa4
2020-10-13T09:18:55.4911636Z         sync.(*Once).doSlow(0xc00084d470, 0xc002085e88)
2020-10-13T09:18:55.4912102Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/sync/once.go:66 +0x104
2020-10-13T09:18:55.4912524Z         sync.(*Once).Do(0xc00084d470, 0xc002085e88)
2020-10-13T09:18:55.4912972Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/sync/once.go:57 +0x69
2020-10-13T09:18:55.4913876Z         github.com/ipfs/go-ipfs/core.NewNode.func1(0xc0013591d0, 0xc002085f10)
2020-10-13T09:18:55.4914684Z         	/home/runner/go/pkg/mod/github.com/ipfs/go-ipfs@v0.7.0/core/builder.go:51 +0x89
2020-10-13T09:18:55.4915711Z         github.com/ipfs/go-ipfs/core.NewNode.func2(0x3a4c6e0, 0xc003127640, 0xc001358fc0, 0x3a4c7a0, 0xc00301f680)
2020-10-13T09:18:55.4916650Z         	/home/runner/go/pkg/mod/github.com/ipfs/go-ipfs@v0.7.0/core/builder.go:69 +0x17e
2020-10-13T09:18:55.4917351Z         created by github.com/ipfs/go-ipfs/core.NewNode
2020-10-13T09:18:55.4918094Z         	/home/runner/go/pkg/mod/github.com/ipfs/go-ipfs@v0.7.0/core/builder.go:63 +0x577
2020-10-13T09:18:55.4918483Z         
2020-10-13T09:18:55.4919214Z          Goroutine 10624 in state select, with github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing on top of the stack:
2020-10-13T09:18:55.4919783Z         goroutine 10624 [select]:
2020-10-13T09:18:55.4920417Z         github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing(0xc002799f80)
2020-10-13T09:18:55.4921233Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:191 +0x158
2020-10-13T09:18:55.4921987Z         created by github.com/libp2p/go-mplex.NewMultiplex
2020-10-13T09:18:55.4922804Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:107 +0x3a2
2020-10-13T09:18:55.4923202Z         
2020-10-13T09:18:55.4924058Z          Goroutine 10441 in state select, with github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing on top of the stack:
2020-10-13T09:18:55.4924816Z         goroutine 10441 [select]:
2020-10-13T09:18:55.4926151Z         github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing(0xc002798680)
2020-10-13T09:18:55.4927071Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:191 +0x158
2020-10-13T09:18:55.5012170Z         created by github.com/libp2p/go-mplex.NewMultiplex
2020-10-13T09:18:55.5013278Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:107 +0x3a2
2020-10-13T09:18:55.5013687Z         
2020-10-13T09:18:55.5014487Z          Goroutine 8550 in state select, with github.com/libp2p/go-libp2p-swarm.(*DialBackoff).background on top of the stack:
2020-10-13T09:18:55.5015105Z         goroutine 8550 [select]:
2020-10-13T09:18:55.5016053Z         github.com/libp2p/go-libp2p-swarm.(*DialBackoff).background(0xc001722d10, 0x3a4c6e0, 0xc0038e0c80)
2020-10-13T09:18:55.5017016Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_dial.go:126 +0x1a1
2020-10-13T09:18:55.5017831Z         created by github.com/libp2p/go-libp2p-swarm.(*DialBackoff).init
2020-10-13T09:18:55.5018694Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_dial.go:119 +0x7b
2020-10-13T09:18:55.5019117Z         
2020-10-13T09:18:55.5019959Z          Goroutine 10284 in state chan receive, with github.com/libp2p/go-libp2p-quic-transport.(*transport).Dial.func1 on top of the stack:
2020-10-13T09:18:55.5020643Z         goroutine 10284 [chan receive]:
2020-10-13T09:18:55.5021462Z         github.com/libp2p/go-libp2p-quic-transport.(*transport).Dial.func1(0x7fab883e9a48, 0xc00302c840, 0xc003872400)
2020-10-13T09:18:55.5022575Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-quic-transport@v0.8.1/transport.go:175 +0x6a
2020-10-13T09:18:55.5023539Z         created by github.com/libp2p/go-libp2p-quic-transport.(*transport).Dial
2020-10-13T09:18:55.5024571Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-quic-transport@v0.8.1/transport.go:174 +0x397
2020-10-13T09:18:55.5025079Z         
2020-10-13T09:18:55.5025879Z          Goroutine 8480 in state chan receive, with github.com/libp2p/go-libp2p/p2p/protocol/identify.(*IDService).loop.func1 on top of the stack:
2020-10-13T09:18:55.5026518Z         goroutine 8480 [chan receive]:
2020-10-13T09:18:55.5027355Z         github.com/libp2p/go-libp2p/p2p/protocol/identify.(*IDService).loop.func1(0x3a1be20, 0xc002f85da0, 0xc0039bdda0, 0xc003cda420)
2020-10-13T09:18:55.5028371Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p@v0.11.0/p2p/protocol/identify/id.go:193 +0xae
2020-10-13T09:18:55.5029489Z         github.com/libp2p/go-libp2p/p2p/protocol/identify.(*IDService).loop(0xc003ab9790)
2020-10-13T09:18:55.5030625Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p@v0.11.0/p2p/protocol/identify/id.go:269 +0xd2b
2020-10-13T09:18:55.5031547Z         created by github.com/libp2p/go-libp2p/p2p/protocol/identify.NewIDService
2020-10-13T09:18:55.5032502Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p@v0.11.0/p2p/protocol/identify/id.go:151 +0x504
2020-10-13T09:18:55.5032931Z         
2020-10-13T09:18:55.5033656Z          Goroutine 10691 in state select, with github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing on top of the stack:
2020-10-13T09:18:55.5034221Z         goroutine 10691 [select]:
2020-10-13T09:18:55.5035021Z         github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing(0xc0026ee200)
2020-10-13T09:18:55.5035833Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:191 +0x158
2020-10-13T09:18:55.5036559Z         created by github.com/libp2p/go-mplex.NewMultiplex
2020-10-13T09:18:55.5037529Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:107 +0x3a2
2020-10-13T09:18:55.5038099Z         
2020-10-13T09:18:55.5038857Z          Goroutine 8551 in state select, with github.com/libp2p/go-libp2p-autonat.(*autoNATService).background on top of the stack:
2020-10-13T09:18:55.5039593Z         goroutine 8551 [select]:
2020-10-13T09:18:55.5040386Z         github.com/libp2p/go-libp2p-autonat.(*autoNATService).background(0xc003a955e0, 0x3a4c6e0, 0xc0038e0f80)
2020-10-13T09:18:55.5041327Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/svc.go:218 +0x3c4
2020-10-13T09:18:55.5042151Z         created by github.com/libp2p/go-libp2p-autonat.(*autoNATService).Enable
2020-10-13T09:18:55.5043024Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/svc.go:198 +0x172
2020-10-13T09:18:55.5043426Z         
2020-10-13T09:18:55.5044239Z          Goroutine 9266 in state chan receive, with github.com/libp2p/go-libp2p-quic-transport.(*transport).Dial.func1 on top of the stack:
2020-10-13T09:18:55.5044901Z         goroutine 9266 [chan receive]:
2020-10-13T09:18:55.5045728Z         github.com/libp2p/go-libp2p-quic-transport.(*transport).Dial.func1(0x7fab883e9a48, 0xc002d82dc0, 0xc003872400)
2020-10-13T09:18:55.5046797Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-quic-transport@v0.8.1/transport.go:175 +0x6a
2020-10-13T09:18:55.5047947Z         created by github.com/libp2p/go-libp2p-quic-transport.(*transport).Dial
2020-10-13T09:18:55.5048967Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-quic-transport@v0.8.1/transport.go:174 +0x397
2020-10-13T09:18:55.5049479Z         
2020-10-13T09:18:55.5050148Z          Goroutine 11577 in state select, with github.com/libp2p/go-mplex.(*Multiplex).Accept on top of the stack:
2020-10-13T09:18:55.5050826Z         goroutine 11577 [select]:
2020-10-13T09:18:55.5051485Z         github.com/libp2p/go-mplex.(*Multiplex).Accept(0xc0028fa600, 0xc001722600, 0x100000000, 0x4d00000000)
2020-10-13T09:18:55.5052457Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:129 +0x129
2020-10-13T09:18:55.5053346Z         github.com/libp2p/go-libp2p-mplex.(*conn).AcceptStream(0xc0028fa600, 0x0, 0xdb7e6e, 0xc002118e98, 0xddf600)
2020-10-13T09:18:55.5054244Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-mplex@v0.2.4/conn.go:25 +0x3d
2020-10-13T09:18:55.5055008Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc002920780)
2020-10-13T09:18:55.5055993Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.5056723Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.5057949Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.5058391Z         
2020-10-13T09:18:55.5059238Z          Goroutine 9495 in state select, with github.com/libp2p/go-mplex.(*Stream).waitForData on top of the stack:
2020-10-13T09:18:55.5059754Z         goroutine 9495 [select]:
2020-10-13T09:18:55.5060394Z         github.com/libp2p/go-mplex.(*Stream).waitForData(0xc003b77b00, 0xc0023cb380, 0x0)
2020-10-13T09:18:55.5061426Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:76 +0x1a9
2020-10-13T09:18:55.5062296Z         github.com/libp2p/go-mplex.(*Stream).Read(0xc003b77b00, 0xc003c37c30, 0x1, 0x1, 0xc00231d8b0, 0xd8b543, 0xc00231d8b0)
2020-10-13T09:18:55.5063098Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:122 +0x3f5
2020-10-13T09:18:55.5063929Z         github.com/libp2p/go-libp2p-swarm.(*Stream).Read(0xc0038ca5b0, 0xc003c37c30, 0x1, 0x1, 0x3, 0xc003d24480, 0xc0024062f8)
2020-10-13T09:18:55.5064794Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_stream.go:71 +0x98
2020-10-13T09:18:55.5065773Z         github.com/multiformats/go-multistream.(*lazyServerConn).Read(0xc00235cc60, 0xc003c37c30, 0x1, 0x1, 0xc0000709e8, 0x1ee3ed4, 0xc0000709a8)
2020-10-13T09:18:55.5066777Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-multistream@v0.1.2/lazyServer.go:32 +0xa8
2020-10-13T09:18:55.5067977Z         github.com/libp2p/go-libp2p/p2p/host/basic.(*streamWrapper).Read(0xc003c37b80, 0xc003c37c30, 0x1, 0x1, 0x1, 0xc00231da68, 0x2ce72c0)
2020-10-13T09:18:55.5069057Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p@v0.11.0/p2p/host/basic/basic_host.go:1008 +0x78
2020-10-13T09:18:55.5069681Z         io.ReadAtLeast(0x7fab883923a0, 0xc003c37b80, 0xc003c37c30, 0x1, 0x1, 0x1, 0x2ce72c0, 0x39c8490, 0x2f76280)
2020-10-13T09:18:55.5070230Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/io/io.go:310 +0x99
2020-10-13T09:18:55.5070744Z         io.ReadFull(...)
2020-10-13T09:18:55.5071105Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/io/io.go:329
2020-10-13T09:18:55.5071904Z         github.com/libp2p/go-msgio.(*simpleByteReader).ReadByte(0xc003c37c20, 0x2ce2ec0, 0xc00231dad8, 0xdc6c3c)
2020-10-13T09:18:55.5072753Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-msgio@v0.0.6/varint.go:185 +0x82
2020-10-13T09:18:55.5073636Z         github.com/multiformats/go-varint.ReadUvarint(0x3a00860, 0xc003c37c20, 0xdbddba, 0xc0020e8480, 0xc003bbccf0)
2020-10-13T09:18:55.5074533Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-varint@v0.0.6/varint.go:80 +0x85
2020-10-13T09:18:55.5075399Z         github.com/libp2p/go-msgio.(*varintReader).nextMsgLen(0xc003bbccc0, 0x597ec40, 0x597ec40, 0xc0023e9fb0)
2020-10-13T09:18:55.5076228Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-msgio@v0.0.6/varint.go:119 +0xb9
2020-10-13T09:18:55.5077154Z         github.com/libp2p/go-msgio.(*varintReader).ReadMsg(0xc003bbccc0, 0x0, 0x0, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.5078320Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-msgio@v0.0.6/varint.go:149 +0xcc
2020-10-13T09:18:55.5079328Z         github.com/ipfs/go-bitswap/message.FromMsgReader(0x7fab477205c8, 0xc003bbccc0, 0xc003bbccc0, 0x7fab477205c8, 0xc003bbccc0, 0x3a7c220)
2020-10-13T09:18:55.5080360Z         	/home/runner/go/pkg/mod/github.com/ipfs/go-bitswap@v0.2.20/message/message.go:404 +0x5d
2020-10-13T09:18:55.5081446Z         github.com/ipfs/go-bitswap/network.(*impl).handleNewStream(0xc0014a70e0, 0x3a72700, 0xc003c37b80)
2020-10-13T09:18:55.5082307Z         	/home/runner/go/pkg/mod/github.com/ipfs/go-bitswap@v0.2.20/network/ipfs_impl.go:391 +0x5a8
2020-10-13T09:18:55.5083278Z         github.com/libp2p/go-libp2p/p2p/host/basic.(*BasicHost).SetStreamHandler.func1(0xc003ac1040, 0x13, 0x7fab883e9b88, 0xc003c37b80, 0x1, 0x0)
2020-10-13T09:18:55.5084261Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p@v0.11.0/p2p/host/basic/basic_host.go:566 +0xb5
2020-10-13T09:18:55.5085058Z         created by github.com/libp2p/go-libp2p/p2p/host/basic.(*BasicHost).newStreamHandler
2020-10-13T09:18:55.5085904Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p@v0.11.0/p2p/host/basic/basic_host.go:416 +0x799
2020-10-13T09:18:55.5086271Z         
2020-10-13T09:18:55.5086881Z          Goroutine 10573 in state select, with github.com/libp2p/go-mplex.(*Multiplex).Accept on top of the stack:
2020-10-13T09:18:55.5087798Z         goroutine 10573 [select]:
2020-10-13T09:18:55.5088570Z         github.com/libp2p/go-mplex.(*Multiplex).Accept(0xc0026b7d00, 0xc001722600, 0x100000000, 0x2c00000000)
2020-10-13T09:18:55.5089456Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:129 +0x129
2020-10-13T09:18:55.5090525Z         github.com/libp2p/go-libp2p-mplex.(*conn).AcceptStream(0xc0026b7d00, 0x0, 0xdb7e6e, 0xc0020f1e98, 0xddf600)
2020-10-13T09:18:55.5291994Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-mplex@v0.2.4/conn.go:25 +0x3d
2020-10-13T09:18:55.5292924Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc0026b7d80)
2020-10-13T09:18:55.5293729Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.5294422Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.5295145Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.5295529Z         
2020-10-13T09:18:55.5296323Z          Goroutine 9524 in state select, with github.com/lucas-clemente/quic-go.(*incomingBidiStreamsMap).AcceptStream on top of the stack:
2020-10-13T09:18:55.5297132Z         goroutine 9524 [select]:
2020-10-13T09:18:55.5298332Z         github.com/lucas-clemente/quic-go.(*incomingBidiStreamsMap).AcceptStream(0xc0037f5c70, 0x3a4c720, 0xc00011c010, 0x0, 0x0, 0xc003bc41d0, 0x10)
2020-10-13T09:18:55.5299463Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/streams_map_incoming_bidi.go:71 +0x239
2020-10-13T09:18:55.5300703Z         github.com/lucas-clemente/quic-go.(*streamsMap).AcceptStream(0xc003b50140, 0x3a4c720, 0xc00011c010, 0xc002b40e28, 0xdfd305, 0xe018a6, 0xc002b40ec8)
2020-10-13T09:18:55.5301869Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/streams_map.go:127 +0x78
2020-10-13T09:18:55.5302799Z         github.com/lucas-clemente/quic-go.(*session).AcceptStream(0xc002d83080, 0x3a4c720, 0xc00011c010, 0xe017ce, 0x0, 0xdb7e6e, 0xc002b40e98)
2020-10-13T09:18:55.5304526Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/session.go:1635 +0x6e
2020-10-13T09:18:55.5306518Z         github.com/libp2p/go-libp2p-quic-transport.(*conn).AcceptStream(0xc003c2e800, 0x36b8990, 0xc003c2e880, 0x3a624c0, 0xc003bc41d0)
2020-10-13T09:18:55.5307805Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-quic-transport@v0.8.1/conn.go:47 +0x87
2020-10-13T09:18:55.5309221Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc003c2e880)
2020-10-13T09:18:55.5310371Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.5311057Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.5311800Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.5312181Z         
2020-10-13T09:18:55.5312819Z          Goroutine 8575 in state select, with github.com/lucas-clemente/quic-go.(*baseServer).run on top of the stack:
2020-10-13T09:18:55.5313318Z         goroutine 8575 [select]:
2020-10-13T09:18:55.5313883Z         github.com/lucas-clemente/quic-go.(*baseServer).run(0xc001f191e0)
2020-10-13T09:18:55.5314639Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/server.go:221 +0x1e5
2020-10-13T09:18:55.5315318Z         created by github.com/lucas-clemente/quic-go.listen
2020-10-13T09:18:55.5316050Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/server.go:207 +0x8b9
2020-10-13T09:18:55.5316408Z         
2020-10-13T09:18:55.5317006Z          Goroutine 10764 in state select, with github.com/libp2p/go-mplex.(*Multiplex).Accept on top of the stack:
2020-10-13T09:18:55.5317908Z         goroutine 10764 [select]:
2020-10-13T09:18:55.5318561Z         github.com/libp2p/go-mplex.(*Multiplex).Accept(0xc002799f80, 0xc001722600, 0x100000000, 0x3b00000000)
2020-10-13T09:18:55.5319516Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:129 +0x129
2020-10-13T09:18:55.5320608Z         github.com/libp2p/go-libp2p-mplex.(*conn).AcceptStream(0xc002799f80, 0x0, 0xdb7e6e, 0xc001310698, 0xddf600)
2020-10-13T09:18:55.5321770Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-mplex@v0.2.4/conn.go:25 +0x3d
2020-10-13T09:18:55.5322443Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc002808000)
2020-10-13T09:18:55.5323178Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.5323841Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.5324540Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.5324908Z         
2020-10-13T09:18:55.5325551Z          Goroutine 8546 in state select, with github.com/libp2p/go-libp2p/p2p/host/relay.(*AutoRelay).background on top of the stack:
2020-10-13T09:18:55.5326048Z         goroutine 8546 [select]:
2020-10-13T09:18:55.5326871Z         github.com/libp2p/go-libp2p/p2p/host/relay.(*AutoRelay).background(0xc001e5adc0, 0x3a4c6e0, 0xc003899380)
2020-10-13T09:18:55.5328131Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p@v0.11.0/p2p/host/relay/autorelay.go:88 +0x2b4
2020-10-13T09:18:55.5328937Z         created by github.com/libp2p/go-libp2p/p2p/host/relay.NewAutoRelay
2020-10-13T09:18:55.5329805Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p@v0.11.0/p2p/host/relay/autorelay.go:72 +0x390
2020-10-13T09:18:55.5330230Z         
2020-10-13T09:18:55.5371965Z          Goroutine 10651 in state select, with github.com/libp2p/go-mplex.(*Multiplex).Accept on top of the stack:
2020-10-13T09:18:55.5372654Z         goroutine 10651 [select]:
2020-10-13T09:18:55.5373390Z         github.com/libp2p/go-mplex.(*Multiplex).Accept(0xc0026ee000, 0xc001722600, 0x100000000, 0x3100000000)
2020-10-13T09:18:55.5374147Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:129 +0x129
2020-10-13T09:18:55.5374966Z         github.com/libp2p/go-libp2p-mplex.(*conn).AcceptStream(0xc0026ee000, 0x0, 0xdb7e6e, 0xc00208b698, 0xddf600)
2020-10-13T09:18:55.5375798Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-mplex@v0.2.4/conn.go:25 +0x3d
2020-10-13T09:18:55.5376507Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc0026ee080)
2020-10-13T09:18:55.5377951Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.5378753Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.5379611Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.5380217Z         
2020-10-13T09:18:55.5382070Z          Goroutine 9095 in state chan receive, with github.com/libp2p/go-libp2p-quic-transport.(*transport).Dial.func1 on top of the stack:
2020-10-13T09:18:55.5382661Z         goroutine 9095 [chan receive]:
2020-10-13T09:18:55.5383407Z         github.com/libp2p/go-libp2p-quic-transport.(*transport).Dial.func1(0x7fab883e9a48, 0xc0039f6000, 0xc003872400)
2020-10-13T09:18:55.5384464Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-quic-transport@v0.8.1/transport.go:175 +0x6a
2020-10-13T09:18:55.5385317Z         created by github.com/libp2p/go-libp2p-quic-transport.(*transport).Dial
2020-10-13T09:18:55.5386224Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-quic-transport@v0.8.1/transport.go:174 +0x397
2020-10-13T09:18:55.5386675Z         
2020-10-13T09:18:55.5387704Z          Goroutine 9751 in state select, with github.com/libp2p/go-mplex.(*Multiplex).Accept on top of the stack:
2020-10-13T09:18:55.5388227Z         goroutine 9751 [select]:
2020-10-13T09:18:55.5388899Z         github.com/libp2p/go-mplex.(*Multiplex).Accept(0xc003d16400, 0xc001722600, 0x100000000, 0x1a00000000)
2020-10-13T09:18:55.5389736Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:129 +0x129
2020-10-13T09:18:55.5391306Z         github.com/libp2p/go-libp2p-mplex.(*conn).AcceptStream(0xc003d16400, 0x0, 0xdb7e6e, 0xc001311698, 0xddf600)
2020-10-13T09:18:55.5392188Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-mplex@v0.2.4/conn.go:25 +0x3d
2020-10-13T09:18:55.5392911Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc003d16480)
2020-10-13T09:18:55.5393706Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.5394571Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.5395307Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.5395682Z         
2020-10-13T09:18:55.5396391Z          Goroutine 8554 in state select, with github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).background on top of the stack:
2020-10-13T09:18:55.5397143Z         goroutine 8554 [select]:
2020-10-13T09:18:55.5398220Z         github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).background(0xc003bee000)
2020-10-13T09:18:55.5399177Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:175 +0x48b
2020-10-13T09:18:55.5400100Z         created by github.com/libp2p/go-libp2p-autonat.New
2020-10-13T09:18:55.5401280Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:125 +0xa7f
2020-10-13T09:18:55.5401678Z         
2020-10-13T09:18:55.5402294Z          Goroutine 10964 in state select, with github.com/libp2p/go-mplex.(*Stream).waitForData on top of the stack:
2020-10-13T09:18:55.5402769Z         goroutine 10964 [select]:
2020-10-13T09:18:55.5403348Z         github.com/libp2p/go-mplex.(*Stream).waitForData(0xc0027952c0, 0xc0027efc80, 0x0)
2020-10-13T09:18:55.5404069Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:76 +0x1a9
2020-10-13T09:18:55.5404808Z         github.com/libp2p/go-mplex.(*Stream).Read(0xc0027952c0, 0xc002838000, 0x1000, 0x1000, 0xc0025f37b0, 0x1a0ec1c, 0x0)
2020-10-13T09:18:55.5405552Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:122 +0x3f5
2020-10-13T09:18:55.5406365Z         github.com/libp2p/go-libp2p-swarm.(*Stream).Read(0xc002826ee0, 0xc002838000, 0x1000, 0x1000, 0xde431c, 0xdff55f, 0xc002826fe4)
2020-10-13T09:18:55.5407631Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_stream.go:71 +0x98
2020-10-13T09:18:55.5408566Z         github.com/multiformats/go-multistream.(*lazyClientConn).Read(0xc002826fc0, 0xc002838000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.5409534Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-multistream@v0.1.2/lazyClient.go:75 +0x107
2020-10-13T09:18:55.5410661Z         github.com/libp2p/go-libp2p/p2p/host/basic.(*streamWrapper).Read(0xc002836080, 0xc002838000, 0x1000, 0x1000, 0x0, 0xc002826fe0, 0x1)
2020-10-13T09:18:55.5411499Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p@v0.11.0/p2p/host/basic/basic_host.go:1008 +0x78
2020-10-13T09:18:55.5412107Z         bufio.(*Reader).fill(0xc0028075c0)
2020-10-13T09:18:55.5412508Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/bufio/bufio.go:100 +0x19a
2020-10-13T09:18:55.5412950Z         bufio.(*Reader).ReadByte(0xc0028075c0, 0xc002826fc0, 0xc0027f9700, 0x74)
2020-10-13T09:18:55.5413409Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/bufio/bufio.go:252 +0x5b
2020-10-13T09:18:55.5414194Z         github.com/multiformats/go-varint.ReadUvarint(0x39ff360, 0xc0028075c0, 0x7c, 0x74, 0xc002815500)
2020-10-13T09:18:55.5415007Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-varint@v0.0.6/varint.go:80 +0x85
2020-10-13T09:18:55.5415808Z         github.com/libp2p/go-msgio/protoio.(*uvarintReader).ReadMsg(0xc002815300, 0x3a3ffe0, 0xc002815500, 0x0, 0x0)
2020-10-13T09:18:55.5416630Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-msgio@v0.0.6/protoio/uvarint_reader.go:60 +0x73
2020-10-13T09:18:55.5418101Z         github.com/libp2p/go-libp2p-autonat.(*client).DialBack(0xc00281ffe0, 0x3a4c760, 0xc0028073e0, 0xc0027ae660, 0x22, 0x0, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.5419517Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/client.go:58 +0x4e8
2020-10-13T09:18:55.5420610Z         github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).probe(0xc003bee000, 0xc00282a540)
2020-10-13T09:18:55.5421507Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:371 +0x23d
2020-10-13T09:18:55.5422517Z         created by github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).tryProbe
2020-10-13T09:18:55.5423343Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:360 +0x457
2020-10-13T09:18:55.5423734Z         
2020-10-13T09:18:55.5424380Z          Goroutine 10834 in state select, with github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing on top of the stack:
2020-10-13T09:18:55.5424889Z         goroutine 10834 [select]:
2020-10-13T09:18:55.5425449Z         github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing(0xc002808780)
2020-10-13T09:18:55.5426191Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:191 +0x158
2020-10-13T09:18:55.5427399Z         created by github.com/libp2p/go-mplex.NewMultiplex
2020-10-13T09:18:55.5428170Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:107 +0x3a2
2020-10-13T09:18:55.5428558Z         
2020-10-13T09:18:55.5429207Z          Goroutine 9445 in state select, with github.com/libp2p/go-mplex.(*Multiplex).Accept on top of the stack:
2020-10-13T09:18:55.5429713Z         goroutine 9445 [select]:
2020-10-13T09:18:55.5430538Z         github.com/libp2p/go-mplex.(*Multiplex).Accept(0xc003c2e580, 0xc001722600, 0x100000000, 0x1b00000000)
2020-10-13T09:18:55.5531858Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:129 +0x129
2020-10-13T09:18:55.5533238Z         github.com/libp2p/go-libp2p-mplex.(*conn).AcceptStream(0xc003c2e580, 0x0, 0xdb7e6e, 0xc003c87e98, 0xddf600)
2020-10-13T09:18:55.5534142Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-mplex@v0.2.4/conn.go:25 +0x3d
2020-10-13T09:18:55.5534884Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc003c2e600)
2020-10-13T09:18:55.5535679Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.5536386Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.5537324Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.5537734Z         
2020-10-13T09:18:55.5538558Z          Goroutine 9306 in state select, with github.com/lucas-clemente/quic-go.(*incomingBidiStreamsMap).AcceptStream on top of the stack:
2020-10-13T09:18:55.5539223Z         goroutine 9306 [select]:
2020-10-13T09:18:55.5540283Z         github.com/lucas-clemente/quic-go.(*incomingBidiStreamsMap).AcceptStream(0xc00326df10, 0x3a4c720, 0xc00011c010, 0x0, 0x0, 0xc003aaa980, 0x10)
2020-10-13T09:18:55.5541356Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/streams_map_incoming_bidi.go:71 +0x239
2020-10-13T09:18:55.5542379Z         github.com/lucas-clemente/quic-go.(*streamsMap).AcceptStream(0xc003ade740, 0x3a4c720, 0xc00011c010, 0xc00006fe28, 0xdfd305, 0xe018a6, 0xc00006fec8)
2020-10-13T09:18:55.5543340Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/streams_map.go:127 +0x78
2020-10-13T09:18:55.5544274Z         github.com/lucas-clemente/quic-go.(*session).AcceptStream(0xc002d82dc0, 0x3a4c720, 0xc00011c010, 0xe017ce, 0x0, 0xdb7e6e, 0xc00006fe98)
2020-10-13T09:18:55.5545194Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/session.go:1635 +0x6e
2020-10-13T09:18:55.5546145Z         github.com/libp2p/go-libp2p-quic-transport.(*conn).AcceptStream(0xc003b90c00, 0x36b8990, 0xc003b90c80, 0x3a624c0, 0xc003aaa980)
2020-10-13T09:18:55.5547746Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-quic-transport@v0.8.1/conn.go:47 +0x87
2020-10-13T09:18:55.5548798Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc003b90c80)
2020-10-13T09:18:55.5549727Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.5550867Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.5551652Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.5552052Z         
2020-10-13T09:18:55.5552876Z          Goroutine 9129 in state select, with github.com/lucas-clemente/quic-go.(*incomingBidiStreamsMap).AcceptStream on top of the stack:
2020-10-13T09:18:55.5553535Z         goroutine 9129 [select]:
2020-10-13T09:18:55.5554770Z         github.com/lucas-clemente/quic-go.(*incomingBidiStreamsMap).AcceptStream(0xc003043ce0, 0x3a4c720, 0xc00011c010, 0x0, 0x0, 0xc003827f20, 0x10)
2020-10-13T09:18:55.5555846Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/streams_map_incoming_bidi.go:71 +0x239
2020-10-13T09:18:55.5557079Z         github.com/lucas-clemente/quic-go.(*streamsMap).AcceptStream(0xc003a0b440, 0x3a4c720, 0xc00011c010, 0xc00380fe28, 0xdfd305, 0xe018a6, 0xc00380fec8)
2020-10-13T09:18:55.5558523Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/streams_map.go:127 +0x78
2020-10-13T09:18:55.5559541Z         github.com/lucas-clemente/quic-go.(*session).AcceptStream(0xc0039f6000, 0x3a4c720, 0xc00011c010, 0xe017ce, 0x0, 0xdb7e6e, 0xc00380fe98)
2020-10-13T09:18:55.5560883Z         	/home/runner/go/pkg/mod/github.com/lucas-clemente/quic-go@v0.18.0/session.go:1635 +0x6e
2020-10-13T09:18:55.5562505Z         github.com/libp2p/go-libp2p-quic-transport.(*conn).AcceptStream(0xc003966e00, 0x36b8990, 0xc003a19180, 0x3a624c0, 0xc003827f20)
2020-10-13T09:18:55.5563560Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-quic-transport@v0.8.1/conn.go:47 +0x87
2020-10-13T09:18:55.5564425Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc003a19180)
2020-10-13T09:18:55.5565787Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.5566656Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.5567856Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.5568281Z         
2020-10-13T09:18:55.5569124Z          Goroutine 9506 in state chan receive, with github.com/libp2p/go-libp2p-quic-transport.(*transport).Dial.func1 on top of the stack:
2020-10-13T09:18:55.5569807Z         goroutine 9506 [chan receive]:
2020-10-13T09:18:55.5570960Z         github.com/libp2p/go-libp2p-quic-transport.(*transport).Dial.func1(0x7fab883e9a48, 0xc002d83080, 0xc003872400)
2020-10-13T09:18:55.5633610Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-quic-transport@v0.8.1/transport.go:175 +0x6a
2020-10-13T09:18:55.5634687Z         created by github.com/libp2p/go-libp2p-quic-transport.(*transport).Dial
2020-10-13T09:18:55.5635644Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-quic-transport@v0.8.1/transport.go:174 +0x397
2020-10-13T09:18:55.5636120Z         
2020-10-13T09:18:55.5636746Z          Goroutine 13023 in state select, with github.com/libp2p/go-mplex.(*Multiplex).Accept on top of the stack:
2020-10-13T09:18:55.5637442Z         goroutine 13023 [select]:
2020-10-13T09:18:55.5638095Z         github.com/libp2p/go-mplex.(*Multiplex).Accept(0xc003d3c100, 0xc001722600, 0x100000000, 0x5100000000)
2020-10-13T09:18:55.5638910Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:129 +0x129
2020-10-13T09:18:55.5639796Z         github.com/libp2p/go-libp2p-mplex.(*conn).AcceptStream(0xc003d3c100, 0x0, 0xdb7e6e, 0xc003be5698, 0xddf600)
2020-10-13T09:18:55.5641015Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-mplex@v0.2.4/conn.go:25 +0x3d
2020-10-13T09:18:55.5641718Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc003d3c200)
2020-10-13T09:18:55.5642637Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.5643387Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.5644114Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.5644491Z         
2020-10-13T09:18:55.5645085Z          Goroutine 11462 in state select, with github.com/libp2p/go-mplex.(*Multiplex).Accept on top of the stack:
2020-10-13T09:18:55.5645543Z         goroutine 11462 [select]:
2020-10-13T09:18:55.5646136Z         github.com/libp2p/go-mplex.(*Multiplex).Accept(0xc002920100, 0xc001722600, 0x100000000, 0x4800000000)
2020-10-13T09:18:55.5647061Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:129 +0x129
2020-10-13T09:18:55.5648333Z         github.com/libp2p/go-libp2p-mplex.(*conn).AcceptStream(0xc002920100, 0x0, 0xdb7e6e, 0xc00155f698, 0xddf600)
2020-10-13T09:18:55.5649250Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-mplex@v0.2.4/conn.go:25 +0x3d
2020-10-13T09:18:55.5650187Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc0028fa300)
2020-10-13T09:18:55.5651540Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.5652516Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.5653265Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.5653831Z         
2020-10-13T09:18:55.5654459Z          Goroutine 11045 in state select, with github.com/libp2p/go-mplex.(*Stream).waitForData on top of the stack:
2020-10-13T09:18:55.5654951Z         goroutine 11045 [select]:
2020-10-13T09:18:55.5655740Z         github.com/libp2p/go-mplex.(*Stream).waitForData(0xc0027955c0, 0xc002846120, 0x0)
2020-10-13T09:18:55.5656489Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:76 +0x1a9
2020-10-13T09:18:55.5657880Z         github.com/libp2p/go-mplex.(*Stream).Read(0xc0027955c0, 0xc002849000, 0x1000, 0x1000, 0xc0027057a8, 0xdff823, 0x0)
2020-10-13T09:18:55.5658878Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:122 +0x3f5
2020-10-13T09:18:55.5660503Z         github.com/libp2p/go-libp2p-swarm.(*Stream).Read(0xc00284a380, 0xc002849000, 0x1000, 0x1000, 0xde431c, 0xdff55f, 0xc00284a954)
2020-10-13T09:18:55.5661769Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_stream.go:71 +0x98
2020-10-13T09:18:55.5662899Z         github.com/multiformats/go-multistream.(*lazyClientConn).Read(0xc00284a930, 0xc002849000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.5664280Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-multistream@v0.1.2/lazyClient.go:75 +0x107
2020-10-13T09:18:55.5665424Z         github.com/libp2p/go-libp2p/p2p/host/basic.(*streamWrapper).Read(0xc002837f80, 0xc002849000, 0x1000, 0x1000, 0x0, 0xc00284a950, 0x1)
2020-10-13T09:18:55.5666517Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p@v0.11.0/p2p/host/basic/basic_host.go:1008 +0x78
2020-10-13T09:18:55.5667556Z         bufio.(*Reader).fill(0xc002807e60)
2020-10-13T09:18:55.5668176Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/bufio/bufio.go:100 +0x19a
2020-10-13T09:18:55.5668805Z         bufio.(*Reader).ReadByte(0xc002807e60, 0xc00284a930, 0xc0027f9800, 0x74)
2020-10-13T09:18:55.5669298Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/bufio/bufio.go:252 +0x5b
2020-10-13T09:18:55.5670106Z         github.com/multiformats/go-varint.ReadUvarint(0x39ff360, 0xc002807e60, 0x7c, 0x74, 0xc00285a140)
2020-10-13T09:18:55.5671362Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-varint@v0.0.6/varint.go:80 +0x85
2020-10-13T09:18:55.5672198Z         github.com/libp2p/go-msgio/protoio.(*uvarintReader).ReadMsg(0xc002815f40, 0x3a3ffe0, 0xc00285a140, 0x0, 0x0)
2020-10-13T09:18:55.5673052Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-msgio@v0.0.6/protoio/uvarint_reader.go:60 +0x73
2020-10-13T09:18:55.5674051Z         github.com/libp2p/go-libp2p-autonat.(*client).DialBack(0xc002837ae0, 0x3a4c760, 0xc002807b60, 0xc0027aeb40, 0x22, 0x0, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.5674971Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/client.go:58 +0x4e8
2020-10-13T09:18:55.5675803Z         github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).probe(0xc003bee000, 0xc00282b230)
2020-10-13T09:18:55.5677008Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:371 +0x23d
2020-10-13T09:18:55.5678341Z         created by github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).tryProbe
2020-10-13T09:18:55.5679570Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:360 +0x457
2020-10-13T09:18:55.5680004Z         
2020-10-13T09:18:55.5681047Z          Goroutine 9430 in state select, with github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing on top of the stack:
2020-10-13T09:18:55.5681578Z         goroutine 9430 [select]:
2020-10-13T09:18:55.5682370Z         github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing(0xc003c2e580)
2020-10-13T09:18:55.5683244Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:191 +0x158
2020-10-13T09:18:55.5683918Z         created by github.com/libp2p/go-mplex.NewMultiplex
2020-10-13T09:18:55.5684620Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:107 +0x3a2
2020-10-13T09:18:55.5684974Z         
2020-10-13T09:18:55.5685568Z          Goroutine 10706 in state select, with github.com/libp2p/go-mplex.(*Multiplex).Accept on top of the stack:
2020-10-13T09:18:55.5686027Z         goroutine 10706 [select]:
2020-10-13T09:18:55.5686627Z         github.com/libp2p/go-mplex.(*Multiplex).Accept(0xc0026ee200, 0xc001722600, 0x100000000, 0x3e00000000)
2020-10-13T09:18:55.5687830Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:129 +0x129
2020-10-13T09:18:55.5688718Z         github.com/libp2p/go-libp2p-mplex.(*conn).AcceptStream(0xc0026ee200, 0x0, 0xdb7e6e, 0xc003b7c698, 0xddf600)
2020-10-13T09:18:55.5689619Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-mplex@v0.2.4/conn.go:25 +0x3d
2020-10-13T09:18:55.5690736Z         github.com/libp2p/go-libp2p-swarm.(*Conn).start.func1(0xc0026ee280)
2020-10-13T09:18:55.5691522Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:106 +0x18a
2020-10-13T09:18:55.5812836Z         created by github.com/libp2p/go-libp2p-swarm.(*Conn).start
2020-10-13T09:18:55.5813635Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_conn.go:101 +0x4d
2020-10-13T09:18:55.5814021Z         
2020-10-13T09:18:55.5814612Z          Goroutine 8548 in state select, with github.com/jbenet/goprocess/context.CloseAfterContext.func1 on top of the stack:
2020-10-13T09:18:55.5815610Z         goroutine 8548 [select]:
2020-10-13T09:18:55.5816441Z         github.com/jbenet/goprocess/context.CloseAfterContext.func1(0x3a4c6e0, 0xc003899380, 0x3a6c900, 0xc003935860)
2020-10-13T09:18:55.5817484Z         	/home/runner/go/pkg/mod/github.com/jbenet/goprocess@v0.1.4/context/context.go:65 +0x10f
2020-10-13T09:18:55.5818180Z         created by github.com/jbenet/goprocess/context.CloseAfterContext
2020-10-13T09:18:55.5818909Z         	/home/runner/go/pkg/mod/github.com/jbenet/goprocess@v0.1.4/context/context.go:64 +0xba
2020-10-13T09:18:55.5819324Z         
2020-10-13T09:18:55.5820165Z          Goroutine 11373 in state select, with github.com/libp2p/go-mplex.(*Stream).waitForData on top of the stack:
2020-10-13T09:18:55.5820830Z         goroutine 11373 [select]:
2020-10-13T09:18:55.5821403Z         github.com/libp2p/go-mplex.(*Stream).waitForData(0xc00287b380, 0xc002847260, 0x0)
2020-10-13T09:18:55.5822115Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:76 +0x1a9
2020-10-13T09:18:55.5822855Z         github.com/libp2p/go-mplex.(*Stream).Read(0xc00287b380, 0xc00291e000, 0x1000, 0x1000, 0xc0027077a8, 0xdff823, 0x0)
2020-10-13T09:18:55.5823766Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:122 +0x3f5
2020-10-13T09:18:55.5824633Z         github.com/libp2p/go-libp2p-swarm.(*Stream).Read(0xc0029190a0, 0xc00291e000, 0x1000, 0x1000, 0xde431c, 0xdff55f, 0xc002919134)
2020-10-13T09:18:55.5825473Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_stream.go:71 +0x98
2020-10-13T09:18:55.5826329Z         github.com/multiformats/go-multistream.(*lazyClientConn).Read(0xc002919110, 0xc00291e000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.5827916Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-multistream@v0.1.2/lazyClient.go:75 +0x107
2020-10-13T09:18:55.5828911Z         github.com/libp2p/go-libp2p/p2p/host/basic.(*streamWrapper).Read(0xc00290b8e0, 0xc00291e000, 0x1000, 0x1000, 0x0, 0xc002919130, 0x1)
2020-10-13T09:18:55.5829862Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p@v0.11.0/p2p/host/basic/basic_host.go:1008 +0x78
2020-10-13T09:18:55.5830348Z         bufio.(*Reader).fill(0xc00290f860)
2020-10-13T09:18:55.5830796Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/bufio/bufio.go:100 +0x19a
2020-10-13T09:18:55.5832060Z         bufio.(*Reader).ReadByte(0xc00290f860, 0xc002919110, 0xc002867600, 0x74)
2020-10-13T09:18:55.5832499Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/bufio/bufio.go:252 +0x5b
2020-10-13T09:18:55.5833455Z         github.com/multiformats/go-varint.ReadUvarint(0x39ff360, 0xc00290f860, 0x7c, 0x74, 0xc00285b500)
2020-10-13T09:18:55.5834283Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-varint@v0.0.6/varint.go:80 +0x85
2020-10-13T09:18:55.5835089Z         github.com/libp2p/go-msgio/protoio.(*uvarintReader).ReadMsg(0xc00285b2c0, 0x3a3ffe0, 0xc00285b500, 0x0, 0x0)
2020-10-13T09:18:55.5835921Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-msgio@v0.0.6/protoio/uvarint_reader.go:60 +0x73
2020-10-13T09:18:55.5837034Z         github.com/libp2p/go-libp2p-autonat.(*client).DialBack(0xc00290b880, 0x3a4c760, 0xc00290f740, 0xc002878840, 0x26, 0x0, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.5838176Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/client.go:58 +0x4e8
2020-10-13T09:18:55.5839421Z         github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).probe(0xc003bee000, 0xc002914480)
2020-10-13T09:18:55.5840374Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:371 +0x23d
2020-10-13T09:18:55.5841660Z         created by github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).tryProbe
2020-10-13T09:18:55.5842489Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:360 +0x457
2020-10-13T09:18:55.5842879Z         
2020-10-13T09:18:55.5843520Z          Goroutine 10609 in state select, with github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing on top of the stack:
2020-10-13T09:18:55.5844024Z         goroutine 10609 [select]:
2020-10-13T09:18:55.5844591Z         github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing(0xc0026ee000)
2020-10-13T09:18:55.5845338Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:191 +0x158
2020-10-13T09:18:55.5846012Z         created by github.com/libp2p/go-mplex.NewMultiplex
2020-10-13T09:18:55.5846908Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:107 +0x3a2
2020-10-13T09:18:55.5847482Z         
2020-10-13T09:18:55.5848165Z          Goroutine 11226 in state select, with github.com/libp2p/go-mplex.(*Stream).waitForData on top of the stack:
2020-10-13T09:18:55.5848699Z         goroutine 11226 [select]:
2020-10-13T09:18:55.5849668Z         github.com/libp2p/go-mplex.(*Stream).waitForData(0xc00287af00, 0xc002846ba0, 0x0)
2020-10-13T09:18:55.5850657Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:76 +0x1a9
2020-10-13T09:18:55.5851411Z         github.com/libp2p/go-mplex.(*Stream).Read(0xc00287af00, 0xc0028ec000, 0x1000, 0x1000, 0xc00265f7a8, 0xdff823, 0x0)
2020-10-13T09:18:55.5852422Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:122 +0x3f5
2020-10-13T09:18:55.5853287Z         github.com/libp2p/go-libp2p-swarm.(*Stream).Read(0xc00284bce0, 0xc0028ec000, 0x1000, 0x1000, 0xde431c, 0xdff55f, 0xc0028e2bf4)
2020-10-13T09:18:55.5854157Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_stream.go:71 +0x98
2020-10-13T09:18:55.5855025Z         github.com/multiformats/go-multistream.(*lazyClientConn).Read(0xc0028e2bd0, 0xc0028ec000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.5856131Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-multistream@v0.1.2/lazyClient.go:75 +0x107
2020-10-13T09:18:55.5857280Z         github.com/libp2p/go-libp2p/p2p/host/basic.(*streamWrapper).Read(0xc0028dfb40, 0xc0028ec000, 0x1000, 0x1000, 0x0, 0xc0028e2bf0, 0x1)
2020-10-13T09:18:55.5858437Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p@v0.11.0/p2p/host/basic/basic_host.go:1008 +0x78
2020-10-13T09:18:55.5858952Z         bufio.(*Reader).fill(0xc0028d5da0)
2020-10-13T09:18:55.5859426Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/bufio/bufio.go:100 +0x19a
2020-10-13T09:18:55.5860439Z         bufio.(*Reader).ReadByte(0xc0028d5da0, 0xc0028e2bd0, 0xc0028a1000, 0x74)
2020-10-13T09:18:55.5861089Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/bufio/bufio.go:252 +0x5b
2020-10-13T09:18:55.5861910Z         github.com/multiformats/go-varint.ReadUvarint(0x39ff360, 0xc0028d5da0, 0x7c, 0x74, 0xc0028f0040)
2020-10-13T09:18:55.5862741Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-varint@v0.0.6/varint.go:80 +0x85
2020-10-13T09:18:55.5863551Z         github.com/libp2p/go-msgio/protoio.(*uvarintReader).ReadMsg(0xc002895dc0, 0x3a3ffe0, 0xc0028f0040, 0x0, 0x0)
2020-10-13T09:18:55.5864381Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-msgio@v0.0.6/protoio/uvarint_reader.go:60 +0x73
2020-10-13T09:18:55.5865251Z         github.com/libp2p/go-libp2p-autonat.(*client).DialBack(0xc00290a9a0, 0x3a4c760, 0xc00290ec00, 0xc0027afbc0, 0x22, 0x0, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.5866122Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/client.go:58 +0x4e8
2020-10-13T09:18:55.5867116Z         github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).probe(0xc003bee000, 0xc00286be30)
2020-10-13T09:18:55.5868254Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:371 +0x23d
2020-10-13T09:18:55.5869133Z         created by github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).tryProbe
2020-10-13T09:18:55.5870066Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:360 +0x457
2020-10-13T09:18:55.5871249Z         
2020-10-13T09:18:55.5872102Z          Goroutine 10480 in state select, with github.com/libp2p/go-mplex.(*Stream).waitForData on top of the stack:
2020-10-13T09:18:55.5872588Z         goroutine 10480 [select]:
2020-10-13T09:18:55.5873171Z         github.com/libp2p/go-mplex.(*Stream).waitForData(0xc002794600, 0xc0027791a0, 0x0)
2020-10-13T09:18:55.5873905Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:76 +0x1a9
2020-10-13T09:18:55.5874821Z         github.com/libp2p/go-mplex.(*Stream).Read(0xc002794600, 0xc00279d000, 0x1000, 0x1000, 0xc0027417a8, 0xdff823, 0x0)
2020-10-13T09:18:55.5875559Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:122 +0x3f5
2020-10-13T09:18:55.5876356Z         github.com/libp2p/go-libp2p-swarm.(*Stream).Read(0xc003d8d960, 0xc00279d000, 0x1000, 0x1000, 0xde431c, 0xdff55f, 0xc003d8da64)
2020-10-13T09:18:55.5878032Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_stream.go:71 +0x98
2020-10-13T09:18:55.5879047Z         github.com/multiformats/go-multistream.(*lazyClientConn).Read(0xc003d8da40, 0xc00279d000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.5892581Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-multistream@v0.1.2/lazyClient.go:75 +0x107
2020-10-13T09:18:55.5893692Z         github.com/libp2p/go-libp2p/p2p/host/basic.(*streamWrapper).Read(0xc002797560, 0xc00279d000, 0x1000, 0x1000, 0x0, 0xc003d8da60, 0x1)
2020-10-13T09:18:55.5894610Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p@v0.11.0/p2p/host/basic/basic_host.go:1008 +0x78
2020-10-13T09:18:55.5895067Z         bufio.(*Reader).fill(0xc0027ac120)
2020-10-13T09:18:55.5895650Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/bufio/bufio.go:100 +0x19a
2020-10-13T09:18:55.5896114Z         bufio.(*Reader).ReadByte(0xc0027ac120, 0xc003d8da40, 0xc002738c00, 0x6a)
2020-10-13T09:18:55.5896791Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/bufio/bufio.go:252 +0x5b
2020-10-13T09:18:55.5898104Z         github.com/multiformats/go-varint.ReadUvarint(0x39ff360, 0xc0027ac120, 0x72, 0x6a, 0xc002788cc0)
2020-10-13T09:18:55.5899073Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-varint@v0.0.6/varint.go:80 +0x85
2020-10-13T09:18:55.5900002Z         github.com/libp2p/go-msgio/protoio.(*uvarintReader).ReadMsg(0xc002788a80, 0x3a3ffe0, 0xc002788cc0, 0x0, 0x0)
2020-10-13T09:18:55.5901227Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-msgio@v0.0.6/protoio/uvarint_reader.go:60 +0x73
2020-10-13T09:18:55.5902224Z         github.com/libp2p/go-libp2p-autonat.(*client).DialBack(0xc0027974a0, 0x3a4c760, 0xc002791f80, 0xc0026256b0, 0x22, 0x0, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.5903070Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/client.go:58 +0x4e8
2020-10-13T09:18:55.5903876Z         github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).probe(0xc003bee000, 0xc00278f590)
2020-10-13T09:18:55.5904713Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:371 +0x23d
2020-10-13T09:18:55.5905495Z         created by github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).tryProbe
2020-10-13T09:18:55.5906321Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:360 +0x457
2020-10-13T09:18:55.5906708Z         
2020-10-13T09:18:55.5907926Z          Goroutine 8489 in state chan receive, with github.com/libp2p/go-libp2p-transport-upgrader.(*listener).Accept on top of the stack:
2020-10-13T09:18:55.5908631Z         goroutine 8489 [chan receive]:
2020-10-13T09:18:55.5909509Z         github.com/libp2p/go-libp2p-transport-upgrader.(*listener).Accept(0xc003934000, 0x102dc0e01, 0xc00211ced0, 0x1a337f7, 0x0)
2020-10-13T09:18:55.5910851Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-transport-upgrader@v0.3.0/listener.go:155 +0x73
2020-10-13T09:18:55.5912108Z         github.com/libp2p/go-libp2p-swarm.(*Swarm).AddListenAddr.func2(0x3a4d3e0, 0xc003934000, 0xc001722600, 0x3a74900, 0xc00000f6e0)
2020-10-13T09:18:55.5913062Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_listen.go:84 +0x1a7
2020-10-13T09:18:55.5914048Z         created by github.com/libp2p/go-libp2p-swarm.(*Swarm).AddListenAddr
2020-10-13T09:18:55.5914838Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_listen.go:69 +0x328
2020-10-13T09:18:55.5915220Z         
2020-10-13T09:18:55.5915867Z          Goroutine 10510 in state select, with github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing on top of the stack:
2020-10-13T09:18:55.5916378Z         goroutine 10510 [select]:
2020-10-13T09:18:55.5917136Z         github.com/libp2p/go-mplex.(*Multiplex).handleOutgoing(0xc0026b7d00)
2020-10-13T09:18:55.5918171Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:191 +0x158
2020-10-13T09:18:55.5919056Z         created by github.com/libp2p/go-mplex.NewMultiplex
2020-10-13T09:18:55.5920045Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/multiplex.go:107 +0x3a2
2020-10-13T09:18:55.5920780Z         
2020-10-13T09:18:55.5921408Z          Goroutine 10917 in state select, with github.com/libp2p/go-mplex.(*Stream).waitForData on top of the stack:
2020-10-13T09:18:55.5921895Z         goroutine 10917 [select]:
2020-10-13T09:18:55.5922485Z         github.com/libp2p/go-mplex.(*Stream).waitForData(0xc002795140, 0xc0027ef9e0, 0x0)
2020-10-13T09:18:55.5923451Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:76 +0x1a9
2020-10-13T09:18:55.5924229Z         github.com/libp2p/go-mplex.(*Stream).Read(0xc002795140, 0xc00282c000, 0x1000, 0x1000, 0xc0027697a8, 0xdff823, 0x0)
2020-10-13T09:18:55.5924956Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-mplex@v0.1.3/stream.go:122 +0x3f5
2020-10-13T09:18:55.5925753Z         github.com/libp2p/go-libp2p-swarm.(*Stream).Read(0xc002826230, 0xc00282c000, 0x1000, 0x1000, 0xde431c, 0xdff55f, 0xc0028262c4)
2020-10-13T09:18:55.5926588Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-swarm@v0.2.8/swarm_stream.go:71 +0x98
2020-10-13T09:18:55.5928081Z         github.com/multiformats/go-multistream.(*lazyClientConn).Read(0xc0028262a0, 0xc00282c000, 0x1000, 0x1000, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.5930259Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-multistream@v0.1.2/lazyClient.go:75 +0x107
2020-10-13T09:18:55.5931467Z         github.com/libp2p/go-libp2p/p2p/host/basic.(*streamWrapper).Read(0xc00281f140, 0xc00282c000, 0x1000, 0x1000, 0x0, 0xc0028262c0, 0x1)
2020-10-13T09:18:55.5933703Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p@v0.11.0/p2p/host/basic/basic_host.go:1008 +0x78
2020-10-13T09:18:55.5934120Z         bufio.(*Reader).fill(0xc002807080)
2020-10-13T09:18:55.5934492Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/bufio/bufio.go:100 +0x19a
2020-10-13T09:18:55.5934899Z         bufio.(*Reader).ReadByte(0xc002807080, 0xc0028262a0, 0xc0027f9680, 0x74)
2020-10-13T09:18:55.5936236Z         	/opt/hostedtoolcache/go/1.14.9/x64/src/bufio/bufio.go:252 +0x5b
2020-10-13T09:18:55.5937543Z         github.com/multiformats/go-varint.ReadUvarint(0x39ff360, 0xc002807080, 0x7c, 0x74, 0xc002814d40)
2020-10-13T09:18:55.5938567Z         	/home/runner/go/pkg/mod/github.com/multiformats/go-varint@v0.0.6/varint.go:80 +0x85
2020-10-13T09:18:55.5939871Z         github.com/libp2p/go-msgio/protoio.(*uvarintReader).ReadMsg(0xc002814b40, 0x3a3ffe0, 0xc002814d40, 0x0, 0x0)
2020-10-13T09:18:55.5941314Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-msgio@v0.0.6/protoio/uvarint_reader.go:60 +0x73
2020-10-13T09:18:55.5942190Z         github.com/libp2p/go-libp2p-autonat.(*client).DialBack(0xc00281f080, 0x3a4c760, 0xc002806f60, 0xc0027ae3f0, 0x22, 0x0, 0x0, 0x0, 0x0)
2020-10-13T09:18:55.5943046Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/client.go:58 +0x4e8
2020-10-13T09:18:55.5943855Z         github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).probe(0xc003bee000, 0xc0027c7e30)
2020-10-13T09:18:55.5944699Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:371 +0x23d
2020-10-13T09:18:55.5945480Z         created by github.com/libp2p/go-libp2p-autonat.(*AmbientAutoNAT).tryProbe
2020-10-13T09:18:55.5946306Z         	/home/runner/go/pkg/mod/github.com/libp2p/go-libp2p-autonat@v0.3.2/autonat.go:360 +0x457
2020-10-13T09:18:55.5946697Z         ]
2020-10-13T09:18:55.5947652Z --- FAIL: TestFlagsLeak (5.83s)
```