### PR TITLE
fix: test windows on CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,8 @@ on:
       - '.github/workflows/go.yml'
 
 jobs:
-  goreleaser:
+  goreleaser-dryrun:
+    name: "GoReleaser (dry-run)"
     runs-on: ubuntu-latest
     needs: golangci-lint
     steps:
@@ -46,6 +47,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   golangci-lint:
+    name: "GolangCI-lint"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -57,7 +59,17 @@ jobs:
           args: --timeout=10m
           # only-new-issues: true
 
+  # this is unusual to have a job that checks the unstable tests.
+  #
+  # reason: some tests are unstable, they works, but not always;
+  #         this job checks that they are working sometimes.
+  #         if this job fails, then a tests switched from "unstable" to "broken".
+  #
+  #         summary: this job checks that "unstable tests" do not become "broken tests".
+  #
+  # we hope we can remove this job because all the tests are stable 100% of the time :)
   unstable-tests:
+    name: "Unstable tests"
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -83,8 +95,7 @@ jobs:
       - name: Avoid triggering make generate
         run: touch go/gen.sum
       - name: Fetch dependencies
-        run: |
-          go mod download
+        run: go mod download
       - name: Compile the testing binaries
         run: |
           pushd ./go/pkg/bertyprotocol  && go test -c -o ./tests.bin . && popd
@@ -95,13 +106,15 @@ jobs:
           git --no-pager diff go.mod go.sum
           git --no-pager diff --quiet go.mod go.sum
       - name: Run fast unstable tests
-        run: |
-          cd go
-          TEST_SPEED=fast TEST_STABILITY=unstable make go.unstable-tests
-          # FIXME: coverage
+        working-directory: go
+        env:
+          TEST_SPEED: fast
+          TEST_STABILITY: unstable
+        run: make go.unstable-tests
+      # FIXME: coverage
 
   go-tests-on-linux:
-    #needs: golangci-lint
+    name: "Stable tests (linux)"
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -127,8 +140,8 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
       - name: Compile the project on Unix-like operating systems
+        working-directory: go
         run: |
-          cd go
           touch gen.sum # avoid triggering make generate
           make go.install
       - name: Check go.mod and go.sum
@@ -137,25 +150,23 @@ jobs:
           git --no-pager diff go.mod go.sum
           git --no-pager diff --quiet go.mod go.sum
       - name: Run fast tests multiple times
-        run: |
-          cd go
-          TEST_SPEED=fast make go.unittest GO_TEST_OPTS="-v -test.timeout=600s -count 5"
+        working-directory: go
+        env:
+          TEST_SPEED: fast
+          GO_TEST_OPTS: -v -test.timeout=600s -count 5
+        run: make go.unittest
       - name: Run all tests
-        run: |
-          cd go
-          TEST_SPEED=any make go.unittest GO_TEST_OPTS="-v -test.timeout=600s -count 1"
-      #- name: Run all tests with race flag and generate coverage
-      #  uses: nick-invision/retry@v1
-      #  with:
-      #    timeout_minutes: 21
-      #    max_attempts: 5
-      #    command: |
-      #      cd go
-      #      TEST_SPEED=any make go.unittest GO_TEST_OPTS="-v -test.timeout=1200s -count 1 -race -cover -coverprofile=coverage.txt -covermode=atomic"
+        working-directory: go
+        env:
+          TEST_SPEED: any
+          GO_TEST_OPTS: -v -test.timeout=600s -count 1
+        run: make go.unittest
       - name: Run all tests with race flag and generate coverage
-        run: |
-          cd go
-          TEST_SPEED=any make go.unittest GO_TEST_OPTS="-v -test.timeout=1200s -count 1 -race -cover -coverprofile=coverage.txt -covermode=atomic"
+        working-directory: go
+        env:
+          TEST_SPEED: any
+          GO_TEST_OPTS: -v -test.timeout=1200s -count=1 -race -cover -coverprofile=coverage.txt -covermode=atomic
+        run: make go.unittest
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v1
         with:
@@ -165,5 +176,59 @@ jobs:
           name: codecov-umbrella
           fail_ci_if_error: false
 
-  # TODO: go-tests-on-windows:
-  # TODO: go-tests-on-darwin:
+  go-tests-on-windows:
+    name: "Stable tests (windows)"
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15.x
+      - name: Cache Go modules
+        uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Compile the project on Windows
+        run: go.exe install -buildmode=exe -v ./go/cmd/...
+      - name: Check go.mod and go.sum
+        run: |
+          go mod tidy -v
+          git --no-pager diff go.mod go.sum
+          git --no-pager diff --quiet go.mod go.sum
+      - name: Run fast tests multiple times
+        working-directory: go
+        env:
+          TEST_SPEED: fast
+        run: go.exe test ./... -buildmode=exe -v -timeout=600s -count=5
+      - name: Run all tests
+        working-directory: go
+        env:
+          TEST_SPEED: any
+        run: go.exe test ./... -buildmode=exe -v -timeout=600s -count=1
+      # broken
+      #- name: Run all tests with race flag and generate coverage
+      #  working-directory: go
+      #  env:
+      #    TEST_SPEED: any
+      #  run: go.exe test ./... -buildmode=exe -v -timeout=1200s -count=1 -race -cover -coverprofile=coverage.txt -covermode=atomic
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          file: ./coverage.txt
+          flags: unittests
+          env_vars: OS,GOLANG
+          name: codecov-umbrella
+          fail_ci_if_error: false
+
+# TODO: consider adding a go-tests-on-darwin.
+#       it can validate that the test suite runs successfully on macos.
+#       concern: it will take a precious slot of darwin builder on github-actions
+#       maybe we should just run it with a cron and not on each push
+
+# TODO: consider adding various GOARCH check per OS.
+#       i.e., to validate that we build on 32/64bit.

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -164,3 +164,6 @@ jobs:
           env_vars: OS,GOLANG
           name: codecov-umbrella
           fail_ci_if_error: false
