### PR TITLE
chore(github): use Dependent Issues action

### DIFF
--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -1,0 +1,36 @@
+name: Dependent Issues
+
+on:
+  issues:
+    types:
+      - opened
+      - edited
+      - reopened
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - reopened
+      - synchronize
+  schedule:
+    - cron: "42 2 * * *" # schedule daily check
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: z0al/dependent-issues@v1
+        env:
+          # (Required) The token to use to make API calls to GitHub.
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # (Optional) The label to use to mark dependent issues
+          label: dependent
+
+          # (Optional) Enable checking for dependencies in issues. Enable by
+          # setting the value to "on". Default "off"
+          check_issues: off
+
+          # (Optional) A comma-separated list of keywords. Default
+          # "depends on, blocked by"
+          keywords: depends on, blocked by


### PR DESCRIPTION
Hey there :wave:

This is to migrate this repo from using [DEP](https://github.com/apps/dep) bot to a new GitHub action:  [Dependent Issues]( https://github.com/marketplace/actions/dependent-issues). 

### :newspaper: TLDR

* The current DEP bot has _been deprecated and no longer works_.
* The new Action works the same way the bot did but with additional features/changes:
  - Works with both _PRs and issues_ (disabled by default).
  - Works with _cross-repository_ dependencies e.g. `microsoft/vscode#999`.
  - It _notifies users by writing a comment_ with the list of dependencies and keep their states updated. This is especially useful when having the action enabled for non-PR issues.
  - Keywords and the label _can now be customized._
  - It sets the state of the head commit on a PR _to `pending` instead of `failure`_ (shows as :orange_circle: instead of a :x: ) when some dependencies are not yet ready (i.e. closed).

Breaking changes? Nothing. You can use the action the same way as before. eg. Writing `Depends on #number` or `Depends on owner/repo#number` clause(s) on the PR/issue description (**not** comments).

For more info please visit :point_right:  https://github.com/marketplace/actions/dependent-issues

### :bulb: Usage

![example](https://raw.githubusercontent.com/z0al/dependent-issues/main/demo.png)