### PR TITLE
update integration, run url gen at first

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -38,6 +38,10 @@ jobs:
       OS: ubuntu-latest
       GOLANG: 1.15.x
     steps:
+      - name: Generate run's URL
+        id: url
+        run: |
+          echo "::set-output name=runUrl::https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
       - name: Checkout
         uses: actions/checkout@master
       - name: Set up Go
@@ -79,10 +83,6 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           #alert-comment-cc-users: '@foobar'
           #auto-push: true
-      - name: Generate run's URL
-        id: url
-        run: |
-          echo "::set-output name=runUrl::https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
       - name: Discord notification
         if: github.event_name == 'schedule' && failure()
         env:


### PR DESCRIPTION
Currently if something fail the urlGen is skipped lefting a blank url