+
+  # TODO: go-tests-on-windows:
+  # TODO: go-tests-on-darwin:

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -216,14 +216,14 @@ jobs:
       #  env:
       #    TEST_SPEED: any
       #  run: go.exe test ./... -buildmode=exe -v -timeout=1200s -count=1 -race -cover -coverprofile=coverage.txt -covermode=atomic
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1
-        with:
-          file: ./coverage.txt
-          flags: unittests
-          env_vars: OS,GOLANG
-          name: codecov-umbrella
-          fail_ci_if_error: false
+      #- name: Upload coverage to Codecov
+      #  uses: codecov/codecov-action@v1
+      #  with:
+      #    file: ./coverage.txt
+      #    flags: unittests
+      #    env_vars: OS,GOLANG
+      #    name: codecov-umbrella
+      #    fail_ci_if_error: false
 
 # TODO: consider adding a go-tests-on-darwin.
 #       it can validate that the test suite runs successfully on macos.

--- a/go/assets/example_test.go
+++ b/go/assets/example_test.go
@@ -1,0 +1,1 @@
+package berty_test

--- a/go/cmd/berty/mini/example_test.go
+++ b/go/cmd/berty/mini/example_test.go
@@ -1,0 +1,1 @@
+package mini_test

--- a/go/cmd/betabot/example_test.go
+++ b/go/cmd/betabot/example_test.go
@@ -1,0 +1,1 @@
+package main_test

--- a/go/cmd/rdvp/example_test.go
+++ b/go/cmd/rdvp/example_test.go
@@ -1,0 +1,1 @@
+package main_test

--- a/go/cmd/testbot/example_test.go
+++ b/go/cmd/testbot/example_test.go
@@ -1,0 +1,1 @@
+package main_test

--- a/go/framework/bertybridge/internal/bridgepb/example_test.go
+++ b/go/framework/bertybridge/internal/bridgepb/example_test.go
@@ -1,0 +1,1 @@
+package bridgepb_test

--- a/go/internal/lifecycle/example_test.go
+++ b/go/internal/lifecycle/example_test.go
@@ -1,0 +1,1 @@
+package lifecycle_test

--- a/go/internal/multipeer-connectivity-transport/driver/example_test.go
+++ b/go/internal/multipeer-connectivity-transport/driver/example_test.go
@@ -1,0 +1,1 @@
+package driver_test

--- a/go/internal/multipeer-connectivity-transport/example_test.go
+++ b/go/internal/multipeer-connectivity-transport/example_test.go
@@ -1,0 +1,1 @@
+package mc_test

--- a/go/internal/multipeer-connectivity-transport/multiaddr/example_test.go
+++ b/go/internal/multipeer-connectivity-transport/multiaddr/example_test.go
@@ -1,0 +1,1 @@
+package multiaddr_test

--- a/go/internal/notification/example_test.go
+++ b/go/internal/notification/example_test.go
@@ -1,0 +1,1 @@
+package notification_test

--- a/go/internal/packingutil/example_test.go
+++ b/go/internal/packingutil/example_test.go
@@ -1,0 +1,1 @@
+package packingutil_test

--- a/go/internal/sysutil/sysutil.go
+++ b/go/internal/sysutil/sysutil.go
@@ -1,0 +1,54 @@
+package sysutil
+
+import (
+	"os"
+	"runtime"
+	"syscall"
+
+	"go.uber.org/multierr"
+	"moul.io/openfiles"
+
+	"berty.tech/berty/v2/go/pkg/bertytypes"
+	"berty.tech/berty/v2/go/pkg/bertyversion"
+	"berty.tech/berty/v2/go/pkg/username"
+)
+
+func SystemInfoProcess() (*bertytypes.SystemInfo_Process, error) {
+	var errs error
+
+	// openfiles
+	nofile, nofileErr := openfiles.Count()
+	errs = multierr.Append(errs, nofileErr)
+
+	// hostname
+	hn, err := os.Hostname()
+	errs = multierr.Append(errs, err)
+
+	// working dir
+	wd, err := syscall.Getwd()
+	errs = multierr.Append(errs, err)
+
+	reply := bertytypes.SystemInfo_Process{
+		Nofile:           nofile,
+		TooManyOpenFiles: openfiles.IsTooManyError(nofileErr),
+		NumCPU:           int64(runtime.NumCPU()),
+		GoVersion:        runtime.Version(),
+		HostName:         hn,
+		NumGoroutine:     int64(runtime.NumGoroutine()),
+		OperatingSystem:  runtime.GOOS,
+		Arch:             runtime.GOARCH,
+		Version:          bertyversion.Version,
+		VcsRef:           bertyversion.VcsRef,
+		PID:              int64(syscall.Getpid()),
+		UID:              int64(syscall.Getuid()),
+		PPID:             int64(syscall.Getppid()),
+		WorkingDir:       wd,
+		SystemUsername:   username.GetUsername(),
+	}
+
+	// see sysutil_<OS>.go files
+	err = appendCustomSystemInfo(&reply)
+	errs = multierr.Append(errs, err)
+
+	return &reply, errs
+}

