### PR TITLE
fix: ConnectAll and ConnectInLine in scenario_test

### DIFF
--- a/go/pkg/bertyprotocol/scenario_test.go
+++ b/go/pkg/bertyprotocol/scenario_test.go
@@ -31,7 +31,7 @@ import (
 type testCase struct {
 	Name           string
 	NumberOfClient int
-	ConnectFunc    ConnnectTestingProtocolFunc
+	ConnectFunc    ConnectTestingProtocolFunc
 	Speed          testutil.Speed
 	Stability      testutil.Stability
 	Timeout        time.Duration
@@ -112,15 +112,11 @@ func TestScenario_MessageSeveralMultiMemberGroups(t *testing.T) {
 
 func TestScenario_AddContact(t *testing.T) {
 	cases := []testCase{
-		{"2 clients/connectAll", 2, ConnectAll, testutil.Fast, testutil.Unstable, time.Second * 20},       // marked as "unstable" because it failed multiple times on the CI recently
-		{"3 clients/connectAll", 3, ConnectAll, testutil.Fast, testutil.Unstable, time.Second * 20},       // marked as "unstable" because it failed multiple times on the CI recently
-		{"3 clients/connectInLine", 3, ConnectInLine, testutil.Fast, testutil.Unstable, time.Second * 20}, // marked as "unstable" because it failed multiple times on the CI recently
-		{"5 clients/connectAll", 5, ConnectAll, testutil.Slow, testutil.Unstable, time.Second * 30},       // marked as "unstable" because it failed multiple times on the CI recently
-		{"5 clients/connectInLine", 5, ConnectInLine, testutil.Slow, testutil.Unstable, time.Second * 30}, // marked as "unstable" because it failed multiple times on the CI recently
-		{"8 clients/connectAll", 8, ConnectAll, testutil.Slow, testutil.Unstable, time.Second * 40},       // marked as "unstable" because it failed multiple times on the CI recently
-		{"8 clients/connectInLine", 8, ConnectInLine, testutil.Slow, testutil.Unstable, time.Second * 40}, // marked as "unstable" because it failed multiple times on the CI recently
+		{"2 clients/connectAll", 2, ConnectAll, testutil.Fast, testutil.Unstable, time.Second * 20}, // marked as "unstable" because it failed multiple times on the CI recently
+		{"3 clients/connectAll", 3, ConnectAll, testutil.Fast, testutil.Unstable, time.Second * 20}, // marked as "unstable" because it failed multiple times on the CI recently
+		{"5 clients/connectAll", 5, ConnectAll, testutil.Slow, testutil.Unstable, time.Second * 30}, // marked as "unstable" because it failed multiple times on the CI recently
+		{"8 clients/connectAll", 8, ConnectAll, testutil.Slow, testutil.Unstable, time.Second * 40}, // marked as "unstable" because it failed multiple times on the CI recently
 		{"10 clients/connectAll", 10, ConnectAll, testutil.Slow, testutil.Broken, time.Second * 60},
-		{"10 clients/connectInLine", 10, ConnectInLine, testutil.Slow, testutil.Broken, time.Second * 60},
 	}
 
 	testingScenario(t, cases, func(ctx context.Context, t *testing.T, tps ...*TestingProtocol) {
@@ -132,13 +128,9 @@ func TestScenario_MessageContactGroup(t *testing.T) {
 	cases := []testCase{
 		{"2 clients/connectAll", 2, ConnectAll, testutil.Fast, testutil.Unstable, time.Second * 20},
 		{"3 clients/connectAll", 3, ConnectAll, testutil.Fast, testutil.Unstable, time.Second * 20},
-		{"3 clients/connectInLine", 3, ConnectInLine, testutil.Fast, testutil.Unstable, time.Second * 20},
 		{"5 clients/connectAll", 5, ConnectAll, testutil.Slow, testutil.Unstable, time.Second * 30},
-		{"5 clients/connectInLine", 5, ConnectInLine, testutil.Slow, testutil.Unstable, time.Second * 30},
 		{"8 clients/connectAll", 8, ConnectAll, testutil.Slow, testutil.Broken, time.Second * 40},
-		{"8 clients/connectInLine", 8, ConnectInLine, testutil.Slow, testutil.Broken, time.Second * 40},
 		{"10 clients/connectAll", 10, ConnectAll, testutil.Slow, testutil.Broken, time.Second * 60},
-		{"10 clients/connectInLine", 10, ConnectInLine, testutil.Slow, testutil.Broken, time.Second * 60},
 	}
 
 	testingScenario(t, cases, func(ctx context.Context, t *testing.T, tps ...*TestingProtocol) {
@@ -214,13 +206,9 @@ func TestScenario_MessageAccountAndContactGroups(t *testing.T) {
 	cases := []testCase{
 		{"2 clients/connectAll", 2, ConnectAll, testutil.Fast, testutil.Broken, time.Second * 10},
 		{"3 clients/connectAll", 3, ConnectAll, testutil.Fast, testutil.Broken, time.Second * 10},
-		{"3 clients/connectInLine", 3, ConnectInLine, testutil.Fast, testutil.Broken, time.Second * 10},
 		{"5 clients/connectAll", 5, ConnectAll, testutil.Slow, testutil.Broken, time.Second * 20},
-		{"5 clients/connectInLine", 5, ConnectInLine, testutil.Slow, testutil.Broken, time.Second * 20},
 		{"8 clients/connectAll", 8, ConnectAll, testutil.Slow, testutil.Broken, time.Second * 30},
-		{"8 clients/connectInLine", 8, ConnectInLine, testutil.Slow, testutil.Broken, time.Second * 30},
 		{"10 clients/connectAll", 10, ConnectAll, testutil.Slow, testutil.Broken, time.Second * 40},
-		{"10 clients/connectInLine", 10, ConnectInLine, testutil.Slow, testutil.Broken, time.Second * 40},
 	}
 
 	testingScenario(t, cases, func(ctx context.Context, t *testing.T, tps ...*TestingProtocol) {
@@ -418,15 +406,13 @@ func testingScenario(t *testing.T, tcs []testCase, tf testFunc) {
 			defer cleanup()
 
 			opts := TestingOpts{
-				Mocknet: libp2p_mocknet.New(ctx),
-				Logger:  logger,
+				Mocknet:     libp2p_mocknet.New(ctx),
+				Logger:      logger,
+				ConnectFunc: tc.ConnectFunc,
 			}
 
 			tps, cleanup := NewTestingProtocolWithMockedPeers(ctx, t, &opts, nil, tc.NumberOfClient)
 			defer cleanup()
-
-			// connect all tps together
-			tc.ConnectFunc(t, opts.Mocknet)
 
 			var cctx context.Context
 


### PR DESCRIPTION
* [x] Replace the default `Mocknet.LinkAll` by a customizable connection function.
* [x] Remove ConnectInLine tests for contact messaging (!= multimembers group)

Signed-off-by: D4ryl00 <d4ryl00@gmail.com>