### PR TITLE
feat: check for health of the RDVPs in `make doctor`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,10 @@ goreleaser.dry-run:
 	goreleaser release --rm-dist --snapshot --skip-publish
 .PHONY: goreleaser.dry-run
 
-
 doctor:
-	go run ./tool/doctor/main.go
+	cd go && $(MAKE) doctor
 .PHONY: doctor
+
+doctor.verbose:
+	cd go && $(MAKE) doctor.verbose
+.PHONY: doctor.verbose

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	berty.tech/go-orbit-db v1.10.10
 	berty.tech/ipfs-webui-packed v1.0.0-v2.11.4-1
 	github.com/Masterminds/goutils v1.1.0 // indirect
-	github.com/Masterminds/semver v1.5.0 // indirect
+	github.com/Masterminds/semver v1.5.0
 	github.com/Masterminds/sprig v2.22.0+incompatible // indirect
 	github.com/aead/ecdh v0.2.0
 	github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412
@@ -19,10 +19,12 @@ require (
 	github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927 // indirect
 	github.com/daixiang0/gci v0.2.4
 	github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c // indirect
+	github.com/denisbrodbeck/machineid v1.0.1
 	github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f // indirect
 	github.com/dgraph-io/badger v1.6.2
 	github.com/dgraph-io/ristretto v0.0.3 // indirect
 	github.com/fabiokung/shm v0.0.0-20150728212823-2852b0d79bae
+	github.com/fatih/color v1.9.0
 	github.com/gdamore/tcell v1.4.0
 	github.com/gen2brain/beeep v0.0.0-20200526185328-e9c15c258e28
 	github.com/githubnemo/CompileDaemon v1.2.1

--- a/go.sum
+++ b/go.sum
@@ -196,6 +196,8 @@ github.com/davidlazar/go-crypto v0.0.0-20170701192655-dcfb0a7ac018/go.mod h1:rQY
 github.com/davidlazar/go-crypto v0.0.0-20190912175916-7055855a373f/go.mod h1:rQYf4tfk5sSwFsnDg3qYaBxSjsD9S8+59vW0dKUgme4=
 github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c h1:pFUpOrbxDR6AkioZ1ySsx5yxlDQZ8stG2b88gTPxgJU=
 github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c/go.mod h1:6UhI8N9EjYm1c2odKpFpAYeR8dsBeM7PtzQhRgxRr9U=
+github.com/denisbrodbeck/machineid v1.0.1 h1:geKr9qtkB876mXguW2X6TU4ZynleN6ezuMSRhl4D7AQ=
+github.com/denisbrodbeck/machineid v1.0.1/go.mod h1:dJUwb7PTidGDeYyUBmXZ2GphQBbjJCrnectwCyxcUSI=
 github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f h1:U5y3Y5UE0w7amNe7Z5G/twsBW0KEalRQXZzf8ufSh9I=
 github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f/go.mod h1:xH/i4TFMt8koVQZ6WFms69WAsDWr2XsYL3Hkl7jkoLE=
 github.com/dgraph-io/badger v1.5.5-0.20190226225317-8115aed38f8f/go.mod h1:VZxzAIRPHRVNRKRo6AXrX9BJegn6il06VMTZVJYCIjQ=

--- a/go/Makefile
+++ b/go/Makefile
@@ -271,7 +271,7 @@ depaware.generate: ./cmd/berty/depaware.txt
 .PHONY: depaware.generate
 
 
-depaware_pkgs = ./cmd/berty ./cmd/rdvp ./framework/bertybridge ./cmd/betabot
+depaware_pkgs = ./cmd/berty ./cmd/rdvp ./framework/bertybridge ./cmd/betabot ./cmd/bertydoctor
 ./cmd/*/depaware.txt: ../go.sum
 	@set -xe; for pkg in $(depaware_pkgs); do $(GO) run github.com/tailscale/depaware --update $$pkg; done
 
@@ -281,5 +281,9 @@ depaware.check:
 .PHONY: depaware.check
 
 doctor:
-	go run ../tool/doctor/main.go
+	go run ./cmd/bertydoctor/
 .PHONY: doctor
+
+doctor.verbose:
+	go run ./cmd/bertydoctor/ -v
+.PHONY: doctor.verbose

--- a/go/cmd/bertydoctor/example_test.go
+++ b/go/cmd/bertydoctor/example_test.go
@@ -1,0 +1,1 @@
+package main_test

--- a/go/cmd/bertydoctor/main.go
+++ b/go/cmd/bertydoctor/main.go
@@ -1,64 +1,83 @@
 package main
 
 import (
+	"context"
+	"flag"
 	"fmt"
 	"os"
 	"os/exec"
+	"os/signal"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/Masterminds/semver"
 	"github.com/fatih/color"
 	"moul.io/u"
+
+	"berty.tech/berty/v2/go/internal/config"
 )
 
 const (
 	goVersionConstraint = ">= 1.14"
 	mustHavePrograms    = "sh make shasum go"
 	mayHavePrograms     = "yarn lsof adb golangci-lint docker"
+	timeout             = time.Minute * 2
 )
 
+var verbose bool
+
 func main() {
+	flag.BoolVar(&verbose, "v", false, "Enable verbose mode.")
+	flag.Parse()
+	var wg sync.WaitGroup
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+
 	// check for programs
-	{
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
 		for _, program := range strings.Split(mustHavePrograms, " ") {
 			path, err := exec.LookPath(program)
 			if err != nil {
-				newError(fmt.Sprintf("%q is not available in $PATH, it is required for most commands.", program))
+				newErrorS("%q is not available in $PATH, it is required for most commands.", program)
 			} else {
-				newOk(fmt.Sprintf("%q is present in $PATH (%s).", program, path))
+				newOkS("%q is present in $PATH (%s).", program, path)
 			}
 		}
 		for _, program := range strings.Split(mayHavePrograms, " ") {
 			path, err := exec.LookPath(program)
 			if err != nil {
-				newWarn(fmt.Sprintf("%q is not available in $PATH, it is only needed for advanced usages.", program))
+				newWarnS("%q is not available in $PATH, it is only needed for advanced usages.", program)
 			} else {
-				newOk(fmt.Sprintf("%q is present in $PATH (%s).", program, path))
+				newOkS("%q is present in $PATH (%s).", program, path)
 			}
 		}
-	}
+	}()
 
 	// check go version
-	{
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
 		goVersionOutput := u.SafeExec(exec.Command("go", "version"))
 		if strings.HasPrefix(goVersionOutput, "go version go1.") {
 			versionString := strings.Split(goVersionOutput, " ")[2][2:]
 			version, err := semver.NewVersion(versionString)
 			if err != nil {
-				newError(fmt.Sprintf("failed to parse semver in 'go version' (%q): %v.", versionString, err))
+				newErrorS("failed to parse semver in 'go version' (%q): %v.", versionString, err)
 			} else {
 				constraint, err := semver.NewConstraint(goVersionConstraint)
 				checkErr(err)
 				if constraint.Check(version) {
-					newOk(fmt.Sprintf("valid go version: %q.", version))
+					newOkS("valid go version: %q.", version)
 				} else {
-					newError(fmt.Sprintf("invalid go version: %q, should match %q.", version, goVersionConstraint))
+					newErrorS("invalid go version: %q, should match %q.", version, goVersionConstraint)
 				}
 			}
 		} else {
 			newError("failed to call `go version`")
 		}
-	}
+	}()
 
 	// check vendor dir
 	{
@@ -69,6 +88,18 @@ func main() {
 		}
 	}
 
+	// check if RDVPs are online.
+	{
+		wg.Add(1)
+		lenRDVPs := len(config.Config.P2P.RDVP)
+		maddrs := make([]string, lenRDVPs)
+		for lenRDVPs > 0 {
+			lenRDVPs--
+			maddrs[lenRDVPs] = config.Config.P2P.RDVP[lenRDVPs].Maddr
+		}
+		go testRDVPs(ctx, &wg, maddrs)
+	}
+
 	// FIXME: berty: if installed, make some checks
 	// FIXME: git: check if outdated
 	// FIXME: docker: version check
@@ -77,39 +108,73 @@ func main() {
 	// FIXME: node version
 	// FIXME: check termcaps support for mini
 
+	// Cancel ctx on sigInt.
+	go func() {
+		signalChannel := make(chan os.Signal, 1)
+		signal.Notify(signalChannel, os.Interrupt)
+
+		select {
+		case <-signalChannel:
+			cancel()
+		case <-ctx.Done():
+		}
+	}()
+
 	// summary
 	{
-		if warns > 0 || errs > 0 {
-			fmt.Printf("[-] %d warns, %d errors.", warns, errs)
+		wg.Wait()
+		if warnc > 0 || errc > 0 {
+			fmt.Printf("[-] %d warns, %d errors.\n", warnc, errc)
 		}
-		if errs > 0 {
+		if errc > 0 {
 			os.Exit(1)
 		}
 	}
 }
 
 var (
-	warns, errs int
+	warnc, errc int
+	talkLock    sync.Mutex
 	green       = color.New(color.FgGreen).SprintFunc()
 	yellow      = color.New(color.FgYellow).SprintFunc()
 	red         = color.New(color.FgRed).SprintFunc()
 )
 
 func newOk(msg string) {
+	talkLock.Lock()
+	defer talkLock.Unlock()
 	fmt.Printf("[+] %s     %s\n", green("OK"), msg)
 }
 
+func newOkS(pattern string, v ...interface{}) {
+	newOk(fmt.Sprintf(pattern, v...))
+}
+
 func newWarn(msg string) {
+	talkLock.Lock()
+	defer talkLock.Unlock()
 	fmt.Printf("[-] %s   %s\n", yellow("WARN"), msg)
-	warns++
+	warnc++
+}
+
+func newWarnS(pattern string, v ...interface{}) {
+	newWarn(fmt.Sprintf(pattern, v...))
 }
 
 func newError(msg string) {
+	talkLock.Lock()
+	defer talkLock.Unlock()
 	fmt.Printf("[-] %s  %s\n", red("ERROR"), msg)
-	errs++
+	errc++
+}
+
+func newErrorS(pattern string, v ...interface{}) {
+	newError(fmt.Sprintf(pattern, v...))
 }
 
 func checkErr(err error) {
+	talkLock.Lock()
+	defer talkLock.Unlock()
 	if err != nil {
 		panic(err)
 	}

--- a/go/cmd/bertydoctor/rdvp.go
+++ b/go/cmd/bertydoctor/rdvp.go
@@ -1,0 +1,294 @@
+package main
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math"
+	"math/rand"
+	"runtime"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/denisbrodbeck/machineid"
+	p2p "github.com/libp2p/go-libp2p"
+	"github.com/libp2p/go-libp2p-core/discovery"
+	"github.com/libp2p/go-libp2p-core/peer"
+	quic "github.com/libp2p/go-libp2p-quic-transport"
+	ma "github.com/multiformats/go-multiaddr"
+	"go.uber.org/zap"
+	"moul.io/srand"
+
+	"berty.tech/berty/v2/go/internal/ipfsutil"
+	"berty.tech/berty/v2/go/internal/tinder"
+)
+
+func testRDVPs(ctx context.Context, gwg *sync.WaitGroup, addrs []string) {
+	defer (*gwg).Done()
+
+	// Isolate each server
+	var pis []peer.AddrInfo
+	{
+		isolator := make(map[peer.ID][]ma.Multiaddr)
+		for _, addr := range addrs {
+			maddr, err := ma.NewMultiaddr(addr)
+			if err != nil {
+				newErrorS("Error parsing maddr: %q %s", addr, err)
+				continue
+			}
+
+			pi, err := peer.AddrInfoFromP2pAddr(maddr)
+			if err != nil {
+				newErrorS("Error creating PeerInfo: %q %s", maddr, err)
+				continue
+			}
+			isolator[pi.ID] = append(isolator[pi.ID], pi.Addrs...)
+		}
+
+		for id, addrs := range isolator {
+			if len(addrs) == 0 {
+				newErrorS("No address found for %s", id)
+				continue
+			}
+			pis = append(pis, peer.AddrInfo{ID: id, Addrs: addrs})
+		}
+
+		if len(pis) == 0 {
+			newError("No server found")
+			return
+		}
+	}
+
+	// Resolve each server
+	var errs []*discServerReturn
+	{
+		lenPis := len(pis)
+		errs = make([]*discServerReturn, lenPis)
+		var wg sync.WaitGroup
+		wg.Add(lenPis)
+		for lenPis > 0 {
+			lenPis--
+			// Start a goroutine per server.
+			go func(j int) {
+				defer wg.Done()
+				pi := pis[j]
+				idMaddr, err := ma.NewMultiaddr(fmt.Sprintf("/p2p/%s", pi.ID))
+				if err != nil {
+					newErrorS(`Can't parse "/p2p/%s" %s`, pi.ID, err)
+					return
+				}
+
+				lenAddrs := len(pi.Addrs)
+				lerrs := make([]*discReturn, lenAddrs)
+				defer func() {
+					rtr := discServerReturn{
+						id:    pi.ID,
+						addrs: lerrs,
+					}
+					for _, v := range lerrs {
+						if v.success {
+							rtr.success = true
+							break
+						}
+					}
+					errs[j] = &rtr
+				}()
+				var lwg sync.WaitGroup
+				lwg.Add(lenAddrs)
+				for lenAddrs > 0 {
+					lenAddrs--
+					// Start a goroutine per addr
+					go func(j int) {
+						defer lwg.Done()
+						tgtMaddr := pi.Addrs[j]
+						rtr := discReturn{
+							target: tgtMaddr,
+						}
+						lerrs[j] = &rtr
+						tgtPi, err := ipfsutil.ParseAndResolveIpfsAddr(ctx, tgtMaddr.Encapsulate(idMaddr).String())
+						if err != nil {
+							rtr.message = fmt.Sprintf("Can't resolve addr %q", tgtMaddr)
+							return
+						}
+
+						// Setup host
+						host, err := p2p.New(ctx,
+							p2p.DisableRelay(),
+							p2p.ListenAddrStrings("/ip4/127.0.0.1/tcp/0"),
+							p2p.UserAgent("Berty Doctor"),
+							p2p.DefaultTransports,
+							p2p.Transport(quic.NewTransport),
+						)
+						if err != nil {
+							rtr.message = fmt.Sprintf("Error creating host: %s", err)
+							return
+						}
+
+						// Check if that particular addr is fine.
+						host.Peerstore().AddAddrs(tgtPi.ID, tgtPi.Addrs, math.MaxInt64)
+
+						// Setup discovery
+						disc := tinder.NewRendezvousDiscovery(
+							zap.NewNop(),
+							host,
+							tgtPi.ID,
+							rand.New(rand.NewSource(srand.SafeFast())), //nolint:gosec
+						)
+
+						// Generate a good key (mostly avoid colision with concurrent `make doctor` runs across the network).
+						var key string
+						{
+							// Using sha256 as this is not critical, probably still fast on most arch.
+							h := sha256.New()
+							buf := make([]byte, 8)
+							binary.LittleEndian.PutUint64(buf, uint64(srand.SafeFast()))
+							doWriteOnHash(h, buf)
+							id, err := machineid.ID()
+							if err == nil {
+								doWriteOnHash(h, []byte(id))
+							}
+							doWriteOnHash(h, []byte("Berty Doctor"))
+							buf = make([]byte, 8)
+							binary.LittleEndian.PutUint64(buf, uint64(runtime.NumCPU()))
+							doWriteOnHash(h, buf)
+							doWriteOnHash(h, []byte(runtime.Version()))
+							key = strconv.FormatUint(binary.LittleEndian.Uint64(h.Sum(nil)), 36)
+						}
+
+						// Advertise
+						{
+							duration, err := disc.Advertise(ctx, key, discovery.TTL(timeout))
+							if err != nil {
+								rtr.message = fmt.Sprintf("Error advertising on %q: %s", tgtMaddr, err)
+								return
+							}
+							// We want at least an Hour of time from the RDVP, else our timeout is fine.
+							if duration < timeout || duration >= time.Hour {
+								rtr.message = fmt.Sprintf("Wrong time (%d) while advertising on %q", duration, tgtMaddr)
+								disc.Unregister(ctx, key) //nolint:errcheck
+								return
+							}
+						}
+
+						// FindPeers
+						hid := host.ID()
+						{
+							// ReturnChannel
+							rc, err := disc.FindPeers(ctx, key)
+							if err != nil {
+								rtr.message = fmt.Sprintf("Error finding peers on %q: %s", tgtMaddr, err)
+								disc.Unregister(ctx, key) //nolint:errcheck
+								return
+							}
+
+							for v := range rc {
+								if hid == v.ID {
+									// Success !
+									goto TryingCheckUnregister
+								}
+							}
+							// Error we weren't able to find us
+							rtr.message = fmt.Sprintf("Wasn't able to find us on maddr %q", tgtMaddr)
+							disc.Unregister(ctx, key) //nolint:errcheck
+							return
+						}
+
+					TryingCheckUnregister:
+						// Unregister
+						{
+							err = disc.Unregister(ctx, key)
+							if err != nil {
+								rtr.message = fmt.Sprintf("Error unregistering us on %q: %s", tgtMaddr, err)
+								return
+							}
+						}
+
+						// FindPeers again but this time we shouldn't be there.
+						{
+							// ReturnChannel
+							rc, err := disc.FindPeers(ctx, key)
+							if err != nil {
+								rtr.message = fmt.Sprintf("Error finding peers after unregister on %q: %s", tgtMaddr, err)
+								return
+							}
+
+							for v := range rc {
+								if hid == v.ID {
+									rtr.message = fmt.Sprintf("Finding us after unregister on %q", tgtMaddr)
+									return
+								}
+							}
+						}
+						rtr.success = true
+					}(lenAddrs)
+				}
+				// Waiting for defers.
+				lwg.Wait()
+			}(lenPis)
+		}
+		wg.Wait()
+	}
+
+	// Checking for results
+	{
+		// Does at least one were successful ?
+		var successCount uint
+		for _, v := range errs {
+			if v.success {
+				successCount++
+			}
+		}
+		if verbose || successCount == 0 {
+			talkLock.Lock()
+			for _, server := range errs {
+				if server.success {
+					fmt.Printf("[+] %s     ", green("OK"))
+				} else {
+					if successCount == 0 {
+						fmt.Printf("[-] %s  ", red("ERROR"))
+						errc++
+					} else {
+						fmt.Printf("[-] %s   ", yellow("WARN"))
+						warnc++
+					}
+				}
+				fmt.Printf("RDVP %s:\n", server.id)
+				for _, addr := range server.addrs {
+					if addr.success {
+						fmt.Printf("   [%s]     %q\n", green("+"), addr.target)
+					} else {
+						fmt.Printf("   [%s]     %q: %s\n", red("-"), addr.target, addr.message)
+					}
+				}
+			}
+			talkLock.Unlock()
+		} else {
+			newOkS("RDVP (%d/%d)", successCount, len(errs))
+		}
+	}
+}
+
+type discServerReturn struct {
+	success bool
+	id      peer.ID
+	addrs   []*discReturn
+}
+
+type discReturn struct {
+	success bool
+	target  ma.Multiaddr
+	message string
+}
+
+func doWriteOnHash(h io.Writer, buf []byte) {
+	toWrite := len(buf)
+	written := 0
+	for written < toWrite {
+		// hash.Hash never returns an error.
+		n, _ := h.Write(buf[written:])
+		written += n
+	}
+}

--- a/go/gen.sum
+++ b/go/gen.sum
@@ -6,4 +6,4 @@ d4d6abe48c659796c97173f742d620bb7f874490  ../api/bertyprotocol.proto
 358a979bdb2969b4af1cb2ce6c3e60f4d5fcf3e5  ../api/errcode.proto
 c314cc3d08e8849bd0693039e42da117c39efef5  ../api/go-internal/handshake.proto
 9b4665f0290b8e94e5ef4b80572a9304f587c2c7  ../api/go-internal/records.proto
-7e5d6fd850bd195d6e673fbe8255e2825933a7ba  Makefile
+594adf10152bd4dcfafbfdd598847aa1619830cf  Makefile

--- a/tool/go.mod
+++ b/tool/go.mod
@@ -6,8 +6,6 @@ go 1.14
 
 require (
 	berty.tech/berty/v2 v2.0.0
-	github.com/Masterminds/semver v1.5.0
-	github.com/fatih/color v1.9.0
 	github.com/mdp/qrterminal/v3 v3.0.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776
 	moul.io/u v1.18.0

--- a/tool/go.sum
+++ b/tool/go.sum
@@ -161,6 +161,7 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davidlazar/go-crypto v0.0.0-20170701192655-dcfb0a7ac018/go.mod h1:rQYf4tfk5sSwFsnDg3qYaBxSjsD9S8+59vW0dKUgme4=
 github.com/davidlazar/go-crypto v0.0.0-20190912175916-7055855a373f/go.mod h1:rQYf4tfk5sSwFsnDg3qYaBxSjsD9S8+59vW0dKUgme4=
 github.com/davidlazar/go-crypto v0.0.0-20200604182044-b73af7476f6c/go.mod h1:6UhI8N9EjYm1c2odKpFpAYeR8dsBeM7PtzQhRgxRr9U=
+github.com/denisbrodbeck/machineid v1.0.1/go.mod h1:dJUwb7PTidGDeYyUBmXZ2GphQBbjJCrnectwCyxcUSI=
 github.com/desertbit/timer v0.0.0-20180107155436-c41aec40b27f/go.mod h1:xH/i4TFMt8koVQZ6WFms69WAsDWr2XsYL3Hkl7jkoLE=
 github.com/dgraph-io/badger v1.5.5-0.20190226225317-8115aed38f8f/go.mod h1:VZxzAIRPHRVNRKRo6AXrX9BJegn6il06VMTZVJYCIjQ=
 github.com/dgraph-io/badger v1.6.0-rc1/go.mod h1:zwt7syl517jmP8s94KqSxTlM6IMsdhYy6psNgSztDR4=
@@ -322,7 +323,7 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.2.2/go.mod h1:EaizFBKfUKtMIF5iaD
 github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgfV/d3M/q6VIi02HzZEHgUlZvzk=
 github.com/grpc-ecosystem/grpc-gateway v1.5.0/go.mod h1:RSKVYQBd5MCa4OVpNdGskqpgL2+G+NZTnrVHpWWfpdw=
 github.com/grpc-ecosystem/grpc-gateway v1.9.5/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
-github.com/grpc-ecosystem/grpc-gateway v1.15.2/go.mod h1:vO11I9oWA+KsxmfFQPhLnnIb1VDE24M+pdxZFiuZcA8=
+github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/gxed/hashland/keccakpg v0.0.1/go.mod h1:kRzw3HkwxFU1mpmPP8v1WyQzwdGfmKFJ6tItnhQ67kU=
 github.com/gxed/hashland/murmur3 v0.0.1/go.mod h1:KjXop02n4/ckmZSnY2+HKcLud/tcmvhST0bie/0lS48=
 github.com/gxed/pubsub v0.0.0-20180201040156-26ebdf44f824/go.mod h1:OiEWyHgK+CWrmOlVquHaIK1vhpUJydC9m0Je6mhaiNE=
@@ -1355,7 +1356,6 @@ golang.org/x/net v0.0.0-20190628185345-da137c7871d7/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20190724013045-ca1201d0de80/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190813141303-74dc4d7220e7/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20190923162816-aa69164e4478/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
-golang.org/x/net v0.0.0-20191002035440-2ec189313ef0/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20191209160850-c0dbc17a3553/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200202094626-16171245cfb2/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
@@ -1629,7 +1629,6 @@ google.golang.org/grpc v1.29.1/go.mod h1:itym6AZVZYACWQqET3MqgPpjcuV5QH3BxFS3Iji
 google.golang.org/grpc v1.30.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.31.1/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
-google.golang.org/grpc v1.32.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/grpc v1.33.1 h1:DGeFlSan2f+WEtCERJ4J9GJWk15TxUi8QGagfI87Xyc=
 google.golang.org/grpc v1.33.1/go.mod h1:fr5YgcSWrqhRRxogOsw7RzIpsmvOZ6IcH4kBYTpR3n0=
 google.golang.org/grpc/examples v0.0.0-20200922230038-4e932bbcb079/go.mod h1:Lh55/1hxmVHEkOvSIQ2uj0P12QyOCUNyRwnUlSS13hw=


### PR DESCRIPTION
Outputs like :
```
[+] OK     RDVP QmdT7AmhhnbuwvCpa5PH1ySK9HJVB82jr3fo1bxMxBPW6p:
  [+] "/ip4/51.159.21.214/tcp/4040"
  [-] "/ip4/51.159.21.214/udp/4040/quic": Error advertising on "/ip4/51.159.21.214/udp/4040/quic": failed to dial QmdT7AmhhnbuwvCpa5PH1ySK9HJVB82jr3fo1bxMxBPW6p: all dials failed
  * [/ip4/51.159.21.214/udp/4040/quic] NO_ERROR: Handshake did not complete in time
[+] OK     RDVP 12D3KooWHhDBv6DJJ4XDWjzEXq6sVNEs6VuxsV1WyBBEhPENHzcZ:
  [+] "/ip4/51.15.25.224/tcp/4040"
  [-] "/ip4/51.15.25.224/udp/4040/quic": Error advertising on "/ip4/51.15.25.224/udp/4040/quic": failed to dial 12D3KooWHhDBv6DJJ4XDWjzEXq6sVNEs6VuxsV1WyBBEhPENHzcZ: all dials failed
  * [/ip4/51.15.25.224/udp/4040/quic] NO_ERROR: Handshake did not complete in time
[-] WARN   RDVP 12D3KooWRpyQpZtUmY5ZktEMgzuhNoWC1C9zokDjLVahNMy3g48u:
  [-] "/ip4/51.75.127.200/udp/4141/quic": Error advertising on "/ip4/51.75.127.200/udp/4141/quic": failed to dial 12D3KooWRpyQpZtUmY5ZktEMgzuhNoWC1C9zokDjLVahNMy3g48u: all dials failed
  * [/ip4/51.75.127.200/udp/4141/quic] CRYPTO_ERROR: peer IDs don't match
```
It checks each maddr individualy, warn if all maddr for a server fail but at least one other server works.
Error if all servers fail.

PS: The `* [/maddr/quic]` are from the libp2p codebase, we can remove them but I would rather knows how this is going wrong even at the cost of a bit of prettyness.