--- a/go/internal/sysutil/sysutil_unix.go
+++ b/go/internal/sysutil/sysutil_unix.go
@@ -1,0 +1,35 @@
+// +build unix
+
+package sysutil
+
+import (
+	"syscall"
+
+	"berty.tech/berty/v2/go/pkg/bertytypes"
+	"go.uber.org/multierr"
+)
+
+func appendCustomSystemInfo(reply *bertytypes.SystemInfo_Process) error {
+	var errs error
+
+	// rlimit
+	rlimitNofile := syscall.Rlimit{}
+	err := syscall.Getrlimit(syscall.RLIMIT_NOFILE, &rlimitNofile)
+	errs = multierr.Append(errs, err)
+	reply.RlimitCur = rlimitNofile.Cur
+	reply.RlimitMax = rlimitNofile.Max
+
+	// rusage
+	rusage := syscall.Rusage{}
+	err = syscall.Getrusage(syscall.RUSAGE_SELF, &rusage)
+	errs = multierr.Append(errs, err)
+	reply.UserCPUTimeMS = int64(rusage.Utime.Sec*1000) + int64(rusage.Utime.Usec/1000)   // nolint:unconvert // on some archs, those vars may be int32 instead of int64
+	reply.SystemCPUTimeMS = int64(rusage.Stime.Sec*1000) + int64(rusage.Stime.Usec/1000) // nolint:unconvert // on some archs, those vars may be int32 instead of int64
+
+	// process priority
+	prio, err := syscall.Getpriority(syscall.PRIO_PROCESS, 0)
+	errs = multierr.Append(errs, err)
+	reply.Priority = int64(prio)
+
+	return errs
+}

--- a/go/internal/sysutil/sysutil_unsupported.go
+++ b/go/internal/sysutil/sysutil_unsupported.go
@@ -1,0 +1,9 @@
+// +build !unix
+
+package sysutil
+
+import "berty.tech/berty/v2/go/pkg/bertytypes"
+
+func appendCustomSystemInfo(reply *bertytypes.SystemInfo_Process) error {
+	return nil
+}

--- a/go/internal/testutil/example_test.go
+++ b/go/internal/testutil/example_test.go
@@ -1,0 +1,1 @@
+package testutil_test

--- a/go/internal/tools/example_test.go
+++ b/go/internal/tools/example_test.go
@@ -1,0 +1,1 @@
+package tools_test

--- a/go/pkg/bertymessenger/api.go
+++ b/go/pkg/bertymessenger/api.go
@@ -13,6 +13,7 @@ import (
 	"go.uber.org/zap"
 
 	"berty.tech/berty/v2/go/internal/discordlog"
+	"berty.tech/berty/v2/go/internal/sysutil"
 	"berty.tech/berty/v2/go/pkg/banner"
 	"berty.tech/berty/v2/go/pkg/bertyprotocol"
 	"berty.tech/berty/v2/go/pkg/bertytypes"
@@ -359,7 +360,7 @@ func (svc *service) SystemInfo(ctx context.Context, req *SystemInfo_Request) (*S
 	var process *bertytypes.SystemInfo_Process
 	{
 		var err error
-		process, err = bertyprotocol.SystemInfoProcess()
+		process, err = sysutil.SystemInfoProcess()
 		errs = multierr.Append(errs, err)
 		reply.Messenger = &SystemInfo_Messenger{Process: process}
 		reply.Messenger.Process.StartedAt = svc.startedAt.Unix()

--- a/go/pkg/bertytypes/example_test.go
+++ b/go/pkg/bertytypes/example_test.go
@@ -1,0 +1,1 @@
+package bertytypes_test

--- a/go/pkg/bertyversion/example_test.go
+++ b/go/pkg/bertyversion/example_test.go
@@ -1,0 +1,1 @@
+package bertyversion_test

--- a/go/pkg/username/example_test.go
+++ b/go/pkg/username/example_test.go
@@ -1,0 +1,1 @@
+package username_test


### PR DESCRIPTION
* create empty test files in packages without ones to force `go test` trying to build them
* add a windows job on the CI that checks if the project compiles
* make the project installable/testable on windows