### PR TITLE
fix: Improve MC stability

### DIFF
--- a/go/framework/bertybridge/bridge_protocol.go
+++ b/go/framework/bertybridge/bridge_protocol.go
@@ -201,7 +201,7 @@ func newProtocolBridge(ctx context.Context, logger *zap.Logger, config *Messenge
 				SwarmAddrs:        defaultSwarmAddrs,
 				APIAddrs:          defaultAPIAddrs,
 				APIConfig:         APIConfig,
-				ExtraLibp2pOption: libp2p.ChainOptions(libp2p.Transport(mc.NewTransportConstructorWithLogger(logger))),
+				ExtraLibp2pOption: libp2p.ChainOptions(libp2p.Transport(mc.ProximityTransportConstructor(ctx, logger))),
 				IpfsConfigPatch: func(cfg *ipfs_cfg.Config) error {
 					for _, p := range rdvpeers {
 						cfg.Peering.Peers = append(cfg.Peering.Peers, *p)

--- a/go/internal/initutil/ipfs.go
+++ b/go/internal/initutil/ipfs.go
@@ -171,7 +171,7 @@ func (m *Manager) getLocalIPFS() (ipfsutil.ExtendedCoreAPI, *ipfs_core.IpfsNode,
 
 			// Setup MC
 			if m.Node.Preset != PresetAnonymity {
-				mcOpt := libp2p.Transport(mc.NewTransportConstructorWithLogger(logger))
+				mcOpt := libp2p.Transport(mc.ProximityTransportConstructor(m.ctx, logger))
 				if p2pOpts == nil {
 					p2pOpts = mcOpt
 				} else {

--- a/go/internal/multipeer-connectivity-transport/conn.go
+++ b/go/internal/multipeer-connectivity-transport/conn.go
@@ -36,12 +36,12 @@ type Conn struct {
 // Timeout handled by the native driver.
 func (c *Conn) Read(payload []byte) (n int, err error) {
 	if c.ctx.Err() != nil {
-		return 0, fmt.Errorf("conn read failed: conn already closed")
+		return 0, fmt.Errorf("proximityTransport: Conn.Read failed: conn already closed")
 	}
 
 	n, err = c.readOut.Read(payload)
 	if err != nil {
-		err = errors.Wrap(err, "conn read failed")
+		err = errors.Wrap(err, "proximityTransport: Conn.Read failed: native read failed")
 	}
 
 	return n, err
@@ -51,12 +51,12 @@ func (c *Conn) Read(payload []byte) (n int, err error) {
 // Timeout handled by the native driver.
 func (c *Conn) Write(payload []byte) (n int, err error) {
 	if c.ctx.Err() != nil {
-		return 0, fmt.Errorf("conn write failed: conn already closed")
+		return 0, fmt.Errorf("proximityTransport: Conn.Write failed: conn already closed")
 	}
 
 	// Write to the peer's device using native driver.
 	if !mcdrv.SendToPeer(c.RemoteAddr().String(), payload) {
-		return 0, fmt.Errorf("conn write failed: native write failed")
+		return 0, fmt.Errorf("proximityTransport: Conn.Write failed: native write failed")
 	}
 
 	return len(payload), nil
@@ -65,6 +65,7 @@ func (c *Conn) Write(payload []byte) (n int, err error) {
 // Close closes the connection.
 // Any blocked Read or Write operations will be unblocked and return errors.
 func (c *Conn) Close() error {
+	logger.Debug("Conn.Close()")
 	c.cancel()
 
 	// Closes read pipe

--- a/go/internal/multipeer-connectivity-transport/driver/MCManager.m
+++ b/go/internal/multipeer-connectivity-transport/driver/MCManager.m
@@ -127,6 +127,7 @@ NSString *BERTY_DRIVER_MC = @"berty-mc";
         break;
     case MCSessionStateNotConnected:
         NSLog(@"MC: Not connected: %@", [peerID displayName]);
+		BridgeHandleLostPeer([peerID displayName]);
         break;
     }
 }

--- a/go/internal/multipeer-connectivity-transport/driver/bridge_unsupported.go
+++ b/go/internal/multipeer-connectivity-transport/driver/bridge_unsupported.go
@@ -5,10 +5,9 @@ package driver
 // Noop implementation for platform that are not Darwin
 
 // Native -> Go functions
-func BindNativeToGoFunctions(_ func(string) bool, _ func(string, []byte)) {}
+func BindNativeToGoFunctions(_ func(string) bool, _ func(string), _ func(string, []byte)) {}
 
 // Go -> Native functions
-// StartMCDriver returns true else the main app will stop
 func StartMCDriver(_ string)             {}
 func StopMCDriver()                      {}
 func DialPeer(_ string) bool             { return false }

--- a/go/internal/multipeer-connectivity-transport/driver/mc-driver.h
+++ b/go/internal/multipeer-connectivity-transport/driver/mc-driver.h
@@ -14,4 +14,5 @@ int SendToPeer(char *remotePID, void *payload, int length);
 int DialPeer(char *remotePID);
 void CloseConnWithPeer(char *remotePID);
 int BridgeHandleFoundPeer(NSString *remotePID);
+void BridgeHandleLostPeer(NSString *remotePID);
 void BridgeReceiveFromPeer(NSString *remotePID, NSData *payload);

--- a/go/internal/multipeer-connectivity-transport/driver/mc-driver.m
+++ b/go/internal/multipeer-connectivity-transport/driver/mc-driver.m
@@ -7,6 +7,7 @@
 
 // This functions are Go functions so they aren't defined here
 extern int HandleFoundPeer(char *);
+extern void HandleLostPeer(char *);
 extern void ReceiveFromPeer(char *, void *, unsigned long);
 
 int driverStarted = 0;
@@ -70,6 +71,11 @@ int BridgeHandleFoundPeer(NSString *remotePID) {
         return (1);
     }
     return (0);
+}
+
+void BridgeHandleLostPeer(NSString *remotePID) {
+    char *cPID = (char *)[remotePID UTF8String];
+    HandleLostPeer(cPID);
 }
 
 void BridgeReceiveFromPeer(NSString *remotePID, NSData *payload) {

--- a/go/internal/multipeer-connectivity-transport/init.go
+++ b/go/internal/multipeer-connectivity-transport/init.go
@@ -10,6 +10,7 @@ func init() {
 	// Bind native to golang bridge functions
 	mcdrv.BindNativeToGoFunctions(
 		HandleFoundPeer,
+		HandleLostPeer,
 		ReceiveFromPeer,
 	)
 }

--- a/go/internal/multipeer-connectivity-transport/listener.go
+++ b/go/internal/multipeer-connectivity-transport/listener.go
@@ -29,7 +29,7 @@ var _ tpt.Listener = &Listener{}
 // package, and also exposes a Multiaddr method as opposed to a regular Addr
 // method.
 type Listener struct {
-	transport      *Transport
+	transport      *ProximityTransport
 	localMa        ma.Multiaddr
 	inboundConnReq chan connReq // Chan used to accept inbound conn.
 	ctx            context.Context
@@ -43,8 +43,9 @@ type connReq struct {
 }
 
 // newListener starts the native driver then returns a new Listener.
-func newListener(localMa ma.Multiaddr, t *Transport) *Listener {
-	ctx, cancel := context.WithCancel(context.Background())
+func newListener(ctx context.Context, localMa ma.Multiaddr, t *ProximityTransport) *Listener {
+	logger.Debug("newListener()")
+	ctx, cancel := context.WithCancel(ctx)
 
 	listener := &Listener{
 		transport:      t,
@@ -80,7 +81,7 @@ func (l *Listener) Accept() (tpt.CapableConn, error) {
 				return conn, nil
 			}
 		case <-l.ctx.Done():
-			return nil, errors.New("listener accept failed: listener already closed")
+			return nil, errors.New("proximityTransport: Listener.Accept failed: listener already closed")
 		}
 	}
 }

--- a/js/packages/berty-app/ios/Podfile.lock
+++ b/js/packages/berty-app/ios/Podfile.lock
@@ -616,7 +616,7 @@ SPEC CHECKSUMS:
   BVLinearGradient: e3aad03778a456d77928f594a649e96995f1c872
   CocoaAsyncSocket: 694058e7c0ed05a9e217d1b3c7ded962f4180845
   CocoaLibEvent: 2fab71b8bd46dd33ddb959f7928ec5909f838e3f
-  DoubleConversion: cde416483dac037923206447da6e1454df403714
+  DoubleConversion: 5805e889d232975c086db112ece9ed034df7a0b2
   FBLazyVector: 878b59e31113e289e275165efbe4b54fa614d43d
   FBReactNativeSpec: 7da9338acfb98d4ef9e5536805a0704572d33c2f
   Firebase: 210f41ca352067d83b1ba4fd2e7fb49a0c017397
@@ -632,7 +632,7 @@ SPEC CHECKSUMS:
   Flipper-RSocket: 64e7431a55835eb953b0bf984ef3b90ae9fdddd7
   FlipperKit: ab353d41aea8aae2ea6daaf813e67496642f3d7d
   Folly: b73c3869541e86821df3c387eb0af5f65addfab4
-  glog: 40a13f7840415b9a77023fbcae0f1e6f43192af3
+  glog: 1f3da668190260b06b429bb211bfbee5cd790c28
   go-bridge: de774afc40774b684cc0e3f07eb7f7b21888a004
   GoogleDataTransport: 672fb0ce96fe7f7f31d43672fca62ad2c9c86f7b
   GoogleUtilities: 7f2f5a07f888cdb145101d6042bc4422f57e70b3

--- a/js/packages/berty-app/ios/info.yaml
+++ b/js/packages/berty-app/ios/info.yaml
@@ -23,6 +23,7 @@ targets:
             localhost:
               NSExceptionAllowsInsecureHTTPLoads: true
         NSCameraUsageDescription: Used to scan QRCodes
+        NSLocalNetworkUsageDescription: Used for local communications
         NSLocationWhenInUseUsageDescription: ""
         Shake:
           APIClientID: "$(SHAKE_API_ID)"


### PR DESCRIPTION
Stabilize MC: close connections when the driver lost the connection with the remote peer

Rename the transporter with a name more generic: in the future, we should reutilize the transporter for multiple drivers (BLE, Nearby)


Signed-off-by: D4ryl00 <d4ryl00@gmail.com>