### PR TITLE
feat: bind go-libtor deps with iOS app

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.14
 require (
 	bazil.org/fuse v0.0.0-20200524192727-fb710f7dfd05 // indirect
 	berty.tech/go-ipfs-log v1.2.6
-	berty.tech/go-libp2p-tor-transport v0.8.2
+	berty.tech/go-libp2p-tor-transport v0.8.3
 	berty.tech/go-orbit-db v1.10.10
 	berty.tech/ipfs-webui-packed v1.0.0-v2.11.4-1
 	github.com/Masterminds/goutils v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,10 @@ bazil.org/fuse v0.0.0-20200117225306-7b5117fecadc h1:utDghgcjE8u+EBjHOgYT+dJPcnD
 bazil.org/fuse v0.0.0-20200117225306-7b5117fecadc/go.mod h1:FbcW6z/2VytnFDhZfumh8Ss8zxHE6qpMP5sHTRe0EaM=
 berty.tech/go-ipfs-log v1.2.6 h1:VBdyZgdkeIt17LS4UX6rJjmskqvfIHaOAEH9Z8aqvIM=
 berty.tech/go-ipfs-log v1.2.6/go.mod h1:4v7G/bAeHNQWqziNC9oZREEFYpSiejSE3+DB4G4nf9M=
-berty.tech/go-libp2p-tor-transport v0.8.2 h1:yKNH38FPT7GxzbdQV3zuxbdPIE+ofyo7ouLM7R+/RrY=
-berty.tech/go-libp2p-tor-transport v0.8.2/go.mod h1:/1ko5aihvU/uyHjKrunrHOam0b/Vumk87ptczocl14c=
-berty.tech/go-libtor v1.0.328 h1:3MRoX3KP9CjVgN5oPu7lbQYu0US00PyHj9mhihK89jQ=
-berty.tech/go-libtor v1.0.328/go.mod h1:9swOOQVb+kmvuAlsgWUK/4c52pm69AdbJsxLzk+fJEw=
+berty.tech/go-libp2p-tor-transport v0.8.3 h1:KhfPBPeuvMqW/88j6BS4O1vdTIRdlMD7bsxYBcp9rts=
+berty.tech/go-libp2p-tor-transport v0.8.3/go.mod h1:uttrniM0oeyYxHCpYy/gXcgZHu2zBy4F1doSUQm4rh0=
+berty.tech/go-libtor v1.0.333 h1:z0Uars8ZFprlGRGDAsomBtjTQfR9T7eMBmPDaZp1GRk=
+berty.tech/go-libtor v1.0.333/go.mod h1:9swOOQVb+kmvuAlsgWUK/4c52pm69AdbJsxLzk+fJEw=
 berty.tech/go-orbit-db v1.10.10 h1:4wljpof6+aICgDWVI9whyop99zF2SoWUT8dt/32JSfs=
 berty.tech/go-orbit-db v1.10.10/go.mod h1:Gl6pmjtt7Db5yA+2S14VP0XJ93Q2OslpyW/eSE9QNCg=
 berty.tech/ipfs-webui-packed v1.0.0-v2.11.4-1 h1:xXAS7M/RcgIWia1XkXLueirm2zDXnMMNGb3UJhfRzbo=

--- a/js/Makefile
+++ b/js/Makefile
@@ -25,6 +25,8 @@ xcodegen_ver = $(shell cat ios/XcodeGen.version)
 required_java_ver = 18
 minimum_ios_ver = 12.0
 minimum_android_ver = 21
+go_libtor_ver = $(shell  go list -modfile=$(PWD)/../go.mod -f '{{.Version}}' -m berty.tech/go-libtor)
+go_libtor_libs_ver = $(shell cat ios/tor-deps/version 2> /dev/null)
 
 ## if (PWD != Makefile directory) then exit
 
@@ -107,6 +109,7 @@ endif
 	rm -rf ios/build
 	rm -rf ios/Pods
 	rm -rf ios/Frameworks/Bertybridge.framework
+	rm -rf ios/tor-deps
 	rm -rf ios/vendor
 	rm -rf ios/Berty.xcodeproj
 	rm -rf ios/Berty.xcworkspace
@@ -333,13 +336,30 @@ _write_gen_sum:
 ios/Frameworks/Bertybridge.framework: $(bridge_src)
 	cd .. && go mod download
 	cd .. && go run golang.org/x/mobile/cmd/gomobile init
-	mkdir -p "ios/Frameworks"
-	cd .. && GO111MODULE=on go run golang.org/x/mobile/cmd/gomobile bind \
-		-o js/$@ \
-		-v $(ext_ldflags) \
-		-target ios \
-		-iosversion $(minimum_ios_ver) \
-		./go/framework/bertybridge
+	# Download required go-libtor deps if needed
+	if [ "$(go_libtor_ver)" != "$(go_libtor_libs_ver)" ]; then \
+		mkdir -p ios/tor-deps $(TMP)/tor-deps/ios && \
+		libs=$$(wget -O - "https://github.com/berty/go-libtor/releases/tag/$(go_libtor_ver)" 2> /dev/null \
+			| grep -o 'ios-.*-universal\.tar\.gz' \
+			| uniq) && \
+		for lib in $$libs; do \
+			wget "https://github.com/berty/go-libtor/releases/download/$(go_libtor_ver)/$$lib" -O "$(TMP)/tor-deps/ios/$$lib" && \
+			tar xvf "$(TMP)/tor-deps/ios/$$lib" -C ios/tor-deps; \
+		done && \
+		echo $(go_libtor_ver) > ios/tor-deps/version; \
+	fi
+	mkdir -p ios/Frameworks
+	cd .. && \
+		GO111MODULE=on \
+		LIBRARY_PATH="$(PWD)/ios/tor-deps/lib" \
+		CPATH="$(PWD)/ios/tor-deps/include" \
+		go run golang.org/x/mobile/cmd/gomobile bind \
+			-o js/$@ \
+			-v $(ext_ldflags) \
+			-target ios \
+			-tags embedTor \
+			-iosversion $(minimum_ios_ver) \
+			./go/framework/bertybridge
 	touch $@
 
 ios/Berty.xcworkspace: $(pkg_desc) ios/Berty.xcodeproj ios/Podfile ios/vendor/bundle package.json
@@ -380,7 +400,7 @@ ios/vendor/bundle: ios/Gemfile
 android/libs/gobridge.aar: $(bridge_src)
 	cd .. && go mod download
 	cd .. && go run golang.org/x/mobile/cmd/gomobile init
-	mkdir -p "android/libs"
+	mkdir -p android/libs
 	cd .. && GO111MODULE=on go run golang.org/x/mobile/cmd/gomobile bind \
 		-o js/$@ \
 		-v $(ext_ldflags) \

--- a/js/Makefile
+++ b/js/Makefile
@@ -362,7 +362,7 @@ ios/Frameworks/Bertybridge.framework: $(bridge_src)
 			./go/framework/bertybridge
 	touch $@
 
-ios/Berty.xcworkspace: $(pkg_desc) ios/Berty.xcodeproj ios/Podfile ios/vendor/bundle package.json
+ios/Berty.xcworkspace: ios/Berty.xcodeproj ios/Podfile ios/vendor/bundle package.json ios/OpenSSL-Universal-Override.podspec
 	$(call check-program, bundle)
 	cd ios && bundle exec pod install
 	touch $@

--- a/js/gen.sum
+++ b/js/gen.sum
@@ -1,4 +1,4 @@
+122d4812811f69e2d76c505c0004f4bac889c5c1  Makefile
 15bab772b80f15b5af4f7049de1e70e13f7b8b00  ../api/bertytypes.proto
 35ebc74ab251dbb359ba0d04a3dafbcb99b10f67  ../api/bertyprotocol.proto
-43349ede963d22483ee5d85bbb9ef1574881705f  Makefile
 b42d7028a61f2047e8dec016510707cc1b6f8a59  ../api/bertymessenger.proto

--- a/js/ios/.gitignore
+++ b/js/ios/.gitignore
@@ -4,3 +4,4 @@ Pods
 Info.plist
 Frameworks
 main.jsbundle
+tor-deps

--- a/js/ios/OpenSSL-Universal-Override.podspec
+++ b/js/ios/OpenSSL-Universal-Override.podspec
@@ -1,0 +1,39 @@
+Pod::Spec.new do |s|
+  s.name         = "OpenSSL-Universal"
+  s.version      = "1.0.2.20"
+  s.summary      = "OpenSSL for iOS"
+  s.description  = "OpenSSL is an SSL/TLS and Crypto toolkit. Supports iOS 64 bits archs including Simulator (arm64,armv64e,x86_64)."
+  s.homepage     = "https://github.com/krzyzanowskim/OpenSSL"
+  s.license	     = { :type => 'OpenSSL (OpenSSL/SSLeay)' }
+  s.source       = { :git => "https://github.com/krzyzanowskim/OpenSSL.git", :tag => "1.0.220" }
+
+  s.authors       =  {'Mark J. Cox' => 'mark@openssl.org',
+                     'Ralf S. Engelschall' => 'rse@openssl.org',
+                     'Dr. Stephen Henson' => 'steve@openssl.org',
+                     'Ben Laurie' => 'ben@openssl.org',
+                     'Lutz Jänicke' => 'jaenicke@openssl.org',
+                     'Nils Larsch' => 'nils@openssl.org',
+                     'Richard Levitte' => 'nils@openssl.org',
+                     'Bodo Möller' => 'bodo@openssl.org',
+                     'Ulf Möller' => 'ulf@openssl.org',
+                     'Andy Polyakov' => 'appro@openssl.org',
+                     'Geoff Thorpe' => 'geoff@openssl.org',
+                     'Holger Reif' => 'holger@openssl.org',
+                     'Paul C. Sutton' => 'geoff@openssl.org',
+                     'Eric A. Young' => 'eay@cryptsoft.com',
+                     'Tim Hudson' => 'tjh@cryptsoft.com',
+                     'Justin Plouffe' => 'plouffe.justin@gmail.com'}
+
+  s.requires_arc = false
+  s.default_subspec = 'Static'
+  s.ios.deployment_target = '12.0'
+
+  s.subspec 'Static' do |sp|
+    sp.ios.deployment_target = '12.0'
+    sp.ios.source_files        = 'tor-deps/include/openssl/**/*.h'
+    sp.ios.public_header_files = 'tor-deps/include/openssl/**/*.h'
+    sp.ios.header_dir          = 'openssl'
+    sp.ios.preserve_paths      = 'tor-deps/lib/libcrypto.a', 'ios/lib/libssl.a'
+    sp.ios.vendored_libraries  = 'tor-deps/lib/libcrypto.a', 'ios/lib/libssl.a'
+  end
+end

--- a/js/ios/Podfile
+++ b/js/ios/Podfile
@@ -8,6 +8,9 @@ target 'Berty' do
 
   use_react_native!(:path => config["reactNativePath"])
 
+  # override OpenSSL-Universal with own openssl static lib
+  pod 'OpenSSL-Universal', :path => "./OpenSSL-Universal-Override.podspec"
+
   # required custom import of permission handler
   pod 'Permission-Camera', :path => "../node_modules/react-native-permissions/ios/Camera.podspec"
 

--- a/js/ios/Podfile.lock
+++ b/js/ios/Podfile.lock
@@ -381,8 +381,8 @@ PODS:
     - RNFBApp
   - RNFS (2.16.6):
     - React
-  - RNGestureHandler (1.8.0):
-    - React
+  - RNGestureHandler (1.9.0):
+    - React-Core
   - RNImageCropPicker (0.35.1):
     - React-Core
     - React-RCTImage
@@ -440,6 +440,7 @@ DEPENDENCIES:
   - glog (from `../node_modules/react-native/third-party-podspecs/glog.podspec`)
   - Interactable (from `../node_modules/react-native-interactable`)
   - lottie-react-native (from `../node_modules/lottie-react-native`)
+  - OpenSSL-Universal (from `./OpenSSL-Universal-Override.podspec`)
   - Permission-Camera (from `../node_modules/react-native-permissions/ios/Camera.podspec`)
   - RCTRequired (from `../node_modules/react-native/Libraries/RCTRequired`)
   - RCTTypeSafety (from `../node_modules/react-native/Libraries/TypeSafety`)
@@ -508,7 +509,6 @@ SPEC REPOS:
     - GoogleUtilities
     - lottie-ios
     - nanopb
-    - OpenSSL-Universal
     - PromisesObjC
     - Shake
     - TOCropViewController
@@ -531,6 +531,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-interactable"
   lottie-react-native:
     :path: "../node_modules/lottie-react-native"
+  OpenSSL-Universal:
+    :path: "./OpenSSL-Universal-Override.podspec"
   Permission-Camera:
     :path: "../node_modules/react-native-permissions/ios/Camera.podspec"
   RCTRequired:
@@ -648,7 +650,7 @@ SPEC CHECKSUMS:
   lottie-ios: 3a3758ef5a008e762faec9c9d50a39842f26d124
   lottie-react-native: 1fb4ce21d6ad37dab8343eaff8719df76035bd93
   nanopb: 1bf24dd71191072e120b83dd02d08f3da0d65e53
-  OpenSSL-Universal: ff34003318d5e1163e9529b08470708e389ffcdd
+  OpenSSL-Universal: 853119ea7eda1a9a6b1971ce0a9aa8a93ecdbc71
   Permission-Camera: 5d2aaf95592660b6dcb5e8d1d90ed5d0156cad02
   PromisesObjC: 8c196f5a328c2cba3e74624585467a557dcb482f
   RCTRequired: 48884c74035a0b5b76dbb7a998bd93bcfc5f2047
@@ -684,7 +686,7 @@ SPEC CHECKSUMS:
   RNFBApp: dd793eec42bce8d09391bd95e42f2ed7511e7fef
   RNFBCrashlytics: 2ff8548152020b4eeba1963f60bb5e35c3dcfc44
   RNFS: 2bd9eb49dc82fa9676382f0585b992c424cd59df
-  RNGestureHandler: 7a5833d0f788dbd107fbb913e09aa0c1ff333c39
+  RNGestureHandler: 9b7e605a741412e20e13c512738a31bd1611759b
   RNImageCropPicker: 16951bc02411f50c4d197488ed6406a23dc3b5f1
   RNInAppBrowser: 48b95ba7a4eaff5cc223bca338d3e319561dbd1b
   RNPermissions: 5df468064df661a4c8c017e2791ce90d7695eea5
@@ -698,6 +700,6 @@ SPEC CHECKSUMS:
   Yoga: 7d13633d129fd179e01b8953d38d47be90db185a
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a
 
-PODFILE CHECKSUM: b8c53ce6d78625731c7197544089c7f2a5cf9933
+PODFILE CHECKSUM: 5c7c09955517d71a585bcd8612c506cefea43b96
 
 COCOAPODS: 1.9.3

--- a/js/ios/berty.yaml
+++ b/js/ios/berty.yaml
@@ -153,6 +153,18 @@ targets:
       link: true
     - framework: ./Frameworks/Bertybridge.framework
       embed: false
+    - framework: ./tor-deps/lib/libz.a
+      embed: false
+      link: true
+    - framework: ./tor-deps/lib/libssl.a
+      embed: false
+      link: true
+    - framework: ./tor-deps/lib/libevent.a
+      embed: false
+      link: true
+    - framework: ./tor-deps/lib/libcrypto.a
+      embed: false
+      link: true
 
     preBuildScripts:
     - name: Copy GoogleService


### PR DESCRIPTION
- [x] update `go-libp2p-tor-transport` to get the last version of `go-libtor`
- [x] download [static libs](https://github.com/berty/go-libtor/releases/tag/v1.0.333) required by `go-libtor` in Makefile (using `go.sum`)
- [x] build iOS gomobile framework with Tor embeded (linked with `go-libtor` static libs)
- [x] override `OpenSSL-Universal` used by RN with `go-libtor` openssl lib (see why [here](https://github.com/berty/go-libtor/issues/1))
- [x] link Berty app with `go-libtor` static libs

**Note:** Overriding `OpenSSL-Universal` pod required by RN using a local podspec could break the project at some point (e.g if we update RN and RN update the `OpenSSL-Universal` version, we will need _at least_ to update the version in our local podspec).
I tried to find a way to remove a pod transitive dependency (which could lead to similar issue anyway), but due to lack of time, I used this solution instead.