### PR TITLE
build: Fix Makefiles to be compatible with jobserver.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,16 +3,16 @@ all: generate test
 
 
 test:
-	cd go; make test
+	cd go; $(MAKE) test
 .PHONY: test
 
 
 generate:
 	touch api/*.proto
-	cd config; make generate
-	cd go; make generate
-	cd docs; make generate
-	cd js; make generate
+	cd config; $(MAKE) generate
+	cd go; $(MAKE) generate
+	cd docs; $(MAKE) generate
+	cd js; $(MAKE) generate
 .PHONY: generate
 
 
@@ -24,7 +24,7 @@ regenerate tidy:
 
 
 docker.build:
-	cd go; make docker.build
+	cd go; $(MAKE) docker.build
 .PHONY: docker.build
 
 

--- a/js/Makefile
+++ b/js/Makefile
@@ -273,7 +273,7 @@ _gen.pbjs:
 ##### config
 
 _gen.config:
-	cd ../config; make generate
+	cd ../config; $(MAKE) generate
 
 ##### gen.sum
 

--- a/js/gen.sum
+++ b/js/gen.sum
@@ -1,4 +1,4 @@
 5bbbc86cd312ef5595ec37244faaee11819fcfa1  ../api/bertytypes.proto
 632066266410cec220b85d1615924893d14d8ba7  ../api/bertymessenger.proto
+9c0a8abf750b44b26eba3c9eff166d8ed1cfffef  Makefile
 d4d6abe48c659796c97173f742d620bb7f874490  ../api/bertyprotocol.proto
-fc81384b951267e091483efc80bad76264f66910  Makefile


### PR DESCRIPTION
This allows to use `-jx` on the root Makefile for concurrent generation using `makeparallel` (just install the `makeparallel` package and then use `make generate -j12`).