### PR TITLE
fix: pass log filters through gobridge

### DIFF
--- a/js/packages/go-bridge/defaults.ts
+++ b/js/packages/go-bridge/defaults.ts
@@ -1,8 +1,8 @@
 import { GoBridgeOpts } from './types'
 
 export const GoBridgeDefaultOpts: GoBridgeOpts = {
+	logFilters: 'info+:bty*,-*.grpc warn+:*.grpc error+:*',
 	cliArgs: [
-		'--log.filters=info+:bty*,-*.grpc warn+:*.grpc error+:*',
 		'--log.format=console',
 		'--node.display-name=',
 		'--store.lowmem=true',

--- a/js/packages/go-bridge/types.ts
+++ b/js/packages/go-bridge/types.ts
@@ -1,4 +1,5 @@
 export type GoBridgeOpts = {
+	logFilters?: string
 	cliArgs?: string[]
 	persistence?: boolean
 }

--- a/js/packages/store/providerEffects.ts
+++ b/js/packages/store/providerEffects.ts
@@ -290,6 +290,7 @@ export const openingDaemon = async (
 				.openAccount({
 					args: bridgeOpts.cliArgs,
 					accountId: selectedAccount.toString(),
+					loggerFilters: GoBridgeDefaultOpts.logFilters,
 				})
 				.then(() => {
 					console.log('account service is opened')


### PR DESCRIPTION
Logger filters must be given via grpc request to `openAccount` (https://github.com/berty/berty/blob/master/go/pkg/bertyaccount/service_account.go#L58)
The command line argument `--log.filters` is not used for mobiles.

Signed-off-by: D4ryl00 <d4ryl00@gmail.com>