### PR TITLE
feat: setup gomobile cache to reduce rebuild time

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -132,4 +132,5 @@ replace (
 	github.com/libp2p/go-libp2p-rendezvous => github.com/berty/go-libp2p-rendezvous v0.0.0-20201028141428-5b2e7e8ff19a // use berty fork of go-libp2p-rendezvous
 	github.com/libp2p/go-libp2p-swarm => github.com/Jorropo/go-libp2p-swarm v0.3.4 // temporary, see https://github.com/libp2p/go-libp2p-swarm/pull/227
 	github.com/peterbourgon/ff/v3 => github.com/moul/ff/v3 v3.0.1 // temporary, see https://github.com/peterbourgon/ff/pull/67, https://github.com/peterbourgon/ff/issues/68
+	golang.org/x/mobile => github.com/aeddi/mobile v0.0.1 // temporary, see https://github.com/golang/mobile/pull/58
 )

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/
 github.com/aead/ecdh v0.2.0 h1:pYop54xVaq/CEREFEcukHRZfTdjiWvYIsZDXXrBapQQ=
 github.com/aead/ecdh v0.2.0/go.mod h1:a9HHtXuSo8J1Js1MwLQx2mBhkXMT6YwUmVVEY4tTB8U=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
+github.com/aeddi/mobile v0.0.1 h1:tzxfiZg58805JUnV4W/3hu1EWPvQE1o/00ykQ94CkHk=
+github.com/aeddi/mobile v0.0.1/go.mod h1:skQtrUTUwhdJvXM/2KKJzY8pDgNr9I/FOMqDVRPBUS4=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=
@@ -1556,7 +1558,6 @@ golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201112155050-0c6587e931a9 h1:umElSU9WZirRdgu2yFHY0ayQkEnKiOC1TtM3fWXFnoU=
 golang.org/x/crypto v0.0.0-20201112155050-0c6587e931a9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
-golang.org/x/exp v0.0.0-20190306152737-a1d7652674e8/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
 golang.org/x/exp v0.0.0-20190510132918-efd6b22b2522/go.mod h1:ZjyILWgesfNpC6sMxTJOJm9Kp84zZh5NQWvqDGG3Qr8=
 golang.org/x/exp v0.0.0-20190731235908-ec7cb31e5a56/go.mod h1:JhuoJpWY28nO4Vef9tZUw9qufEGTyX1+7lmHxV5q5G4=
 golang.org/x/exp v0.0.0-20190829153037-c13cbed26979/go.mod h1:86+5VVa7VpoJ4kLfm080zCjGlMRFzhUhsZKEZO7MGek=
@@ -1581,10 +1582,6 @@ golang.org/x/lint v0.0.0-20191125180803-fdd1cda4f05f/go.mod h1:5qLYkcX4OjUUV8bRu
 golang.org/x/lint v0.0.0-20200130185559-910be7a94367/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b h1:Wh+f8QHJXR411sJR8/vRBTZ7YapZaRvUcLFFJhusH0k=
 golang.org/x/lint v0.0.0-20200302205851-738671d3881b/go.mod h1:3xt1FjdF8hUf6vQPIChWIBhFzV8gjjsPE/fR3IyQdNY=
-golang.org/x/mobile v0.0.0-20190312151609-d3739f865fa6/go.mod h1:z+o9i4GpDbdi3rU15maQ/Ox0txvL9dWGYEHz965HBQE=
-golang.org/x/mobile v0.0.0-20190719004257-d2bd2a29d028/go.mod h1:E/iHnbuqvinMTCcRqshq8CkpyQDoeVncDDYHnLhea+o=
-golang.org/x/mobile v0.0.0-20200801112145-973feb4309de h1:OVJ6QQUBAesB8CZijKDSsXX7xYVtUhrkY0gwMfbi4p4=
-golang.org/x/mobile v0.0.0-20200801112145-973feb4309de/go.mod h1:skQtrUTUwhdJvXM/2KKJzY8pDgNr9I/FOMqDVRPBUS4=
 golang.org/x/mod v0.0.0-20190513183733-4bf6d317e70e/go.mod h1:mXi4GBBbnImb6dmsKGUJ2LatrhH/nqhxcFungHvyanc=
 golang.org/x/mod v0.1.0/go.mod h1:0QHyrYULN0/3qlju5TqG8bIK38QM8yzMo5ekMj3DlcY=
 golang.org/x/mod v0.1.1-0.20191105210325-c90efee705ee/go.mod h1:QqPTAvyqsEbceGzBzNggFXnrqF1CaUcvgkdR5Ot7KZg=

