### PR TITLE
chore(messenger): unify date formatting

### DIFF
--- a/js/packages/components/chat/MultiMember.tsx
+++ b/js/packages/components/chat/MultiMember.tsx
@@ -265,7 +265,7 @@ const MessageList: React.FC<{
 	setStickyDate: any
 	setShowStickyDate: any
 }> = ({ id, scrollToMessage, setStickyDate, setShowStickyDate }) => {
-	const [{ overflow, margin, row, flex }, { scaleHeight, windowHeight }] = useStyles()
+	const [{ overflow, margin, row, flex }, { scaleHeight }] = useStyles()
 	const conversation = useConversation(id)
 	const ctx = useMsgrContext()
 	const members = (ctx as any).members[id] || {}

--- a/js/packages/components/chat/OneToOne.tsx
+++ b/js/packages/components/chat/OneToOne.tsx
@@ -44,7 +44,7 @@ import { SwipeNavRecognizer } from '../shared-components/SwipeNavRecognizer'
 import Logo from '../main/1_berty_picto.svg'
 import Avatar from '../modals/Buck_Berty_Icon_Card.svg'
 import { groupBy } from 'lodash'
-import { pbDateToNum } from '../helpers'
+import { pbDateToNum, timeFormat } from '../helpers'
 import { useLayout } from '../hooks'
 
 //
@@ -526,8 +526,7 @@ const InfosChat: React.FC<api.berty.messenger.v1.IConversation & any> = ({
 	isBetabotAdded,
 }) => {
 	const [{ flex, text, padding, margin }] = useStyles()
-	const createdDate =
-		(createdDateStr && parseInt((createdDateStr as unknown) as string, 10)) || Date.now()
+	const createdDate = pbDateToNum(createdDateStr) || Date.now()
 	const ctx = useMsgrContext()
 	const contact =
 		Object.values(ctx.contacts).find((c: any) => c.conversationPublicKey === publicKey) || null
@@ -559,9 +558,7 @@ const InfosChat: React.FC<api.berty.messenger.v1.IConversation & any> = ({
 				<>
 					<View style={[flex.align.center]}>
 						<Text style={[text.size.tiny, text.color.grey, margin.top.tiny]}>
-							{Date.now() - new Date(createdDate).getTime() > 86400000
-								? moment(createdDate).format('DD/MM/YYYY')
-								: moment(createdDate).format('hh:mm')}
+							{timeFormat.fmtTimestamp1(pbDateToNum(createdDate))}
 						</Text>
 					</View>
 					<InfosContactState

--- a/js/packages/components/chat/shared-components/Chat.tsx
+++ b/js/packages/components/chat/shared-components/Chat.tsx
@@ -162,11 +162,6 @@ const useStylesChatDate = () => {
 	}
 }
 
-// const formatTimestamp = (date: Date) => {
-// 	const arr = date.toString().split(' ')
-// 	return arr[1] + ' ' + arr[2] + ' ' + arr[3]
-// }
-
 export const ChatDate: React.FC<ChatDateProps> = ({ date }) => {
 	const _styles = useStylesChatDate()
 	const [{ border, row }] = useStyles()
@@ -174,10 +169,7 @@ export const ChatDate: React.FC<ChatDateProps> = ({ date }) => {
 	const textColor = '#AFB1C0'
 	return (
 		<View style={[row.item.justify, border.radius.medium, _styles.date, { backgroundColor }]}>
-			<Text style={[_styles.dateText, { color: textColor }]}>
-				{/* {formatTimestamp(new Date(date))} */}
-				{timeFormat.fmtTimestamp2(date)}
-			</Text>
+			<Text style={[_styles.dateText, { color: textColor }]}>{timeFormat.fmtTimestamp2(date)}</Text>
 		</View>
 	)
 }

--- a/js/packages/components/chat/shared-components/Message.tsx
+++ b/js/packages/components/chat/shared-components/Message.tsx
@@ -17,6 +17,7 @@ import { SHA3 } from 'sha3'
 import Logo from '../../main/1_berty_picto.svg'
 import { ProceduralCircleAvatar } from '../../shared-components'
 import { useNavigation as useNativeNavigation } from '@react-navigation/core'
+import { pbDateToNum, timeFormat } from '../../helpers'
 
 const pal = palette('tol-rainbow', 256)
 
@@ -53,24 +54,6 @@ const useStylesMessage = () => {
 		dateMessageWithState: [padding.right.scale(5), text.size.tiny],
 		stateMessageValue: [padding.left.scale(1.5), text.size.tiny],
 	}
-}
-
-const formatTimestamp = (date: Date | number) => {
-	let d = date
-	if (typeof date === 'number') {
-		d = new Date()
-		d.setTime(date)
-	}
-	if (!d) {
-		return 'x'
-	}
-	const arr = d.toString().split(' ')
-	if (!arr[4]) {
-		return '?'
-	}
-	const hours = arr[4].split(':')
-	const hour = hours[0] + ':' + hours[1]
-	return hour
 }
 
 export const MessageInvitationButton: React.FC<{
@@ -357,7 +340,7 @@ export const Message: React.FC<{
 	let isFollowupMessage = false
 	let isFollowedMessage = false
 	let isWithinCollapseDuration = false
-	const sentDate = inte?.sentDate && parseInt(inte.sentDate, 10)
+	const sentDate = pbDateToNum(inte?.sentDate)
 	if (inte.type === messengerpb.AppMessage.Type.TypeUserMessage) {
 		if (inte.memberPublicKey && members && members[inte.memberPublicKey]) {
 			name = members[inte.memberPublicKey].displayName
@@ -495,7 +478,7 @@ export const Message: React.FC<{
 										text.size.scale(11),
 									]}
 								>
-									{sentDate ? formatTimestamp(sentDate) : ''}{' '}
+									{sentDate > 0 ? timeFormat.fmtTimestamp3(sentDate) : ''}{' '}
 								</Text>
 							)}
 							{!cmd && !isWithinCollapseDuration && (
@@ -539,7 +522,7 @@ export const Message: React.FC<{
 							_styles.dateMessage,
 						]}
 					>
-						{sentDate ? formatTimestamp(sentDate) : ''}{' '}
+						{sentDate ? timeFormat.fmtTimestamp3(sentDate) : ''}{' '}
 					</Text>
 				</View>
 				<MessageInvitation message={inte} />

--- a/js/packages/components/helpers.ts
+++ b/js/packages/components/helpers.ts
@@ -25,6 +25,10 @@ const getValidDateMoment = (date: number | Date): moment.Moment => {
 	return mDate.isValid() ? mDate : moment(0)
 }
 
+/**
+ * When we show time or date, depending on recency
+ * (e.g. conversation list)
+ */
 const fmtTimestamp1 = (date: number | Date): string => {
 	const now = moment()
 	const mDate = getValidDateMoment(date)
@@ -38,6 +42,9 @@ const fmtTimestamp1 = (date: number | Date): string => {
 	}
 }
 
+/**
+ * When we just care about the day (e.g. 1-1 chat confirmed header)
+ */
 const fmtTimestamp2 = (date: number | Date): string => {
 	const now = moment()
 	const mDate = getValidDateMoment(date)
@@ -49,11 +56,26 @@ const fmtTimestamp2 = (date: number | Date): string => {
 	return mDate.format('MMM D YYYY')
 }
 
-export const timeFormat = { fmtTimestamp1, fmtTimestamp2 }
+/**
+ * Only show time
+ * Use for messages in chatrooms
+ * (We don't need to show the date; it is in the sticky header)
+ */
+const fmtTimestamp3 = (date: number | Date): string => {
+	const mDate = getValidDateMoment(date)
+	return mDate.format('hh:mm a')
+}
+
+export const timeFormat = { fmtTimestamp1, fmtTimestamp2, fmtTimestamp3 }
 
 export const strToTimestamp = (dateStr?: string): number =>
 	new Date(parseInt(dateStr || '0', 10)).getTime()
 
 export const pbDateToNum = (pbTimestamp?: number | Long | string | null): number => {
-	return !pbTimestamp ? 0 : parseInt(pbTimestamp as string, 10)
+	try {
+		return !pbTimestamp ? 0 : parseInt(pbTimestamp as string, 10)
+	} catch (e) {
+		console.warn(`Error parsing date ${pbTimestamp}; returning zero`)
+		return 0
+	}
 }

--- a/js/packages/components/main/Home.tsx
+++ b/js/packages/components/main/Home.tsx
@@ -132,7 +132,7 @@ const ContactRequest: React.FC<api.berty.messenger.v1.IContact> = ({
 
 	const id = publicKey
 	const [{ border, padding, row, absolute, text, color }, { scaleSize }] = useStyles()
-	const createdDate = typeof createdDateStr === 'string' ? parseInt(createdDateStr, 10) : Date.now()
+	const createdDate = pbDateToNum(createdDateStr) || Date.now()
 	const textColor = '#AFB1C0'
 	return (
 		<Translation>

--- a/js/packages/components/main/Search.tsx
+++ b/js/packages/components/main/Search.tsx
@@ -1,4 +1,3 @@
-import dayjs from 'dayjs'
 import React, { useEffect, useMemo, useRef, useState } from 'react'
 import {
 	Keyboard,


### PR DESCRIPTION
Even though moment (library) is not performant, now we have the time formatters in one place, so it should be easier to swap out the library and/or tweak the display.

Signed-off-by: Elizabeth Kelen <erskelen@gmail.com>