### PR TITLE
WIP: build(messenger): allow iOS dev landscape orientation

### DIFF
--- a/js/packages/berty-app/ios/berty.yaml
+++ b/js/packages/berty-app/ios/berty.yaml
@@ -113,12 +113,13 @@ targets:
         SWIFT_OBJC_INTERFACE_HEADER_NAME: Berty-Swift.h
         CODE_SIGN_STYLE: Automatic
         INTERFACE_ORIENTATION: [UIInterfaceOrientationPortrait] # default
+        INTERFACE_ORIENTATION_IPAD: [UIInterfaceOrientationPortrait] # default
       configs:
         Debug:
           DEVELOPMENT_TEAM: WMBQ84HN4T
           PRODUCT_NAME: Berty Debug
           PRODUCT_BUNDLE_IDENTIFIER: $(PRODUCT_IDENTIFIER).debug
-          INTERFACE_ORIENTATION: [UIInterfaceOrientationPortrait, UIInterfaceOrientationLandscapeLeft, UIInterfaceOrientationLandscapeRight]
+          INTERFACE_ORIENTATION_IPAD: [UIInterfaceOrientationPortrait, UIInterfaceOrientationLandscapeRight, UIInterfaceOrientationLandscapeLeft]
         AppStore:
           DEVELOPMENT_TEAM: WMBQ84HN4T
           PRODUCT_NAME: Berty Release
@@ -131,7 +132,7 @@ targets:
           DEVELOPMENT_TEAM: GR5463T564
           PRODUCT_NAME: Berty Yolo
           PRODUCT_BUNDLE_IDENTIFIER: $(PRODUCT_IDENTIFIER).yolo
-          INTERFACE_ORIENTATION: [UIInterfaceOrientationPortrait, UIInterfaceOrientationLandscapeLeft, UIInterfaceOrientationLandscapeRight]
+          INTERFACE_ORIENTATION_IPAD: [UIInterfaceOrientationPortrait, UIInterfaceOrientationLandscapeRight, UIInterfaceOrientationLandscapeLeft]
 
 
     sources:

--- a/js/packages/berty-app/ios/berty.yaml
+++ b/js/packages/berty-app/ios/berty.yaml
@@ -112,11 +112,13 @@ targets:
         SWIFT_OBJC_BRIDGING_HEADER: Berty/Berty-Bridging-Header.h
         SWIFT_OBJC_INTERFACE_HEADER_NAME: Berty-Swift.h
         CODE_SIGN_STYLE: Automatic
+        INTERFACE_ORIENTATION: [UIInterfaceOrientationPortrait] # default
       configs:
         Debug:
           DEVELOPMENT_TEAM: WMBQ84HN4T
           PRODUCT_NAME: Berty Debug
           PRODUCT_BUNDLE_IDENTIFIER: $(PRODUCT_IDENTIFIER).debug
+          INTERFACE_ORIENTATION: [UIInterfaceOrientationPortrait, UIInterfaceOrientationLandscapeLeft, UIInterfaceOrientationLandscapeRight]
         AppStore:
           DEVELOPMENT_TEAM: WMBQ84HN4T
           PRODUCT_NAME: Berty Release
@@ -129,6 +131,7 @@ targets:
           DEVELOPMENT_TEAM: GR5463T564
           PRODUCT_NAME: Berty Yolo
           PRODUCT_BUNDLE_IDENTIFIER: $(PRODUCT_IDENTIFIER).yolo
+          INTERFACE_ORIENTATION: [UIInterfaceOrientationPortrait, UIInterfaceOrientationLandscapeLeft, UIInterfaceOrientationLandscapeRight]
 
 
     sources:

--- a/js/packages/berty-app/ios/info.yaml
+++ b/js/packages/berty-app/ios/info.yaml
@@ -59,5 +59,5 @@ targets:
         - processing
         UILaunchStoryboardName: LaunchScreen
         UIRequiredDeviceCapabilities: [armv7]
-        UISupportedInterfaceOrientations: [UIInterfaceOrientationPortrait]
+        UISupportedInterfaceOrientations: "$(INTERFACE_ORIENTATION)"
         UIViewControllerBasedStatusBarAppearance: false

--- a/js/packages/berty-app/ios/info.yaml
+++ b/js/packages/berty-app/ios/info.yaml
@@ -60,4 +60,5 @@ targets:
         UILaunchStoryboardName: LaunchScreen
         UIRequiredDeviceCapabilities: [armv7]
         UISupportedInterfaceOrientations: "$(INTERFACE_ORIENTATION)"
+        UISupportedInterfaceOrientations~ipad: "$(INTERFACE_ORIENTATION_IPAD)"
         UIViewControllerBasedStatusBarAppearance: false


### PR DESCRIPTION
I think this should work, but I'm not sure. The idea is to lock portrait orientation on iOS everywhere, except for Debug and Yolo releases on **iPad**, where we also need to support landscape.

@gfanton I would much appreciate your input. I added an iPad-specific key `UISupportedInterfaceOrientations~ipad` and corresponding `INTERFACE_ORIENTATION_IPAD` in the config, but for some reason my iPhone is now allowing landscape, not just iPad.