### PR TITLE
feat: implement native tempdir getter for Android and iOS

### DIFF
--- a/go/pkg/tempdir/tempdir.go
+++ b/go/pkg/tempdir/tempdir.go
@@ -1,0 +1,5 @@
+package tempdir
+
+func TempDir() string {
+	return tempDir()
+}

--- a/go/pkg/tempdir/tempdir_android.go
+++ b/go/pkg/tempdir/tempdir_android.go
@@ -1,0 +1,63 @@
+// +build android
+
+package tempdir
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"os"
+)
+
+const (
+	globalCacheDir = "/data/local/tmp"
+	appCacheDir1   = "/data/user/0/%s/cache"
+	appCacheDir2   = "/data/data/%s/cache"
+)
+
+func tempDir() string {
+	// Return androidCacheDir if previously set from Java
+	if androidCacheDir != "" {
+		return androidCacheDir
+	}
+
+	// If not set, try to get the temp dir through env
+	if envPath := os.Getenv("TMPDIR"); envPath != "" {
+		if _, err := os.Stat(envPath); err == nil {
+			return envPath
+		}
+	}
+
+	// If not available, get ApplicationID for next tries
+	content, err := ioutil.ReadFile("/proc/self/cmdline")
+	if err == nil {
+		applicationID := string(content[:bytes.IndexByte(content, 0)])
+
+		// Try to get app cache dir variant 1
+		variant1 := fmt.Sprintf(appCacheDir1, applicationID)
+		if _, err := os.Stat(variant1); err == nil {
+			return variant1
+		}
+
+		// Try to get app cache dir variant 2
+		variant2 := fmt.Sprintf(appCacheDir2, applicationID)
+		if _, err := os.Stat(variant2); err == nil {
+			return variant2
+		}
+	}
+
+	// If not available, try to use the global cache dir
+	if _, err := os.Stat(globalCacheDir); err == nil {
+		return globalCacheDir
+	}
+
+	return ""
+}
+
+// Can be set from Java by calling `getCacheDir().getAbsolutePath()` from a
+// context and passing the returned value to `SetAndroidCacheDir()`.
+var androidCacheDir string = ""
+
+func SetAndroidCacheDir(path string) {
+	androidCacheDir = path
+}

--- a/go/pkg/tempdir/tempdir_darwin.go
+++ b/go/pkg/tempdir/tempdir_darwin.go
@@ -1,0 +1,27 @@
+// +build darwin
+
+package tempdir
+
+/*
+#cgo CFLAGS: -x objective-c
+#cgo LDFLAGS: -framework Foundation
+#import <Foundation/Foundation.h>
+
+const char* NativeTempDir() {
+    NSString *tempDir = NSTemporaryDirectory();
+    char *copy = strdup([tempDir UTF8String]);
+
+    return copy;
+}
+*/
+import "C"
+
+import "unsafe"
+
+func tempDir() string {
+	cstring := C.NativeTempDir()
+	path := C.GoString(cstring)
+	C.free(unsafe.Pointer(cstring))
+
+	return path
+}

--- a/go/pkg/tempdir/tempdir_others.go
+++ b/go/pkg/tempdir/tempdir_others.go
@@ -1,0 +1,9 @@
+// +build !android,!darwin
+
+package tempdir
+
+import "os"
+
+func tempDir() string {
+	return os.TempDir()
+}


### PR DESCRIPTION
We should pass the result of the `getCacheDir().getAbsolutePath()` Java method to `SetAndroidCacheDir(path)`.
Could be done in #2499 :) (or I will do it when it will be merged)