### PR TITLE
test: add a speedy test suite

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -180,6 +180,36 @@ jobs:
           name: codecov-umbrella
           fail_ci_if_error: false
 
+  go-speedy-tests-on-linux:
+    name: "Speedy Stable tests (linux)"
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        golang:
+          - 1.14.x
+          - 1.15.x
+          #- tip
+    env:
+      OS: ubuntu-latest
+      GOLANG: ${{ matrix.golang }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ matrix.golang }}
+      - name: Cache Go modules
+        uses: actions/cache@v1
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+      - name: Run tests
+        working-directory: go
+        run: make test.speedy
+
   go-tests-on-windows:
     name: "Stable tests (windows)"
     runs-on: windows-latest

--- a/go/Makefile
+++ b/go/Makefile
@@ -6,6 +6,7 @@
 GO ?= go
 GOPATH ?= $(HOME)/go
 GO_TEST_OPTS ?= -test.timeout=300s -race -cover -coverprofile=coverage.txt -covermode=atomic
+GO_TEST_SPEEDY_OPTS ?= -test.timeout=300s
 GO_TEST_PATH ?= ./...
 
 BUILD_DATE ?= `date +%s`
@@ -30,9 +31,17 @@ help:
 test: unittest lint tidy
 .PHONY: test
 
+# Speedy tests are regular tests but runned with some options optimising regular tiny runs while implementing some code.
+# Once speedy tests are fine you should run a run of regular tests (mainly for race).
+test.speedy: unittest.speedy
+.PHONY: test.speedy
+
 
 unittest: go.unittest
 .PHONY: unittest
+
+unittest.speedy: go.unittest.speedy
+.PHONY: unittest.speedy
 
 
 generate: pb.generate
@@ -93,6 +102,11 @@ go.unittest: pb.generate
 	$(call check-program, $(GO))
 	$(GO_TEST_ENV) GO111MODULE=on $(GO) test $(GO_TEST_OPTS) $(GO_TEST_PATH)
 .PHONY: go.unittest
+
+go.unittest.speedy:
+	$(call check-program, $(GO))
+	$(GO_TEST_ENV) GO111MODULE=on $(GO) test $(GO_TEST_SPEEDY_OPTS) $(GO_TEST_PATH)
+.PHONY: go.unittest.speedy
 
 
 go.unstable-tests: pb.generate

--- a/go/gen.sum
+++ b/go/gen.sum
@@ -7,4 +7,4 @@ c314cc3d08e8849bd0693039e42da117c39efef5  ../api/go-internal/handshake.proto
 851d354abf878a3afd1e1759511b7b3ce297330f  ../api/go-internal/testutil.proto
 3bacc8da36f08349f9aeea1c781d17bc3bb78208  ../api/messengertypes.proto
 e320eefe0ea2dcd46e81248096b5cb62c4e28e60  ../api/protocoltypes.proto
-f3ae2c6986b84b97f1b15c114bef2e7aab929da8  Makefile
+c8898eb5f3d737f47f053599ea796a6f4160c8ed  Makefile


### PR DESCRIPTION
I'm surprised my self that we need it but somehow our current master (5febf9ca969d400925cb32b91b15fcee899df3c7) test suite is working only because we have `-race` enabled.
This will hopefully let us catch this kind of bug next time.