### PR TITLE
fix: android flavors config for network security and app name

### DIFF
--- a/js/android/app/src/debug/AndroidManifest.xml
+++ b/js/android/app/src/debug/AndroidManifest.xml
@@ -4,5 +4,5 @@
 
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
 
-    <application android:usesCleartextTraffic="true" tools:targetApi="28" tools:ignore="GoogleAppIndexingWarning" />
+    <application android:usesCleartextTraffic="true" tools:targetApi="28" tools:ignore="GoogleAppIndexingWarning" tools:remove="networkSecurityConfig" />
 </manifest>

--- a/js/android/app/src/debug/res/values/strings.xml
+++ b/js/android/app/src/debug/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Berty Debug</string>
+</resources>

--- a/js/android/app/src/releaseStaff/res/values/strings.xml
+++ b/js/android/app/src/releaseStaff/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Berty Staff</string>
+</resources>

--- a/js/android/app/src/releaseYolo/res/values/strings.xml
+++ b/js/android/app/src/releaseYolo/res/values/strings.xml
@@ -1,0 +1,3 @@
+<resources>
+    <string name="app_name">Berty Yolo</string>
+</resources>


### PR DESCRIPTION
- Remove network-security-config from debug variant to restore automatic binding between Android device/emulator and metro server
- Set different app name for each variant