### PR TITLE
fix(ci): downgrade go version in ios build

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.15.x
+          go-version: 1.15.3
 
       - name: Setup Node
         uses: actions/setup-node@v2.1.2


### PR DESCRIPTION
This fixes the `go build runtime/cgo: invalid flag in go:cgo_ldflag: -fembed-bitcode` error