--- a/js/Makefile
+++ b/js/Makefile
@@ -121,6 +121,9 @@ endif
 	@echo "  rm -rf $(HOME)/.gradle/caches"
 	@echo "  rm -rf $(HOME)/Library/Developer/Xcode/DerivedData"
 	@echo "  rm -rf $(HOME)/Library/Caches/CocoaPods"
+	@echo "  sudo rm -rf $(PWD)/ios/.gomobile-cache"
+	@echo "  sudo rm -rf $(PWD)/android/.gomobile-cache"
+
 
 .PHONY: gen.clean
 gen.clean:
@@ -356,6 +359,7 @@ ios/Frameworks/Bertybridge.framework: $(bridge_src)
 		go run golang.org/x/mobile/cmd/gomobile bind \
 			-o js/$@ \
 			-v $(ext_ldflags) \
+			-cache "$(PWD)/ios/.gomobile-cache" \
 			-target ios \
 			-tags embedTor \
 			-iosversion $(minimum_ios_ver) \
@@ -404,6 +408,7 @@ android/libs/gobridge.aar: $(bridge_src)
 	cd .. && GO111MODULE=on go run golang.org/x/mobile/cmd/gomobile bind \
 		-o js/$@ \
 		-v $(ext_ldflags) \
+		-cache "$(PWD)/android/.gomobile-cache" \
 		-target android \
 		-androidapi $(minimum_android_ver) \
 		./go/framework/bertybridge

--- a/js/android/.gitignore
+++ b/js/android/.gitignore
@@ -1,0 +1,1 @@
+.gomobile-cache

--- a/js/gen.sum
+++ b/js/gen.sum
@@ -1,4 +1,4 @@
-122d4812811f69e2d76c505c0004f4bac889c5c1  Makefile
 15bab772b80f15b5af4f7049de1e70e13f7b8b00  ../api/bertytypes.proto
 35ebc74ab251dbb359ba0d04a3dafbcb99b10f67  ../api/bertyprotocol.proto
+490d8b13642872266b0c2bd10182718f9558994b  Makefile
 b42d7028a61f2047e8dec016510707cc1b6f8a59  ../api/bertymessenger.proto

--- a/js/ios/.gitignore
+++ b/js/ios/.gitignore
@@ -5,3 +5,4 @@ Info.plist
 Frameworks
 main.jsbundle
 tor-deps
+.gomobile-cache

--- a/js/metro.config.js
+++ b/js/metro.config.js
@@ -7,6 +7,7 @@
 
 const defaultAssetExts = require('metro-config/src/defaults/defaults').assetExts
 const defaultSourceExts = require('metro-config/src/defaults/defaults').sourceExts
+const exclusionList = require('metro-config/src/defaults/exclusionList')
 
 module.exports = {
 	transformer: {
@@ -22,5 +23,6 @@ module.exports = {
 		extraNodeModules: require('node-libs-react-native'),
 		assetExts: defaultAssetExts.filter((ext) => ext !== 'svg'),
 		sourceExts: [...defaultSourceExts, 'svg'],
+		blacklistRE: exclusionList([/\.gomobile-cache\/.*/]),
 	},
 }


### PR DESCRIPTION
We waste a lot of time rebuilding the framework from scratch each time we modify two lines of go in the project (sometimes ten times a day).

I temporarily replace gomobile by my fork in the go.mod in order to take advantage of the cache. This replace will be removed when this [PR](https://github.com/golang/mobile/pull/58) will be merged or when someone else will have implemented this feature in gomobile. :)