### PR TITLE
fix: Makefile rule for tor deps download

### DIFF
--- a/js/Makefile
+++ b/js/Makefile
@@ -25,7 +25,7 @@ xcodegen_ver = $(shell cat ios/XcodeGen.version)
 required_java_ver = 18
 minimum_ios_ver = 12.0
 minimum_android_ver = 21
-go_libtor_ver = $(shell  go list -modfile=$(PWD)/../go.mod -f '{{.Version}}' -m berty.tech/go-libtor)
+go_libtor_ver = $(shell  go list -mod=readonly -modfile=$(PWD)/../go.mod -f '{{.Version}}' -m berty.tech/go-libtor)
 go_libtor_libs_ver = $(shell cat ios/tor-deps/version 2> /dev/null)
 
 ## if (PWD != Makefile directory) then exit
@@ -341,13 +341,14 @@ ios/Frameworks/Bertybridge.framework: $(bridge_src)
 	cd .. && go run golang.org/x/mobile/cmd/gomobile init
 	# Download required go-libtor deps if needed
 	if [ "$(go_libtor_ver)" != "$(go_libtor_libs_ver)" ]; then \
+		set -o pipefail; \
 		mkdir -p ios/tor-deps $(TMP)/tor-deps/ios && \
 		libs=$$(wget -O - "https://github.com/berty/go-libtor/releases/tag/$(go_libtor_ver)" 2> /dev/null \
 			| grep -o 'ios-.*-universal\.tar\.gz' \
 			| uniq) && \
 		for lib in $$libs; do \
 			wget "https://github.com/berty/go-libtor/releases/download/$(go_libtor_ver)/$$lib" -O "$(TMP)/tor-deps/ios/$$lib" && \
-			tar xvf "$(TMP)/tor-deps/ios/$$lib" -C ios/tor-deps; \
+			tar xvf "$(TMP)/tor-deps/ios/$$lib" -C ios/tor-deps || exit 1; \
 		done && \
 		echo $(go_libtor_ver) > ios/tor-deps/version; \
 	fi

--- a/js/gen.sum
+++ b/js/gen.sum
@@ -1,4 +1,4 @@
 15bab772b80f15b5af4f7049de1e70e13f7b8b00  ../api/bertytypes.proto
 35ebc74ab251dbb359ba0d04a3dafbcb99b10f67  ../api/bertyprotocol.proto
-490d8b13642872266b0c2bd10182718f9558994b  Makefile
+9ee1d17ab9c3ad1d6c5eeff76d9e5e2b36dc9189  Makefile
 b42d7028a61f2047e8dec016510707cc1b6f8a59  ../api/bertymessenger.proto


### PR DESCRIPTION
- [x] add `-mod=readonly` in `go list` command that retrieves `go-libtor` version
- [x] make download script exit on error