### PR TITLE
fix(messenger): flow bridge

### DIFF
--- a/js/packages/berty-i18n/locale/en/messages.json
+++ b/js/packages/berty-i18n/locale/en/messages.json
@@ -256,6 +256,7 @@
     "devtools": {
       "title": "Dev tools",
       "header-left-button": "Device infos",
+      "simulate-button": "Simulate stream error",
       "header-middle-button": "Generate fake data",
       "header-right-button": "Restart daemon",
       "system-info-button": "System info",

--- a/js/packages/components/onboarding/CreateAccount.js
+++ b/js/packages/components/onboarding/CreateAccount.js
@@ -60,7 +60,6 @@ const CreateAccountBody = ({ next }) => {
 							loop
 							style={{ width: '100%' }}
 						/>
-
 						{!isPressed ? (
 							<LottieView
 								source={require('./Berty_onboard_animation_assets2/Startup animation assets/Shield appear.json')}

--- a/js/packages/components/settings/DevTools.tsx
+++ b/js/packages/components/settings/DevTools.tsx
@@ -317,6 +317,18 @@ const BodyDevTools: React.FC<{}> = () => {
 				onPress={() => navigate.settings.systemInfo()}
 			/>
 			<ButtonSetting
+				name={t('settings.devtools.simulate-button')}
+				icon='info-outline'
+				iconSize={30}
+				iconColor={color.dark.grey}
+				onPress={() =>
+					ctx.dispatch({
+						type: MessengerActions.SetStreamError,
+						payload: { error: t('settings.devtools.simulate-button') },
+					})
+				}
+			/>
+			<ButtonSetting
 				name={t('settings.devtools.debug-button')}
 				icon='info-outline'
 				iconSize={30}

--- a/js/packages/store/context.ts
+++ b/js/packages/store/context.ts
@@ -243,7 +243,6 @@ export type MsgrState = {
 	persistentOptions: PersistentOptions
 	accounts: beapi.account.IAccountMetadata[]
 	initialListComplete: boolean
-	clearDaemon: (() => Promise<void>) | null
 	clearClients: (() => Promise<void>) | null
 
 	embedded: boolean
@@ -275,7 +274,6 @@ export const initialState = {
 	persistentOptions: defaultPersistentOptions(),
 	daemonAddress: '',
 	initialListComplete: false,
-	clearDaemon: null,
 	clearClients: null,
 
 	embedded: true,

--- a/js/packages/store/provider.tsx
+++ b/js/packages/store/provider.tsx
@@ -20,7 +20,9 @@ export const MsgrProvider: React.FC<any> = ({ children, daemonAddress, embedded 
 	const [state, dispatch] = React.useReducer(reducer, { ...initialState, daemonAddress, embedded })
 	const [eventEmitter] = React.useState(new EventEmitter())
 
-	useEffect(() => initialLaunch(dispatch, embedded), [embedded])
+	useEffect(() => {
+		initialLaunch(dispatch, embedded)
+	}, [embedded])
 
 	useEffect(() => {
 		openingDaemon(dispatch, state.appState, state.selectedAccount)
@@ -50,10 +52,7 @@ export const MsgrProvider: React.FC<any> = ({ children, daemonAddress, embedded 
 		state.conversations,
 	])
 
-	useEffect(() => closingDaemon(state.clearDaemon, state.clearClients, dispatch), [
-		state.clearDaemon,
-		state.clearClients,
-	])
+	useEffect(() => closingDaemon(state.clearClients, dispatch), [state.clearClients])
 
 	useEffect(() => deletingStorage(state.appState, dispatch, embedded, state.selectedAccount), [
 		state.appState,

--- a/js/packages/store/providerReducer.ts
+++ b/js/packages/store/providerReducer.ts
@@ -238,10 +238,9 @@ export const reducerActions: {
 		}
 	},
 
-	[MessengerActions.SetStateOpeningClients]: (oldState, action) => ({
+	[MessengerActions.SetStateOpeningClients]: (oldState, _action) => ({
 		...oldState,
 		appState: MessengerAppState.OpeningWaitingForClients,
-		clearDaemon: action.payload.clearDaemon || oldState.clearDaemon,
 	}),
 
 	[MessengerActions.SetStateOpeningGettingLocalSettings]: (oldState, _action) => ({
@@ -273,7 +272,6 @@ export const reducerActions: {
 				oldState.appState === MessengerAppState.OpeningWaitingForDaemon
 					? MessengerAppState.Closed
 					: MessengerAppState.ClosingDaemon,
-			clearDaemon: null,
 			clearClients: null,
 		}
 	},
@@ -291,7 +289,6 @@ export const reducerActions: {
 			...oldState,
 			nextSelectedAccount: oldState.selectedAccount,
 			appState: MessengerAppState.ClosingDaemon,
-			clearDaemon: null,
 			clearClients: null,
 		}
 	},
@@ -305,7 +302,6 @@ export const reducerActions: {
 					: oldState.embedded
 					? MessengerAppState.DeletingClosingDaemon
 					: MessengerAppState.DeletingClearingStorage,
-			clearDaemon: null,
 			clearClients: null,
 		}
 	},
@@ -357,7 +353,6 @@ export const reducerActions: {
 		return {
 			...oldState,
 			selectedAccount: action.payload.accountId,
-			clearDaemon: action.payload.clearDaemon,
 			appState: MessengerAppState.OpeningWaitingForClients,
 		}
 	},


### PR DESCRIPTION
# Details
This is a quick fix for the flow bridge in js store

# TODO
We have to use all methods from `accountService` instead of `GoBridge`
When we have a stream error, the restart button does not work (i've add a devtool button that simulate this error)

Signed-off-by: clegirar <clemntgirard@gmail.com>