### PR TITLE
ci: update semantic release action to pull from ghcr

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
         run: sudo apt-get install -y libgl1-mesa-glx libgl1-mesa-dev xorg-dev
       - name: Run Semantic Release
         id: semantic
-        uses: codfish/semantic-release-action@v1
+        uses: docker://ghcr.io/codfish/semantic-release-action:v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Go


### PR DESCRIPTION
Improves workflow run times by ~45s. Leverages changes here https://github.com/codfish/semantic-release-action/pull/156

See https://github.com/codfish/semantic-release-action/issues/142 for more context