### PR TITLE
fix(messenger): prevent overriding contact info with own info

### DIFF
--- a/go/pkg/bertymessenger/handlers.go
+++ b/go/pkg/bertymessenger/handlers.go
@@ -843,6 +843,10 @@ func (h *eventHandler) handleAppMessageSetUserInfo(tx *dbWrapper, i *messengerty
 	payload := amPayload.(*messengertypes.AppMessage_SetUserInfo)
 
 	if i.GetConversation().GetType() == messengertypes.Conversation_ContactType {
+		if i.GetIsMe() {
+			return i, false, nil
+		}
+
 		cpk := i.GetConversation().GetContactPublicKey()
 		c, err := tx.getContactByPK(cpk)
 		if err != nil {


### PR DESCRIPTION
Signed-off-by: Norman Meier <norman@berty.tech>
Fixes https://github.com/berty/bugs/issues/191