### PR TITLE
feat: rework some flags

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -52,32 +52,7 @@ TODO
 [embedmd]:# (.tmp/berty-share-invite.txt console)
 ```console
 foo@bar:~$ berty share-invite
-█████████████████████████████████████████████████
-█████████████████████████████████████████████████
-████ ▄▄▄▄▄ ██▄▀▀▄▄▀     ▄▀█ ▀▄█▀▀█▄▀▀█ ▄▄▄▄▄ ████
-████ █   █ █▄▀█▀▀  ▀▀█▀█▄█▀ █▀ ▄▀▀ █ █ █   █ ████
-████ █▄▄▄█ ██▄ ▀▄ ▄▀    ▀▀  ▀█▀ ▀▀  ▀█ █▄▄▄█ ████
-████▄▄▄▄▄▄▄█ █▄█ ▀ ▀▄▀ ▀ ▀ █▄▀ █ ▀▄█ █▄▄▄▄▄▄▄████
-████▄▄▄▀▄ ▄  ▄▀█▄▀▀█ ██▀ █▀█▀ █▀▀▄█▄   ▀█▀▄██████
-████ ▀ ▀▀▀▄▄█▀▀▀▄▀ █▀ ▀▀▄  ▀ ▀█▀▀ ███  █▄██▄▄████
-██████▄▄█▄▄▀██▀  ▀   █▄█  ▄▀▀██ ▀██▀ ▄▄██▄█▄▀████
-████▀█▄ ▀▀▄▄▀▄▄▄ ▀▄▄   ▀ ▀█▀█▀█▀▄ ▄██▄▀▀ ▄█▄▄████
-████▄█ ▀ █▄▀ ▄▄▄▀▄█  ▄███▀▀█ ▄▄▄ ▄█  ▀ ███▄  ████
-████▀▀ ▀ ▀▄█▀▄ ▀█▄██▄▄█▀  ███▀▄▀█▀█▀▀█   █▄█ ████
-████▄ ▄▄▄▄▄█  ▄▀███ █▀█▄  █ ▀▄  ▀▄   ▄▄ █ ▀▀ ████
-████ ▄█▄▀ ▄▄█▄▄▀█▀▀▀█ ▀▀▀▀ ▀▀▀▀█▄ ▀▀ █   ▄▄  ████
-████▀▄█ █ ▄  ▀█▀▀▀█▀▀    █▀█ ▀▀▄ ▀▀██  ██▀▀▀▄████
-████▀█ ▀▀▀▄▀████ ▀ ██▀ ▀▀ █▀  ▄█ ▀▄▀█▀█▄▀ ▄▄ ████
-████▄██▄██▄█▀▄ ▀ ▀ ▀ █ ▄█ █▄████▀ █▄█▄ █▄ ▀  ████
-████▄▀▀▄ ▀▄   █▄  ▄▄ ▀▄▀▀ ▀█▀▀▄▀▄ ▄▀██▀▄███▄▄████
-████▄██▄▄▄▄█ ▄▄  ██▄ ███  █▀ ██▀▀█▀█ ▄▄▄ ▀  ▄████
-████ ▄▄▄▄▄ █ ▀██▀▄██▀▄█▀ ▀ █▀ ▀█▀▀▄▄ █▄█ ▀█▄ ████
-████ █   █ █▄█ ▀███ █▀██ ▄██▀▄ ▄██▀█▄▄▄  ███ ████
-████ █▄▄▄█ █ █▄▀█▀ ▀█ ▀▀▀ ▀█▄ ███▀ ▄▄▀██ ██ ▄████
-████▄▄▄▄▄▄▄█▄▄██▄▄█████▄▄███▄▄██▄▄█▄▄▄█▄█▄█▄▄████
-█████████████████████████████████████████████████
-▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀▀
-html url: https://berty.tech/id#key=CiDjoRYoVim_Wl-XNgLkdwuTQWoDmL0H-Kg8G_cZOe9PmBIgFQsGC-WIjFwI8fSXsQ4KOrNL0hS0zXWzTH2O2w5QSak&name=demo
+https://berty.tech/id#contact/oZBLFCLBf9jVeFU12w6KEqBbGfvPqRzNdDq8gw3yogYqHhQ1o4jsy6ucYBmicj2TRkSQ4zLkPGwWP9wfFSQsBCZ3zdrVXcB/name=demo
 ```
 
 ### Info
@@ -88,29 +63,29 @@ foo@bar:~$ berty info
 {
   "protocol": {
     "process": {
-      "version": "v2.210.2-dev.1+g73f9f964",
-      "vcsRef": "73f9f964",
-      "uptimeMs": "6544",
-      "userCpuTimeMs": "1105",
-      "systemCpuTimeMs": "468",
-      "startedAt": "1605559580",
+      "version": "v2.278.2-dev.4+gf50460f5",
+      "vcsRef": "f50460f5",
+      "uptimeMs": "3938",
+      "userCpuTimeMs": "402",
+      "systemCpuTimeMs": "99",
+      "startedAt": "1619711919",
       "rlimitCur": "2560",
-      "numGoroutine": "657",
-      "nofile": "57",
-      "numCpu": "4",
-      "goVersion": "go1.15.4",
+      "numGoroutine": "418",
+      "nofile": "43",
+      "numCpu": "8",
+      "goVersion": "go1.16.2",
       "operatingSystem": "darwin",
       "hostName": "REDACTED",
-      "arch": "amd64",
+      "arch": "arm64",
       "rlimitMax": "9223372036854775807",
-      "pid": "22456",
-      "ppid": "22455",
+      "pid": "36035",
+      "ppid": "36034",
       "uid": "501",
       "workingDir": "REDACTED",
       "systemUsername": "Guilhem Fanton"
     },
     "p2p": {
-      "connectedPeers": "30"
+      "connectedPeers": "8"
     },
     "orbitdb": {
       "accountMetadata": {
@@ -150,13 +125,17 @@ SUBCOMMANDS
   repl-server   replication server
   peers         list peers
   export        export messenger data from the specified berty node
+  search        use omnisearch to find information about some things
+  remote-logs   stream logs from a remote node
 
 FLAGS
-  -log.file ...                             if specified, will log everything in JSON into a file and nothing on stderr
-  -log.filters info+:bty*,-*.grpc error+:*  zapfilter configuration
-  -log.format color                         can be: json, console, color, light-console, light-color
-  -log.service berty                        service name, used by the tracer
-  -log.tracer ...                           specify "stdout" to output tracing on stdout or <hostname:port> to trace on jaeger
+  -log.file ...                                  if specified, will log everything in JSON into a file and nothing on stderr
+  -log.filters info+:bty*,-*.grpc error+:*       zapfilter configuration
+  -log.format color                              can be: json, console, color, light-console, light-color
+  -log.ring-filters info+:bty*,-*.grpc error+:*  zapfilter configuration for ring
+  -log.ring-size 10                              logging ring buffer size in MB
+  -log.service berty                             service name, used by the tracer
+  -log.tracer ...                                specify "stdout" to output tracing on stdout or <hostname:port> to trace on Jaeger
 
 ADVANCED
   -log.filters=':default: CUSTOM'  equivalent to -log.filters='info+:bty*,-*.grpc error+:* CUSTOM'
@@ -167,45 +146,56 @@ USAGE
   berty [global flags] daemon [flags]
 
 FLAGS
-  -config ...                                                                   config file (optional)
-  -log.file ...                                                                 if specified, will log everything in JSON into a file and nothing on stderr
-  -log.filters info+:bty*,-*.grpc error+:*                                      zapfilter configuration
-  -log.format color                                                             can be: json, console, color, light-console, light-color
-  -log.service berty                                                            service name, used by the tracer
-  -log.tracer ...                                                               specify "stdout" to output tracing on stdout or <hostname:port> to trace on jaeger
-  -metrics.listener ...                                                         Metrics listener, will enable metrics
-  -metrics.pedantic false                                                       Enable Metrics pedantic for debug
-  -node.disable-group-monitor false                                             disable group monitoring
-  -node.display-name guilhemfanton (cli)                                        display name
-  -node.listeners /ip4/127.0.0.1/tcp/9091/grpc                                  gRPC API listeners
-  -node.no-notif false                                                          disable desktop notifications
-  -node.rebuild-db false                                                        reconstruct messenger DB from OrbitDB logs
-  -node.restore-export-path ...                                                 inits node from a specified export path
-  -p2p.ble true                                                                 if true Bluetooth Low Energy will be enabled
-  -p2p.disable-ipfs-network false                                               disable as much networking feature as possible, useful during development
-  -p2p.ipfs-api-listeners ...                                                   IPFS API listeners
-  -p2p.local-discovery true                                                     if true local discovery will be enabled
-  -p2p.max-backoff 1m0s                                                         maximum p2p backoff duration
-  -p2p.min-backoff 1s                                                           minimum p2p backoff duration
-  -p2p.multipeer-connectivity true                                              if true Multipeer Connectivity will be enabled
-  -p2p.rdvp :default:                                                           list of rendezvous point maddr, ":dev:" will add the default devs servers, ":none:" will disable rdvp
-  -p2p.relay-hack false                                                         *temporary flag*; if set, Berty will use relays from the config optimistically
-  -p2p.swarm-announce ...                                                       IPFS announce addrs
-  -p2p.swarm-listeners :default:                                                IPFS swarm listeners
-  -p2p.swarm-no-announce ...                                                    IPFS exclude announce addrs
-  -p2p.webui-listener :3999                                                     IPFS WebUI listener
-  -preset ...                                                                   applies various default values, see ADVANCED section below
-  -store.dir /Users/guilhemfanton/Library/Application Support/berty-tech/berty  root datastore directory
-  -store.inmem false                                                            disable datastore persistence
-  -store.lowmem false                                                           enable LowMemory Profile, useful for mobile environment
-  -tor.binary-path ...                                                          if set berty will use this external tor binary instead of his builtin one
-  -tor.mode disabled                                                            changes the behavior of libp2p regarding tor, see advanced help for more details
+  -config ...                                                             config file (optional)
+  -log.file ...                                                           if specified, will log everything in JSON into a file and nothing on stderr
+  -log.filters info+:bty*,-*.grpc error+:*                                zapfilter configuration
+  -log.format color                                                       can be: json, console, color, light-console, light-color
+  -log.ring-filters info+:bty*,-*.grpc error+:*                           zapfilter configuration for ring
+  -log.ring-size 10                                                       logging ring buffer size in MB
+  -log.service berty                                                      service name, used by the tracer
+  -log.tracer ...                                                         specify "stdout" to output tracing on stdout or <hostname:port> to trace on Jaeger
+  -metrics.listener ...                                                   Metrics listener, will enable metrics
+  -metrics.pedantic false                                                 Enable Metrics pedantic for debug
+  -node.disable-group-monitor false                                       disable group monitoring
+  -node.display-name gfanton (cli)                                        display name
+  -node.init-timeout 1m0s                                                 maximum time allowed for the initialization
+  -node.listeners /ip4/127.0.0.1/tcp/9091/grpc                            gRPC API listeners
+  -node.no-notif false                                                    disable desktop notifications
+  -node.rebuild-db false                                                  reconstruct messenger DB from OrbitDB logs
+  -node.restore-export-path ...                                           inits node from a specified export path
+  -p2p.ble true                                                           if true Bluetooth Low Energy will be enabled
+  -p2p.bootstrap :default:                                                ipfs bootstrap node, `:default:` will set ipfs default bootstrap node
+  -p2p.dht client                                                         dht mode, can be: `client`, `server`, `auto`, `autoserver`
+  -p2p.dht-randomwalk true                                                if true dht will have randomwalk enable
+  -p2p.disable-ipfs-network false                                         disable as much networking feature as possible, useful during development
+  -p2p.ipfs-api-listeners /ip4/127.0.0.1/tcp/5001                         IPFS API listeners
+  -p2p.max-backoff 10m0s                                                  maximum p2p backoff duration
+  -p2p.mdns true                                                          if true mdns will be enabled
+  -p2p.min-backoff 1m0s                                                   minimum p2p backoff duration
+  -p2p.multipeer-connectivity true                                        if true Multipeer Connectivity will be enabled
+  -p2p.nearby false                                                       if true Android Nearby will be enabled
+  -p2p.poll-interval 1s                                                   how long the discovery system will waits for more peers
+  -p2p.rdvp :default:                                                     list of rendezvous point maddr, ":dev:" will add the default devs servers, ":none:" will disable rdvp
+  -p2p.static-relays :default:                                            list of static relay maddrs, `:default:` will use statics relays from the config
+  -p2p.swarm-announce ...                                                 IPFS announce addrs
+  -p2p.swarm-listeners :default:                                          IPFS swarm listeners
+  -p2p.swarm-no-announce ...                                              IPFS exclude announce addrs
+  -p2p.tinder-dht-driver true                                             if true dht driver will be enable for tinder
+  -p2p.tinder-rdvp-driver true                                            if true rdvp driver will be enable for tinder
+  -p2p.webui-listener :3999                                               IPFS WebUI listener
+  -preset ...                                                             applies various default values, see ADVANCED section below
+  -store.dir /Users/gfanton/Library/Application Support/berty-tech/berty  root datastore directory
+  -store.inmem false                                                      disable datastore persistence
+  -store.lowmem false                                                     enable LowMemory Profile, useful for mobile environment
+  -tor.binary-path ...                                                    if set berty will use this external tor binary instead of his builtin one
+  -tor.mode disabled                                                      changes the behavior of libp2p regarding tor, see advanced help for more details
 
 ADVANCED
   -log.filters=':default: CUSTOM'        equivalent to -log.filters='info+:bty*,-*.grpc error+:* CUSTOM'
                                          -> more info at https://github.com/moul/zapfilter
   -preset=performance                    better performance: current development defaults
-  -preset=anonymity                      better privacy: -tor.mode=required -p2p.local-discovery=false -p2p.multipeer-connectivity=false
+  -preset=anonymity                      better privacy: -tor.mode=required -p2p.mdns=false -p2p.multipeer-connectivity=false -p2p.ble=false -p2p.nearby=false
+  -preset=volatile                       similar to performance but optimize for a quick throwable node: -store.inmem=true -p2p.ipfs-api-listeners="" -p2p.swarm-listeners="" -p2p.webui-listener=""
   -p2p.swarm-listeners=:default:,CUSTOM  equivalent to -p2p.swarm-listeners=/ip4/0.0.0.0/tcp/0,/ip6/::/tcp/0,/ip4/0.0.0.0/udp/0/quic,/ip6/::/udp/0/quic,CUSTOM
   -p2p.rdvp=:default:,CUSTOM             equivalent to -p2p.rdvp=/ip4/51.159.21.214/tcp/4040/p2p/QmdT7Amhhn...,CUSTOM
                                          -> full list available at https://github.com/berty/berty/tree/master/config)
@@ -218,47 +208,58 @@ USAGE
   berty [global flags] mini [flags]
 
 FLAGS
-  -config ...                                                                   config file (optional)
-  -log.file ...                                                                 if specified, will log everything in JSON into a file and nothing on stderr
-  -log.filters info+:bty*,-*.grpc error+:*                                      zapfilter configuration
-  -log.format color                                                             can be: json, console, color, light-console, light-color
-  -log.service berty                                                            service name, used by the tracer
-  -log.tracer ...                                                               specify "stdout" to output tracing on stdout or <hostname:port> to trace on jaeger
-  -metrics.listener ...                                                         Metrics listener, will enable metrics
-  -metrics.pedantic false                                                       Enable Metrics pedantic for debug
-  -mini.group ...                                                               group to join, leave empty to create a new group
-  -node.disable-group-monitor false                                             disable group monitoring
-  -node.display-name guilhemfanton (cli)                                        display name
-  -node.listeners ...                                                           gRPC API listeners
-  -node.no-notif false                                                          disable desktop notifications
-  -node.rebuild-db false                                                        reconstruct messenger DB from OrbitDB logs
-  -node.remote-addr ...                                                         remote Berty gRPC API address
-  -node.restore-export-path ...                                                 inits node from a specified export path
-  -p2p.ble true                                                                 if true Bluetooth Low Energy will be enabled
-  -p2p.disable-ipfs-network false                                               disable as much networking feature as possible, useful during development
-  -p2p.ipfs-api-listeners ...                                                   IPFS API listeners
-  -p2p.local-discovery true                                                     if true local discovery will be enabled
-  -p2p.max-backoff 1m0s                                                         maximum p2p backoff duration
-  -p2p.min-backoff 1s                                                           minimum p2p backoff duration
-  -p2p.multipeer-connectivity true                                              if true Multipeer Connectivity will be enabled
-  -p2p.rdvp :default:                                                           list of rendezvous point maddr, ":dev:" will add the default devs servers, ":none:" will disable rdvp
-  -p2p.relay-hack false                                                         *temporary flag*; if set, Berty will use relays from the config optimistically
-  -p2p.swarm-announce ...                                                       IPFS announce addrs
-  -p2p.swarm-listeners :default:                                                IPFS swarm listeners
-  -p2p.swarm-no-announce ...                                                    IPFS exclude announce addrs
-  -p2p.webui-listener ...                                                       IPFS WebUI listener
-  -preset ...                                                                   applies various default values, see ADVANCED section below
-  -store.dir /Users/guilhemfanton/Library/Application Support/berty-tech/berty  root datastore directory
-  -store.inmem false                                                            disable datastore persistence
-  -store.lowmem false                                                           enable LowMemory Profile, useful for mobile environment
-  -tor.binary-path ...                                                          if set berty will use this external tor binary instead of his builtin one
-  -tor.mode disabled                                                            changes the behavior of libp2p regarding tor, see advanced help for more details
+  -config ...                                                             config file (optional)
+  -log.file ...                                                           if specified, will log everything in JSON into a file and nothing on stderr
+  -log.filters info+:bty*,-*.grpc error+:*                                zapfilter configuration
+  -log.format color                                                       can be: json, console, color, light-console, light-color
+  -log.ring-filters info+:bty*,-*.grpc error+:*                           zapfilter configuration for ring
+  -log.ring-size 10                                                       logging ring buffer size in MB
+  -log.service berty                                                      service name, used by the tracer
+  -log.tracer ...                                                         specify "stdout" to output tracing on stdout or <hostname:port> to trace on Jaeger
+  -metrics.listener ...                                                   Metrics listener, will enable metrics
+  -metrics.pedantic false                                                 Enable Metrics pedantic for debug
+  -mini.group ...                                                         group to join, leave empty to create a new group
+  -node.disable-group-monitor false                                       disable group monitoring
+  -node.display-name gfanton (cli)                                        display name
+  -node.init-timeout 1m0s                                                 maximum time allowed for the initialization
+  -node.listeners ...                                                     gRPC API listeners
+  -node.no-notif false                                                    disable desktop notifications
+  -node.rebuild-db false                                                  reconstruct messenger DB from OrbitDB logs
+  -node.remote-addr ...                                                   remote Berty gRPC API address
+  -node.restore-export-path ...                                           inits node from a specified export path
+  -p2p.ble true                                                           if true Bluetooth Low Energy will be enabled
+  -p2p.bootstrap :default:                                                ipfs bootstrap node, `:default:` will set ipfs default bootstrap node
+  -p2p.dht client                                                         dht mode, can be: `client`, `server`, `auto`, `autoserver`
+  -p2p.dht-randomwalk true                                                if true dht will have randomwalk enable
+  -p2p.disable-ipfs-network false                                         disable as much networking feature as possible, useful during development
+  -p2p.ipfs-api-listeners /ip4/127.0.0.1/tcp/5001                         IPFS API listeners
+  -p2p.max-backoff 10m0s                                                  maximum p2p backoff duration
+  -p2p.mdns true                                                          if true mdns will be enabled
+  -p2p.min-backoff 1m0s                                                   minimum p2p backoff duration
+  -p2p.multipeer-connectivity true                                        if true Multipeer Connectivity will be enabled
+  -p2p.nearby false                                                       if true Android Nearby will be enabled
+  -p2p.poll-interval 1s                                                   how long the discovery system will waits for more peers
+  -p2p.rdvp :default:                                                     list of rendezvous point maddr, ":dev:" will add the default devs servers, ":none:" will disable rdvp
+  -p2p.static-relays :default:                                            list of static relay maddrs, `:default:` will use statics relays from the config
+  -p2p.swarm-announce ...                                                 IPFS announce addrs
+  -p2p.swarm-listeners :default:                                          IPFS swarm listeners
+  -p2p.swarm-no-announce ...                                              IPFS exclude announce addrs
+  -p2p.tinder-dht-driver true                                             if true dht driver will be enable for tinder
+  -p2p.tinder-rdvp-driver true                                            if true rdvp driver will be enable for tinder
+  -p2p.webui-listener :3999                                               IPFS WebUI listener
+  -preset ...                                                             applies various default values, see ADVANCED section below
+  -store.dir /Users/gfanton/Library/Application Support/berty-tech/berty  root datastore directory
+  -store.inmem false                                                      disable datastore persistence
+  -store.lowmem false                                                     enable LowMemory Profile, useful for mobile environment
+  -tor.binary-path ...                                                    if set berty will use this external tor binary instead of his builtin one
+  -tor.mode disabled                                                      changes the behavior of libp2p regarding tor, see advanced help for more details
 
 ADVANCED
   -log.filters=':default: CUSTOM'        equivalent to -log.filters='info+:bty*,-*.grpc error+:* CUSTOM'
                                          -> more info at https://github.com/moul/zapfilter
   -preset=performance                    better performance: current development defaults
-  -preset=anonymity                      better privacy: -tor.mode=required -p2p.local-discovery=false -p2p.multipeer-connectivity=false
+  -preset=anonymity                      better privacy: -tor.mode=required -p2p.mdns=false -p2p.multipeer-connectivity=false -p2p.ble=false -p2p.nearby=false
+  -preset=volatile                       similar to performance but optimize for a quick throwable node: -store.inmem=true -p2p.ipfs-api-listeners="" -p2p.swarm-listeners="" -p2p.webui-listener=""
   -p2p.swarm-listeners=:default:,CUSTOM  equivalent to -p2p.swarm-listeners=/ip4/0.0.0.0/tcp/0,/ip6/::/tcp/0,/ip4/0.0.0.0/udp/0/quic,/ip6/::/udp/0/quic,CUSTOM
   -p2p.rdvp=:default:,CUSTOM             equivalent to -p2p.rdvp=/ip4/51.159.21.214/tcp/4040/p2p/QmdT7Amhhn...,CUSTOM
                                          -> full list available at https://github.com/berty/berty/tree/master/config)
@@ -271,14 +272,16 @@ USAGE
   berty banner [flags]
 
 FLAGS
-  -config ...                               config file (optional)
-  -light false                              light mode
-  -log.file ...                             if specified, will log everything in JSON into a file and nothing on stderr
-  -log.filters info+:bty*,-*.grpc error+:*  zapfilter configuration
-  -log.format color                         can be: json, console, color, light-console, light-color
-  -log.service berty                        service name, used by the tracer
-  -log.tracer ...                           specify "stdout" to output tracing on stdout or <hostname:port> to trace on jaeger
-  -random false                             pick a random quote
+  -config ...                                    config file (optional)
+  -light false                                   light mode
+  -log.file ...                                  if specified, will log everything in JSON into a file and nothing on stderr
+  -log.filters info+:bty*,-*.grpc error+:*       zapfilter configuration
+  -log.format color                              can be: json, console, color, light-console, light-color
+  -log.ring-filters info+:bty*,-*.grpc error+:*  zapfilter configuration for ring
+  -log.ring-size 10                              logging ring buffer size in MB
+  -log.service berty                             service name, used by the tracer
+  -log.tracer ...                                specify "stdout" to output tracing on stdout or <hostname:port> to trace on Jaeger
+  -random false                                  pick a random quote
 
 ADVANCED
   -log.filters=':default: CUSTOM'  equivalent to -log.filters='info+:bty*,-*.grpc error+:* CUSTOM'
@@ -297,44 +300,55 @@ USAGE
   berty [global flags] info [flags]
 
 FLAGS
-  -config ...                                                                   config file (optional)
-  -info.anonymize false                                                         anonymize output for sharing
-  -info.refresh 0s                                                              refresh every DURATION (0: no refresh)
-  -log.file ...                                                                 if specified, will log everything in JSON into a file and nothing on stderr
-  -log.filters info+:bty*,-*.grpc error+:*                                      zapfilter configuration
-  -log.format color                                                             can be: json, console, color, light-console, light-color
-  -log.service berty                                                            service name, used by the tracer
-  -log.tracer ...                                                               specify "stdout" to output tracing on stdout or <hostname:port> to trace on jaeger
-  -node.disable-group-monitor false                                             disable group monitoring
-  -node.display-name guilhemfanton (cli)                                        display name
-  -node.no-notif false                                                          disable desktop notifications
-  -node.rebuild-db false                                                        reconstruct messenger DB from OrbitDB logs
-  -node.remote-addr ...                                                         remote Berty gRPC API address
-  -node.restore-export-path ...                                                 inits node from a specified export path
-  -p2p.ble true                                                                 if true Bluetooth Low Energy will be enabled
-  -p2p.disable-ipfs-network false                                               disable as much networking feature as possible, useful during development
-  -p2p.ipfs-api-listeners ...                                                   IPFS API listeners
-  -p2p.local-discovery true                                                     if true local discovery will be enabled
-  -p2p.max-backoff 1m0s                                                         maximum p2p backoff duration
-  -p2p.min-backoff 1s                                                           minimum p2p backoff duration
-  -p2p.multipeer-connectivity true                                              if true Multipeer Connectivity will be enabled
-  -p2p.rdvp :default:                                                           list of rendezvous point maddr, ":dev:" will add the default devs servers, ":none:" will disable rdvp
-  -p2p.relay-hack false                                                         *temporary flag*; if set, Berty will use relays from the config optimistically
-  -p2p.swarm-announce ...                                                       IPFS announce addrs
-  -p2p.swarm-listeners :default:                                                IPFS swarm listeners
-  -p2p.swarm-no-announce ...                                                    IPFS exclude announce addrs
-  -preset ...                                                                   applies various default values, see ADVANCED section below
-  -store.dir /Users/guilhemfanton/Library/Application Support/berty-tech/berty  root datastore directory
-  -store.inmem false                                                            disable datastore persistence
-  -store.lowmem false                                                           enable LowMemory Profile, useful for mobile environment
-  -tor.binary-path ...                                                          if set berty will use this external tor binary instead of his builtin one
-  -tor.mode disabled                                                            changes the behavior of libp2p regarding tor, see advanced help for more details
+  -config ...                                                             config file (optional)
+  -info.anonymize false                                                   anonymize output for sharing
+  -info.refresh 0s                                                        refresh every DURATION (0: no refresh)
+  -log.file ...                                                           if specified, will log everything in JSON into a file and nothing on stderr
+  -log.filters info+:bty*,-*.grpc error+:*                                zapfilter configuration
+  -log.format color                                                       can be: json, console, color, light-console, light-color
+  -log.ring-filters info+:bty*,-*.grpc error+:*                           zapfilter configuration for ring
+  -log.ring-size 10                                                       logging ring buffer size in MB
+  -log.service berty                                                      service name, used by the tracer
+  -log.tracer ...                                                         specify "stdout" to output tracing on stdout or <hostname:port> to trace on Jaeger
+  -node.disable-group-monitor false                                       disable group monitoring
+  -node.display-name gfanton (cli)                                        display name
+  -node.no-notif false                                                    disable desktop notifications
+  -node.rebuild-db false                                                  reconstruct messenger DB from OrbitDB logs
+  -node.remote-addr ...                                                   remote Berty gRPC API address
+  -node.restore-export-path ...                                           inits node from a specified export path
+  -p2p.ble true                                                           if true Bluetooth Low Energy will be enabled
+  -p2p.bootstrap :default:                                                ipfs bootstrap node, `:default:` will set ipfs default bootstrap node
+  -p2p.dht client                                                         dht mode, can be: `client`, `server`, `auto`, `autoserver`
+  -p2p.dht-randomwalk true                                                if true dht will have randomwalk enable
+  -p2p.disable-ipfs-network false                                         disable as much networking feature as possible, useful during development
+  -p2p.ipfs-api-listeners /ip4/127.0.0.1/tcp/5001                         IPFS API listeners
+  -p2p.max-backoff 10m0s                                                  maximum p2p backoff duration
+  -p2p.mdns true                                                          if true mdns will be enabled
+  -p2p.min-backoff 1m0s                                                   minimum p2p backoff duration
+  -p2p.multipeer-connectivity true                                        if true Multipeer Connectivity will be enabled
+  -p2p.nearby false                                                       if true Android Nearby will be enabled
+  -p2p.poll-interval 1s                                                   how long the discovery system will waits for more peers
+  -p2p.rdvp :default:                                                     list of rendezvous point maddr, ":dev:" will add the default devs servers, ":none:" will disable rdvp
+  -p2p.static-relays :default:                                            list of static relay maddrs, `:default:` will use statics relays from the config
+  -p2p.swarm-announce ...                                                 IPFS announce addrs
+  -p2p.swarm-listeners :default:                                          IPFS swarm listeners
+  -p2p.swarm-no-announce ...                                              IPFS exclude announce addrs
+  -p2p.tinder-dht-driver true                                             if true dht driver will be enable for tinder
+  -p2p.tinder-rdvp-driver true                                            if true rdvp driver will be enable for tinder
+  -p2p.webui-listener :3999                                               IPFS WebUI listener
+  -preset ...                                                             applies various default values, see ADVANCED section below
+  -store.dir /Users/gfanton/Library/Application Support/berty-tech/berty  root datastore directory
+  -store.inmem false                                                      disable datastore persistence
+  -store.lowmem false                                                     enable LowMemory Profile, useful for mobile environment
+  -tor.binary-path ...                                                    if set berty will use this external tor binary instead of his builtin one
+  -tor.mode disabled                                                      changes the behavior of libp2p regarding tor, see advanced help for more details
 
 ADVANCED
   -log.filters=':default: CUSTOM'        equivalent to -log.filters='info+:bty*,-*.grpc error+:* CUSTOM'
                                          -> more info at https://github.com/moul/zapfilter
   -preset=performance                    better performance: current development defaults
-  -preset=anonymity                      better privacy: -tor.mode=required -p2p.local-discovery=false -p2p.multipeer-connectivity=false
+  -preset=anonymity                      better privacy: -tor.mode=required -p2p.mdns=false -p2p.multipeer-connectivity=false -p2p.ble=false -p2p.nearby=false
+  -preset=volatile                       similar to performance but optimize for a quick throwable node: -store.inmem=true -p2p.ipfs-api-listeners="" -p2p.swarm-listeners="" -p2p.webui-listener=""
   -p2p.swarm-listeners=:default:,CUSTOM  equivalent to -p2p.swarm-listeners=/ip4/0.0.0.0/tcp/0,/ip6/::/tcp/0,/ip4/0.0.0.0/udp/0/quic,/ip6/::/udp/0/quic,CUSTOM
   -p2p.rdvp=:default:,CUSTOM             equivalent to -p2p.rdvp=/ip4/51.159.21.214/tcp/4040/p2p/QmdT7Amhhn...,CUSTOM
                                          -> full list available at https://github.com/berty/berty/tree/master/config)
@@ -347,12 +361,16 @@ USAGE
   berty groupinit
 
 FLAGS
-  -config ...                               config file (optional)
-  -log.file ...                             if specified, will log everything in JSON into a file and nothing on stderr
-  -log.filters info+:bty*,-*.grpc error+:*  zapfilter configuration
-  -log.format color                         can be: json, console, color, light-console, light-color
-  -log.service berty                        service name, used by the tracer
-  -log.tracer ...                           specify "stdout" to output tracing on stdout or <hostname:port> to trace on jaeger
+  -config ...                                    config file (optional)
+  -log.file ...                                  if specified, will log everything in JSON into a file and nothing on stderr
+  -log.filters info+:bty*,-*.grpc error+:*       zapfilter configuration
+  -log.format color                              can be: json, console, color, light-console, light-color
+  -log.ring-filters info+:bty*,-*.grpc error+:*  zapfilter configuration for ring
+  -log.ring-size 10                              logging ring buffer size in MB
+  -log.service berty                             service name, used by the tracer
+  -log.tracer ...                                specify "stdout" to output tracing on stdout or <hostname:port> to trace on Jaeger
+  -no-qr false                                   do not print the QR code in terminal
+  -passphrase ...                                optional encryption passphrase
 
 ADVANCED
   -log.filters=':default: CUSTOM'  equivalent to -log.filters='info+:bty*,-*.grpc error+:* CUSTOM'
@@ -363,44 +381,57 @@ USAGE
   berty [global flags] share-invite [flags]
 
 FLAGS
-  -config ...                                                                   config file (optional)
-  -dev-channel false                                                            post qrcode on dev channel
-  -log.file ...                                                                 if specified, will log everything in JSON into a file and nothing on stderr
-  -log.filters info+:bty*,-*.grpc error+:*                                      zapfilter configuration
-  -log.format color                                                             can be: json, console, color, light-console, light-color
-  -log.service berty                                                            service name, used by the tracer
-  -log.tracer ...                                                               specify "stdout" to output tracing on stdout or <hostname:port> to trace on jaeger
-  -no-term false                                                                do not print the QR code in terminal
-  -node.disable-group-monitor false                                             disable group monitoring
-  -node.display-name guilhemfanton (cli)                                        display name
-  -node.no-notif false                                                          disable desktop notifications
-  -node.rebuild-db false                                                        reconstruct messenger DB from OrbitDB logs
-  -node.remote-addr ...                                                         remote Berty gRPC API address
-  -node.restore-export-path ...                                                 inits node from a specified export path
-  -p2p.ble true                                                                 if true Bluetooth Low Energy will be enabled
-  -p2p.disable-ipfs-network false                                               disable as much networking feature as possible, useful during development
-  -p2p.ipfs-api-listeners ...                                                   IPFS API listeners
-  -p2p.local-discovery true                                                     if true local discovery will be enabled
-  -p2p.max-backoff 1m0s                                                         maximum p2p backoff duration
-  -p2p.min-backoff 1s                                                           minimum p2p backoff duration
-  -p2p.multipeer-connectivity true                                              if true Multipeer Connectivity will be enabled
-  -p2p.rdvp :default:                                                           list of rendezvous point maddr, ":dev:" will add the default devs servers, ":none:" will disable rdvp
-  -p2p.relay-hack false                                                         *temporary flag*; if set, Berty will use relays from the config optimistically
-  -p2p.swarm-announce ...                                                       IPFS announce addrs
-  -p2p.swarm-listeners :default:                                                IPFS swarm listeners
-  -p2p.swarm-no-announce ...                                                    IPFS exclude announce addrs
-  -preset ...                                                                   applies various default values, see ADVANCED section below
-  -store.dir /Users/guilhemfanton/Library/Application Support/berty-tech/berty  root datastore directory
-  -store.inmem false                                                            disable datastore persistence
-  -store.lowmem false                                                           enable LowMemory Profile, useful for mobile environment
-  -tor.binary-path ...                                                          if set berty will use this external tor binary instead of his builtin one
-  -tor.mode disabled                                                            changes the behavior of libp2p regarding tor, see advanced help for more details
+  -config ...                                                             config file (optional)
+  -dev-channel false                                                      post qrcode on dev channel
+  -log.file ...                                                           if specified, will log everything in JSON into a file and nothing on stderr
+  -log.filters info+:bty*,-*.grpc error+:*                                zapfilter configuration
+  -log.format color                                                       can be: json, console, color, light-console, light-color
+  -log.ring-filters info+:bty*,-*.grpc error+:*                           zapfilter configuration for ring
+  -log.ring-size 10                                                       logging ring buffer size in MB
+  -log.service berty                                                      service name, used by the tracer
+  -log.tracer ...                                                         specify "stdout" to output tracing on stdout or <hostname:port> to trace on Jaeger
+  -name ...                                                               override display name
+  -no-qr false                                                            do not print the QR code in terminal
+  -node.disable-group-monitor false                                       disable group monitoring
+  -node.display-name gfanton (cli)                                        display name
+  -node.no-notif false                                                    disable desktop notifications
+  -node.rebuild-db false                                                  reconstruct messenger DB from OrbitDB logs
+  -node.remote-addr ...                                                   remote Berty gRPC API address
+  -node.restore-export-path ...                                           inits node from a specified export path
+  -p2p.ble true                                                           if true Bluetooth Low Energy will be enabled
+  -p2p.bootstrap :default:                                                ipfs bootstrap node, `:default:` will set ipfs default bootstrap node
+  -p2p.dht client                                                         dht mode, can be: `client`, `server`, `auto`, `autoserver`
+  -p2p.dht-randomwalk true                                                if true dht will have randomwalk enable
+  -p2p.disable-ipfs-network false                                         disable as much networking feature as possible, useful during development
+  -p2p.ipfs-api-listeners /ip4/127.0.0.1/tcp/5001                         IPFS API listeners
+  -p2p.max-backoff 10m0s                                                  maximum p2p backoff duration
+  -p2p.mdns true                                                          if true mdns will be enabled
+  -p2p.min-backoff 1m0s                                                   minimum p2p backoff duration
+  -p2p.multipeer-connectivity true                                        if true Multipeer Connectivity will be enabled
+  -p2p.nearby false                                                       if true Android Nearby will be enabled
+  -p2p.poll-interval 1s                                                   how long the discovery system will waits for more peers
+  -p2p.rdvp :default:                                                     list of rendezvous point maddr, ":dev:" will add the default devs servers, ":none:" will disable rdvp
+  -p2p.static-relays :default:                                            list of static relay maddrs, `:default:` will use statics relays from the config
+  -p2p.swarm-announce ...                                                 IPFS announce addrs
+  -p2p.swarm-listeners :default:                                          IPFS swarm listeners
+  -p2p.swarm-no-announce ...                                              IPFS exclude announce addrs
+  -p2p.tinder-dht-driver true                                             if true dht driver will be enable for tinder
+  -p2p.tinder-rdvp-driver true                                            if true rdvp driver will be enable for tinder
+  -p2p.webui-listener :3999                                               IPFS WebUI listener
+  -passphrase ...                                                         optional encryption passphrase
+  -preset ...                                                             applies various default values, see ADVANCED section below
+  -store.dir /Users/gfanton/Library/Application Support/berty-tech/berty  root datastore directory
+  -store.inmem false                                                      disable datastore persistence
+  -store.lowmem false                                                     enable LowMemory Profile, useful for mobile environment
+  -tor.binary-path ...                                                    if set berty will use this external tor binary instead of his builtin one
+  -tor.mode disabled                                                      changes the behavior of libp2p regarding tor, see advanced help for more details
 
 ADVANCED
   -log.filters=':default: CUSTOM'        equivalent to -log.filters='info+:bty*,-*.grpc error+:* CUSTOM'
                                          -> more info at https://github.com/moul/zapfilter
   -preset=performance                    better performance: current development defaults
-  -preset=anonymity                      better privacy: -tor.mode=required -p2p.local-discovery=false -p2p.multipeer-connectivity=false
+  -preset=anonymity                      better privacy: -tor.mode=required -p2p.mdns=false -p2p.multipeer-connectivity=false -p2p.ble=false -p2p.nearby=false
+  -preset=volatile                       similar to performance but optimize for a quick throwable node: -store.inmem=true -p2p.ipfs-api-listeners="" -p2p.swarm-listeners="" -p2p.webui-listener=""
   -p2p.swarm-listeners=:default:,CUSTOM  equivalent to -p2p.swarm-listeners=/ip4/0.0.0.0/tcp/0,/ip6/::/tcp/0,/ip4/0.0.0.0/udp/0/quic,/ip6/::/udp/0/quic,CUSTOM
   -p2p.rdvp=:default:,CUSTOM             equivalent to -p2p.rdvp=/ip4/51.159.21.214/tcp/4040/p2p/QmdT7Amhhn...,CUSTOM
                                          -> full list available at https://github.com/berty/berty/tree/master/config)
@@ -413,16 +444,20 @@ USAGE
   berty [global flags] token-server [flags]
 
 FLAGS
-  -auth.secret ...                          base64 encoded secret
-  -auth.sk ...                              base64 encoded signature key
-  -config ...                               config file (optional)
-  -http.listener 127.0.0.1:8080             http listener
-  -log.file ...                             if specified, will log everything in JSON into a file and nothing on stderr
-  -log.filters info+:bty*,-*.grpc error+:*  zapfilter configuration
-  -log.format color                         can be: json, console, color, light-console, light-color
-  -log.service berty                        service name, used by the tracer
-  -log.tracer ...                           specify "stdout" to output tracing on stdout or <hostname:port> to trace on jaeger
-  -svc ...                                  comma separated list of supported services as name@ip:port
+  -auth.secret ...                               base64 encoded secret
+  -auth.sk ...                                   base64 encoded signature key
+  -config ...                                    config file (optional)
+  -generate false                                generate a single token and output it on stdout
+  -http.listener 127.0.0.1:8080                  http listener
+  -log.file ...                                  if specified, will log everything in JSON into a file and nothing on stderr
+  -log.filters info+:bty*,-*.grpc error+:*       zapfilter configuration
+  -log.format color                              can be: json, console, color, light-console, light-color
+  -log.ring-filters info+:bty*,-*.grpc error+:*  zapfilter configuration for ring
+  -log.ring-size 10                              logging ring buffer size in MB
+  -log.service berty                             service name, used by the tracer
+  -log.tracer ...                                specify "stdout" to output tracing on stdout or <hostname:port> to trace on Jaeger
+  -no-click false                                disable the login screen and redirect to the next token step directly
+  -svc ...                                       comma separated list of supported services as name@ip:port
 
 ADVANCED
   -log.filters=':default: CUSTOM'  equivalent to -log.filters='info+:bty*,-*.grpc error+:* CUSTOM'
@@ -433,40 +468,50 @@ USAGE
   berty [global flags] repl-server [flags]
 
 FLAGS
-  -config ...                                                                   config file (optional)
-  -log.file ...                                                                 if specified, will log everything in JSON into a file and nothing on stderr
-  -log.filters info+:bty*,-*.grpc error+:*                                      zapfilter configuration
-  -log.format color                                                             can be: json, console, color, light-console, light-color
-  -log.service berty                                                            service name, used by the tracer
-  -log.tracer ...                                                               specify "stdout" to output tracing on stdout or <hostname:port> to trace on jaeger
-  -node.auth-pk ...                                                             Protocol API Authentication Public Key (base64 encoded)
-  -node.auth-secret ...                                                         Protocol API Authentication Secret (base64 encoded)
-  -node.listeners /ip4/127.0.0.1/tcp/9091/grpc                                  gRPC API listeners
-  -p2p.ble true                                                                 if true Bluetooth Low Energy will be enabled
-  -p2p.disable-ipfs-network false                                               disable as much networking feature as possible, useful during development
-  -p2p.ipfs-api-listeners ...                                                   IPFS API listeners
-  -p2p.local-discovery true                                                     if true local discovery will be enabled
-  -p2p.max-backoff 1m0s                                                         maximum p2p backoff duration
-  -p2p.min-backoff 1s                                                           minimum p2p backoff duration
-  -p2p.multipeer-connectivity true                                              if true Multipeer Connectivity will be enabled
-  -p2p.rdvp :default:                                                           list of rendezvous point maddr, ":dev:" will add the default devs servers, ":none:" will disable rdvp
-  -p2p.relay-hack false                                                         *temporary flag*; if set, Berty will use relays from the config optimistically
-  -p2p.swarm-announce ...                                                       IPFS announce addrs
-  -p2p.swarm-listeners :default:                                                IPFS swarm listeners
-  -p2p.swarm-no-announce ...                                                    IPFS exclude announce addrs
-  -p2p.webui-listener :3999                                                     IPFS WebUI listener
-  -preset ...                                                                   applies various default values, see ADVANCED section below
-  -store.dir /Users/guilhemfanton/Library/Application Support/berty-tech/berty  root datastore directory
-  -store.inmem false                                                            disable datastore persistence
-  -store.lowmem false                                                           enable LowMemory Profile, useful for mobile environment
-  -tor.binary-path ...                                                          if set berty will use this external tor binary instead of his builtin one
-  -tor.mode disabled                                                            changes the behavior of libp2p regarding tor, see advanced help for more details
+  -config ...                                                             config file (optional)
+  -log.file ...                                                           if specified, will log everything in JSON into a file and nothing on stderr
+  -log.filters info+:bty*,-*.grpc error+:*                                zapfilter configuration
+  -log.format color                                                       can be: json, console, color, light-console, light-color
+  -log.ring-filters info+:bty*,-*.grpc error+:*                           zapfilter configuration for ring
+  -log.ring-size 10                                                       logging ring buffer size in MB
+  -log.service berty                                                      service name, used by the tracer
+  -log.tracer ...                                                         specify "stdout" to output tracing on stdout or <hostname:port> to trace on Jaeger
+  -node.auth-pk ...                                                       Protocol API Authentication Public Key (base64 encoded)
+  -node.auth-secret ...                                                   Protocol API Authentication Secret (base64 encoded)
+  -node.listeners /ip4/127.0.0.1/tcp/9091/grpc                            gRPC API listeners
+  -p2p.ble true                                                           if true Bluetooth Low Energy will be enabled
+  -p2p.bootstrap :default:                                                ipfs bootstrap node, `:default:` will set ipfs default bootstrap node
+  -p2p.dht client                                                         dht mode, can be: `client`, `server`, `auto`, `autoserver`
+  -p2p.dht-randomwalk true                                                if true dht will have randomwalk enable
+  -p2p.disable-ipfs-network false                                         disable as much networking feature as possible, useful during development
+  -p2p.ipfs-api-listeners /ip4/127.0.0.1/tcp/5001                         IPFS API listeners
+  -p2p.max-backoff 10m0s                                                  maximum p2p backoff duration
+  -p2p.mdns true                                                          if true mdns will be enabled
+  -p2p.min-backoff 1m0s                                                   minimum p2p backoff duration
+  -p2p.multipeer-connectivity true                                        if true Multipeer Connectivity will be enabled
+  -p2p.nearby false                                                       if true Android Nearby will be enabled
+  -p2p.poll-interval 1s                                                   how long the discovery system will waits for more peers
+  -p2p.rdvp :default:                                                     list of rendezvous point maddr, ":dev:" will add the default devs servers, ":none:" will disable rdvp
+  -p2p.static-relays :default:                                            list of static relay maddrs, `:default:` will use statics relays from the config
+  -p2p.swarm-announce ...                                                 IPFS announce addrs
+  -p2p.swarm-listeners :default:                                          IPFS swarm listeners
+  -p2p.swarm-no-announce ...                                              IPFS exclude announce addrs
+  -p2p.tinder-dht-driver true                                             if true dht driver will be enable for tinder
+  -p2p.tinder-rdvp-driver true                                            if true rdvp driver will be enable for tinder
+  -p2p.webui-listener :3999                                               IPFS WebUI listener
+  -preset ...                                                             applies various default values, see ADVANCED section below
+  -store.dir /Users/gfanton/Library/Application Support/berty-tech/berty  root datastore directory
+  -store.inmem false                                                      disable datastore persistence
+  -store.lowmem false                                                     enable LowMemory Profile, useful for mobile environment
+  -tor.binary-path ...                                                    if set berty will use this external tor binary instead of his builtin one
+  -tor.mode disabled                                                      changes the behavior of libp2p regarding tor, see advanced help for more details
 
 ADVANCED
   -log.filters=':default: CUSTOM'        equivalent to -log.filters='info+:bty*,-*.grpc error+:* CUSTOM'
                                          -> more info at https://github.com/moul/zapfilter
   -preset=performance                    better performance: current development defaults
-  -preset=anonymity                      better privacy: -tor.mode=required -p2p.local-discovery=false -p2p.multipeer-connectivity=false
+  -preset=anonymity                      better privacy: -tor.mode=required -p2p.mdns=false -p2p.multipeer-connectivity=false -p2p.ble=false -p2p.nearby=false
+  -preset=volatile                       similar to performance but optimize for a quick throwable node: -store.inmem=true -p2p.ipfs-api-listeners="" -p2p.swarm-listeners="" -p2p.webui-listener=""
   -p2p.swarm-listeners=:default:,CUSTOM  equivalent to -p2p.swarm-listeners=/ip4/0.0.0.0/tcp/0,/ip6/::/tcp/0,/ip4/0.0.0.0/udp/0/quic,/ip6/::/udp/0/quic,CUSTOM
   -p2p.rdvp=:default:,CUSTOM             equivalent to -p2p.rdvp=/ip4/51.159.21.214/tcp/4040/p2p/QmdT7Amhhn...,CUSTOM
                                          -> full list available at https://github.com/berty/berty/tree/master/config)
@@ -479,38 +524,49 @@ USAGE
   berty [global flags] peers [flags]
 
 FLAGS
-  -config ...                                                                   config file (optional)
-  -log.file ...                                                                 if specified, will log everything in JSON into a file and nothing on stderr
-  -log.filters info+:bty*,-*.grpc error+:*                                      zapfilter configuration
-  -log.format color                                                             can be: json, console, color, light-console, light-color
-  -log.service berty                                                            service name, used by the tracer
-  -log.tracer ...                                                               specify "stdout" to output tracing on stdout or <hostname:port> to trace on jaeger
-  -node.remote-addr ...                                                         remote Berty gRPC API address
-  -p2p.ble true                                                                 if true Bluetooth Low Energy will be enabled
-  -p2p.disable-ipfs-network false                                               disable as much networking feature as possible, useful during development
-  -p2p.ipfs-api-listeners ...                                                   IPFS API listeners
-  -p2p.local-discovery true                                                     if true local discovery will be enabled
-  -p2p.max-backoff 1m0s                                                         maximum p2p backoff duration
-  -p2p.min-backoff 1s                                                           minimum p2p backoff duration
-  -p2p.multipeer-connectivity true                                              if true Multipeer Connectivity will be enabled
-  -p2p.rdvp :default:                                                           list of rendezvous point maddr, ":dev:" will add the default devs servers, ":none:" will disable rdvp
-  -p2p.relay-hack false                                                         *temporary flag*; if set, Berty will use relays from the config optimistically
-  -p2p.swarm-announce ...                                                       IPFS announce addrs
-  -p2p.swarm-listeners :default:                                                IPFS swarm listeners
-  -p2p.swarm-no-announce ...                                                    IPFS exclude announce addrs
-  -peers.refresh 1s                                                             refresh every DURATION (0: no refresh)
-  -preset ...                                                                   applies various default values, see ADVANCED section below
-  -store.dir /Users/guilhemfanton/Library/Application Support/berty-tech/berty  root datastore directory
-  -store.inmem false                                                            disable datastore persistence
-  -store.lowmem false                                                           enable LowMemory Profile, useful for mobile environment
-  -tor.binary-path ...                                                          if set berty will use this external tor binary instead of his builtin one
-  -tor.mode disabled                                                            changes the behavior of libp2p regarding tor, see advanced help for more details
+  -config ...                                                             config file (optional)
+  -log.file ...                                                           if specified, will log everything in JSON into a file and nothing on stderr
+  -log.filters info+:bty*,-*.grpc error+:*                                zapfilter configuration
+  -log.format color                                                       can be: json, console, color, light-console, light-color
+  -log.ring-filters info+:bty*,-*.grpc error+:*                           zapfilter configuration for ring
+  -log.ring-size 10                                                       logging ring buffer size in MB
+  -log.service berty                                                      service name, used by the tracer
+  -log.tracer ...                                                         specify "stdout" to output tracing on stdout or <hostname:port> to trace on Jaeger
+  -node.remote-addr ...                                                   remote Berty gRPC API address
+  -p2p.ble true                                                           if true Bluetooth Low Energy will be enabled
+  -p2p.bootstrap :default:                                                ipfs bootstrap node, `:default:` will set ipfs default bootstrap node
+  -p2p.dht client                                                         dht mode, can be: `client`, `server`, `auto`, `autoserver`
+  -p2p.dht-randomwalk true                                                if true dht will have randomwalk enable
+  -p2p.disable-ipfs-network false                                         disable as much networking feature as possible, useful during development
+  -p2p.ipfs-api-listeners /ip4/127.0.0.1/tcp/5001                         IPFS API listeners
+  -p2p.max-backoff 10m0s                                                  maximum p2p backoff duration
+  -p2p.mdns true                                                          if true mdns will be enabled
+  -p2p.min-backoff 1m0s                                                   minimum p2p backoff duration
+  -p2p.multipeer-connectivity true                                        if true Multipeer Connectivity will be enabled
+  -p2p.nearby false                                                       if true Android Nearby will be enabled
+  -p2p.poll-interval 1s                                                   how long the discovery system will waits for more peers
+  -p2p.rdvp :default:                                                     list of rendezvous point maddr, ":dev:" will add the default devs servers, ":none:" will disable rdvp
+  -p2p.static-relays :default:                                            list of static relay maddrs, `:default:` will use statics relays from the config
+  -p2p.swarm-announce ...                                                 IPFS announce addrs
+  -p2p.swarm-listeners :default:                                          IPFS swarm listeners
+  -p2p.swarm-no-announce ...                                              IPFS exclude announce addrs
+  -p2p.tinder-dht-driver true                                             if true dht driver will be enable for tinder
+  -p2p.tinder-rdvp-driver true                                            if true rdvp driver will be enable for tinder
+  -p2p.webui-listener :3999                                               IPFS WebUI listener
+  -peers.refresh 1s                                                       refresh every DURATION (0: no refresh)
+  -preset ...                                                             applies various default values, see ADVANCED section below
+  -store.dir /Users/gfanton/Library/Application Support/berty-tech/berty  root datastore directory
+  -store.inmem false                                                      disable datastore persistence
+  -store.lowmem false                                                     enable LowMemory Profile, useful for mobile environment
+  -tor.binary-path ...                                                    if set berty will use this external tor binary instead of his builtin one
+  -tor.mode disabled                                                      changes the behavior of libp2p regarding tor, see advanced help for more details
 
 ADVANCED
   -log.filters=':default: CUSTOM'        equivalent to -log.filters='info+:bty*,-*.grpc error+:* CUSTOM'
                                          -> more info at https://github.com/moul/zapfilter
   -preset=performance                    better performance: current development defaults
-  -preset=anonymity                      better privacy: -tor.mode=required -p2p.local-discovery=false -p2p.multipeer-connectivity=false
+  -preset=anonymity                      better privacy: -tor.mode=required -p2p.mdns=false -p2p.multipeer-connectivity=false -p2p.ble=false -p2p.nearby=false
+  -preset=volatile                       similar to performance but optimize for a quick throwable node: -store.inmem=true -p2p.ipfs-api-listeners="" -p2p.swarm-listeners="" -p2p.webui-listener=""
   -p2p.swarm-listeners=:default:,CUSTOM  equivalent to -p2p.swarm-listeners=/ip4/0.0.0.0/tcp/0,/ip6/::/tcp/0,/ip4/0.0.0.0/udp/0/quic,/ip6/::/udp/0/quic,CUSTOM
   -p2p.rdvp=:default:,CUSTOM             equivalent to -p2p.rdvp=/ip4/51.159.21.214/tcp/4040/p2p/QmdT7Amhhn...,CUSTOM
                                          -> full list available at https://github.com/berty/berty/tree/master/config)
@@ -523,49 +579,129 @@ USAGE
   berty [global flags] export [flags]
 
 FLAGS
-  -config ...                                                                   config file (optional)
-  -export-path ...                                                              path of the export tarball
-  -log.file ...                                                                 if specified, will log everything in JSON into a file and nothing on stderr
-  -log.filters info+:bty*,-*.grpc error+:*                                      zapfilter configuration
-  -log.format color                                                             can be: json, console, color, light-console, light-color
-  -log.service berty                                                            service name, used by the tracer
-  -log.tracer ...                                                               specify "stdout" to output tracing on stdout or <hostname:port> to trace on jaeger
-  -node.disable-group-monitor false                                             disable group monitoring
-  -node.display-name guilhemfanton (cli)                                        display name
-  -node.no-notif false                                                          disable desktop notifications
-  -node.rebuild-db false                                                        reconstruct messenger DB from OrbitDB logs
-  -node.remote-addr ...                                                         remote Berty gRPC API address
-  -node.restore-export-path ...                                                 inits node from a specified export path
-  -p2p.ble true                                                                 if true Bluetooth Low Energy will be enabled
-  -p2p.disable-ipfs-network false                                               disable as much networking feature as possible, useful during development
-  -p2p.ipfs-api-listeners ...                                                   IPFS API listeners
-  -p2p.local-discovery true                                                     if true local discovery will be enabled
-  -p2p.max-backoff 1m0s                                                         maximum p2p backoff duration
-  -p2p.min-backoff 1s                                                           minimum p2p backoff duration
-  -p2p.multipeer-connectivity true                                              if true Multipeer Connectivity will be enabled
-  -p2p.rdvp :default:                                                           list of rendezvous point maddr, ":dev:" will add the default devs servers, ":none:" will disable rdvp
-  -p2p.relay-hack false                                                         *temporary flag*; if set, Berty will use relays from the config optimistically
-  -p2p.swarm-announce ...                                                       IPFS announce addrs
-  -p2p.swarm-listeners :default:                                                IPFS swarm listeners
-  -p2p.swarm-no-announce ...                                                    IPFS exclude announce addrs
-  -preset ...                                                                   applies various default values, see ADVANCED section below
-  -store.dir /Users/guilhemfanton/Library/Application Support/berty-tech/berty  root datastore directory
-  -store.inmem false                                                            disable datastore persistence
-  -store.lowmem false                                                           enable LowMemory Profile, useful for mobile environment
-  -tor.binary-path ...                                                          if set berty will use this external tor binary instead of his builtin one
-  -tor.mode disabled                                                            changes the behavior of libp2p regarding tor, see advanced help for more details
+  -config ...                                                             config file (optional)
+  -export-path ...                                                        path of the export tarball
+  -log.file ...                                                           if specified, will log everything in JSON into a file and nothing on stderr
+  -log.filters info+:bty*,-*.grpc error+:*                                zapfilter configuration
+  -log.format color                                                       can be: json, console, color, light-console, light-color
+  -log.ring-filters info+:bty*,-*.grpc error+:*                           zapfilter configuration for ring
+  -log.ring-size 10                                                       logging ring buffer size in MB
+  -log.service berty                                                      service name, used by the tracer
+  -log.tracer ...                                                         specify "stdout" to output tracing on stdout or <hostname:port> to trace on Jaeger
+  -node.disable-group-monitor false                                       disable group monitoring
+  -node.display-name gfanton (cli)                                        display name
+  -node.no-notif false                                                    disable desktop notifications
+  -node.rebuild-db false                                                  reconstruct messenger DB from OrbitDB logs
+  -node.remote-addr ...                                                   remote Berty gRPC API address
+  -node.restore-export-path ...                                           inits node from a specified export path
+  -p2p.ble true                                                           if true Bluetooth Low Energy will be enabled
+  -p2p.bootstrap :default:                                                ipfs bootstrap node, `:default:` will set ipfs default bootstrap node
+  -p2p.dht client                                                         dht mode, can be: `client`, `server`, `auto`, `autoserver`
+  -p2p.dht-randomwalk true                                                if true dht will have randomwalk enable
+  -p2p.disable-ipfs-network false                                         disable as much networking feature as possible, useful during development
+  -p2p.ipfs-api-listeners /ip4/127.0.0.1/tcp/5001                         IPFS API listeners
+  -p2p.max-backoff 10m0s                                                  maximum p2p backoff duration
+  -p2p.mdns true                                                          if true mdns will be enabled
+  -p2p.min-backoff 1m0s                                                   minimum p2p backoff duration
+  -p2p.multipeer-connectivity true                                        if true Multipeer Connectivity will be enabled
+  -p2p.nearby false                                                       if true Android Nearby will be enabled
+  -p2p.poll-interval 1s                                                   how long the discovery system will waits for more peers
+  -p2p.rdvp :default:                                                     list of rendezvous point maddr, ":dev:" will add the default devs servers, ":none:" will disable rdvp
+  -p2p.static-relays :default:                                            list of static relay maddrs, `:default:` will use statics relays from the config
+  -p2p.swarm-announce ...                                                 IPFS announce addrs
+  -p2p.swarm-listeners :default:                                          IPFS swarm listeners
+  -p2p.swarm-no-announce ...                                              IPFS exclude announce addrs
+  -p2p.tinder-dht-driver true                                             if true dht driver will be enable for tinder
+  -p2p.tinder-rdvp-driver true                                            if true rdvp driver will be enable for tinder
+  -p2p.webui-listener :3999                                               IPFS WebUI listener
+  -preset ...                                                             applies various default values, see ADVANCED section below
+  -store.dir /Users/gfanton/Library/Application Support/berty-tech/berty  root datastore directory
+  -store.inmem false                                                      disable datastore persistence
+  -store.lowmem false                                                     enable LowMemory Profile, useful for mobile environment
+  -tor.binary-path ...                                                    if set berty will use this external tor binary instead of his builtin one
+  -tor.mode disabled                                                      changes the behavior of libp2p regarding tor, see advanced help for more details
 
 ADVANCED
   -log.filters=':default: CUSTOM'        equivalent to -log.filters='info+:bty*,-*.grpc error+:* CUSTOM'
                                          -> more info at https://github.com/moul/zapfilter
   -preset=performance                    better performance: current development defaults
-  -preset=anonymity                      better privacy: -tor.mode=required -p2p.local-discovery=false -p2p.multipeer-connectivity=false
+  -preset=anonymity                      better privacy: -tor.mode=required -p2p.mdns=false -p2p.multipeer-connectivity=false -p2p.ble=false -p2p.nearby=false
+  -preset=volatile                       similar to performance but optimize for a quick throwable node: -store.inmem=true -p2p.ipfs-api-listeners="" -p2p.swarm-listeners="" -p2p.webui-listener=""
   -p2p.swarm-listeners=:default:,CUSTOM  equivalent to -p2p.swarm-listeners=/ip4/0.0.0.0/tcp/0,/ip6/::/tcp/0,/ip4/0.0.0.0/udp/0/quic,/ip6/::/udp/0/quic,CUSTOM
   -p2p.rdvp=:default:,CUSTOM             equivalent to -p2p.rdvp=/ip4/51.159.21.214/tcp/4040/p2p/QmdT7Amhhn...,CUSTOM
                                          -> full list available at https://github.com/berty/berty/tree/master/config)
   -tor.mode=disabled                     tor is completely disabled
   -tor.mode=optional                     tor is added to the list of existing transports and can be used to contact other tor-ready nodes
   -tor.mode=required                     tor is the only available transport; you can only communicate with other tor-ready nodes
+
+foo@bar:~$ berty search -h
+USAGE
+  berty [global flags] search QUERY
+
+Currently parsers and engines available for omnisearch are :
+- Berty invite parser (parse berty's group and one to one invites)
+- Berty swiper engine (find peers (peer.AddrInfo) from their invites)
+
+Example:
+berty omnisearch https://berty.tech/id#key=CiDnVU4YlFPkjTbSggoZAWbFdAIsnuv5qoruQDyN_NB8rBIgfrT2x0wzMjiK4kBXnPYStGxW2Hssk8UyYfW8ITJbEFg&name=Example
+
+FLAGS
+  -node.disable-group-monitor false                                       disable group monitoring
+  -node.display-name gfanton (cli)                                        display name
+  -node.listeners /ip4/127.0.0.1/tcp/9091/grpc                            gRPC API listeners
+  -node.no-notif false                                                    disable desktop notifications
+  -node.rebuild-db false                                                  reconstruct messenger DB from OrbitDB logs
+  -node.restore-export-path ...                                           inits node from a specified export path
+  -p2p.ble true                                                           if true Bluetooth Low Energy will be enabled
+  -p2p.bootstrap :default:                                                ipfs bootstrap node, `:default:` will set ipfs default bootstrap node
+  -p2p.dht client                                                         dht mode, can be: `client`, `server`, `auto`, `autoserver`
+  -p2p.dht-randomwalk true                                                if true dht will have randomwalk enable
+  -p2p.disable-ipfs-network false                                         disable as much networking feature as possible, useful during development
+  -p2p.ipfs-api-listeners /ip4/127.0.0.1/tcp/5001                         IPFS API listeners
+  -p2p.max-backoff 10m0s                                                  maximum p2p backoff duration
+  -p2p.mdns true                                                          if true mdns will be enabled
+  -p2p.min-backoff 1m0s                                                   minimum p2p backoff duration
+  -p2p.multipeer-connectivity true                                        if true Multipeer Connectivity will be enabled
+  -p2p.nearby false                                                       if true Android Nearby will be enabled
+  -p2p.poll-interval 1s                                                   how long the discovery system will waits for more peers
+  -p2p.rdvp :default:                                                     list of rendezvous point maddr, ":dev:" will add the default devs servers, ":none:" will disable rdvp
+  -p2p.static-relays :default:                                            list of static relay maddrs, `:default:` will use statics relays from the config
+  -p2p.swarm-announce ...                                                 IPFS announce addrs
+  -p2p.swarm-listeners :default:                                          IPFS swarm listeners
+  -p2p.swarm-no-announce ...                                              IPFS exclude announce addrs
+  -p2p.tinder-dht-driver true                                             if true dht driver will be enable for tinder
+  -p2p.tinder-rdvp-driver true                                            if true rdvp driver will be enable for tinder
+  -p2p.webui-listener :3999                                               IPFS WebUI listener
+  -preset ...                                                             applies various default values, see ADVANCED section below
+  -store.dir /Users/gfanton/Library/Application Support/berty-tech/berty  root datastore directory
+  -store.inmem false                                                      disable datastore persistence
+  -store.lowmem false                                                     enable LowMemory Profile, useful for mobile environment
+  -tor.binary-path ...                                                    if set berty will use this external tor binary instead of his builtin one
+  -tor.mode disabled                                                      changes the behavior of libp2p regarding tor, see advanced help for more details
+
+ADVANCED
+  -log.filters=':default: CUSTOM'        equivalent to -log.filters='info+:bty*,-*.grpc error+:* CUSTOM'
+                                         -> more info at https://github.com/moul/zapfilter
+  -preset=performance                    better performance: current development defaults
+  -preset=anonymity                      better privacy: -tor.mode=required -p2p.mdns=false -p2p.multipeer-connectivity=false -p2p.ble=false -p2p.nearby=false
+  -preset=volatile                       similar to performance but optimize for a quick throwable node: -store.inmem=true -p2p.ipfs-api-listeners="" -p2p.swarm-listeners="" -p2p.webui-listener=""
+  -p2p.swarm-listeners=:default:,CUSTOM  equivalent to -p2p.swarm-listeners=/ip4/0.0.0.0/tcp/0,/ip6/::/tcp/0,/ip4/0.0.0.0/udp/0/quic,/ip6/::/udp/0/quic,CUSTOM
+  -p2p.rdvp=:default:,CUSTOM             equivalent to -p2p.rdvp=/ip4/51.159.21.214/tcp/4040/p2p/QmdT7Amhhn...,CUSTOM
+                                         -> full list available at https://github.com/berty/berty/tree/master/config)
+  -tor.mode=disabled                     tor is completely disabled
+  -tor.mode=optional                     tor is added to the list of existing transports and can be used to contact other tor-ready nodes
+  -tor.mode=required                     tor is the only available transport; you can only communicate with other tor-ready nodes
+
+foo@bar:~$ berty remote-logs -h
+USAGE
+  berty [global flags] remote-logs
+
+FLAGS
+  -node.remote-addr ...  remote Berty gRPC API address
+
+ADVANCED
+  -log.filters=':default: CUSTOM'  equivalent to -log.filters='info+:bty*,-*.grpc error+:* CUSTOM'
+                                   -> more info at https://github.com/moul/zapfilter
 ```
 
 ## Other Binaries
@@ -579,8 +715,9 @@ USAGE
   rdvp [global flags] <subcommand>
 
 SUBCOMMANDS
-  serve   
-  genkey  
+  serve
+  genkey
+  sharekey
 
 FLAGS
   -log.file stderr      if specified, will log everything in JSON into a file and nothing on stderr
@@ -610,6 +747,13 @@ USAGE
 FLAGS
   -length 2048   The length (in bits) of the key generated.
   -type Ed25519  Type of the private key generated, one of : Ed25519, ECDSA, Secp256k1, RSA
+
+foo@bar:~$ rdvp sharekey -h
+USAGE
+  rdvp [global flags] sharekey -pk PK
+
+FLAGS
+  -pk ...  private key (generated by `rdvp genkey`)
 ```
 
 ### `betabot`
@@ -621,7 +765,9 @@ Usage of betabot:
   -addr string
     	remote 'berty daemon' address (default "127.0.0.1:9091")
   -display-name string
-    	bot's display name (default "guilhemfanton (betabot)")
+    	bot's display name (default "gfanton (betabot)")
+  -log-format string
+    	console, json, light-console, light-json (default "console")
   -staff-conversation-link string
     	link of the staff's conversation to join
   -store string

--- a/go/cmd/berty-integration/README.md
+++ b/go/cmd/berty-integration/README.md
@@ -78,8 +78,6 @@ Usage of integration:
     	if true Multipeer Connectivity will be enabled (default true)
   -p2p.rdvp string
     	list of rendezvous point maddr, ":dev:" will add the default devs servers, ":none:" will disable rdvp (default ":default:")
-  -p2p.relay-hack
-    	*temporary flag*; if set, Berty will use relays from the config optimistically
   -p2p.swarm-listeners string
     	IPFS swarm listeners (default ":default:")
   -p2p.webui-listener string

--- a/go/framework/bertybridge/blackbox_test.go
+++ b/go/framework/bertybridge/blackbox_test.go
@@ -45,7 +45,7 @@ func Example() {
 		"--node.display-name=",
 		"--node.listeners=/ip4/127.0.0.1/tcp/0/grpcws",
 		"--p2p.swarm-listeners=/ip4/0.0.0.0/tcp/0,/ip6/::/tcp/0",
-		"--p2p.local-discovery=false",
+		"--p2p.mdns=false",
 		"--p2p.webui-listener=:3000",
 		"--store.dir=" + tmpdir,
 	}

--- a/go/internal/initutil/ipfs.go
+++ b/go/internal/initutil/ipfs.go
@@ -63,7 +63,7 @@ func (m *Manager) SetupLocalIPFSFlags(fs *flag.FlagSet) {
 	fs.StringVar(&m.Node.Protocol.DHT, "p2p.dht", "client", "dht mode, can be: `client`, `server`, `auto`, `autoserver`") // @TODO(gfanton): add disabled mode
 	fs.BoolVar(&m.Node.Protocol.DHTRandomWalk, "p2p.dht-randomwalk", true, "if true dht will have randomwalk enable")
 	fs.StringVar(&m.Node.Protocol.NoAnnounce, "p2p.swarm-no-announce", "", "IPFS exclude announce addrs")
-	fs.BoolVar(&m.Node.Protocol.LocalDiscovery, "p2p.local-discovery", true, "if true local discovery will be enabled")
+	fs.BoolVar(&m.Node.Protocol.MDNS, "p2p.mdns", true, "if true mdns will be enabled")
 	fs.BoolVar(&m.Node.Protocol.TinderDHTDriver, "p2p.tinder-dht-driver", true, "if true dht driver will be enable for tinder")
 	fs.BoolVar(&m.Node.Protocol.TinderRDVPDriver, "p2p.tinder-rdvp-driver", true, "if true rdvp driver will be enable for tinder")
 	fs.StringVar(&m.Node.Protocol.StaticRelays, "p2p.static-relays", ":default:", "list of static relay maddrs, `:default:` will use statics relays from the config")
@@ -413,7 +413,7 @@ func (m *Manager) setupIPFSConfig(cfg *ipfs_cfg.Config) ([]libp2p.Option, error)
 	}
 
 	// localdisc driver
-	if !m.Node.Protocol.LocalDiscovery {
+	if !m.Node.Protocol.MDNS {
 		cfg.Discovery.MDNS.Enabled = false
 	}
 

--- a/go/internal/initutil/ipfs.go
+++ b/go/internal/initutil/ipfs.go
@@ -55,29 +55,28 @@ func (m *Manager) SetNBDriver(d proximity.NativeDriver) {
 
 func (m *Manager) SetupLocalIPFSFlags(fs *flag.FlagSet) {
 	m.SetupPresetFlags(fs)
-	fs.StringVar(&m.Node.Protocol.SwarmListeners, "p2p.swarm-listeners", ":default:", "IPFS swarm listeners")
+	fs.StringVar(&m.Node.Protocol.SwarmListeners, "p2p.swarm-listeners", KeywordDefault, "IPFS swarm listeners")
 	fs.StringVar(&m.Node.Protocol.IPFSAPIListeners, "p2p.ipfs-api-listeners", "/ip4/127.0.0.1/tcp/5001", "IPFS API listeners")
 	fs.StringVar(&m.Node.Protocol.IPFSWebUIListener, "p2p.webui-listener", ":3999", "IPFS WebUI listener")
 	fs.StringVar(&m.Node.Protocol.Announce, "p2p.swarm-announce", "", "IPFS announce addrs")
-	fs.StringVar(&m.Node.Protocol.Bootstrap, "p2p.bootstrap", ":default:", "ipfs bootstrap node, `:default:` will set ipfs default bootstrap node")
+	fs.StringVar(&m.Node.Protocol.Bootstrap, "p2p.bootstrap", KeywordDefault, "ipfs bootstrap node, `:default:` will set ipfs default bootstrap node")
 	fs.StringVar(&m.Node.Protocol.DHT, "p2p.dht", "client", "dht mode, can be: `client`, `server`, `auto`, `autoserver`") // @TODO(gfanton): add disabled mode
 	fs.BoolVar(&m.Node.Protocol.DHTRandomWalk, "p2p.dht-randomwalk", true, "if true dht will have randomwalk enable")
 	fs.StringVar(&m.Node.Protocol.NoAnnounce, "p2p.swarm-no-announce", "", "IPFS exclude announce addrs")
 	fs.BoolVar(&m.Node.Protocol.MDNS, "p2p.mdns", true, "if true mdns will be enabled")
 	fs.BoolVar(&m.Node.Protocol.TinderDHTDriver, "p2p.tinder-dht-driver", true, "if true dht driver will be enable for tinder")
 	fs.BoolVar(&m.Node.Protocol.TinderRDVPDriver, "p2p.tinder-rdvp-driver", true, "if true rdvp driver will be enable for tinder")
-	fs.StringVar(&m.Node.Protocol.StaticRelays, "p2p.static-relays", ":default:", "list of static relay maddrs, `:default:` will use statics relays from the config")
+	fs.StringVar(&m.Node.Protocol.StaticRelays, "p2p.static-relays", KeywordDefault, "list of static relay maddrs, `:default:` will use statics relays from the config")
 	fs.DurationVar(&m.Node.Protocol.MinBackoff, "p2p.min-backoff", time.Minute, "minimum p2p backoff duration")
 	fs.DurationVar(&m.Node.Protocol.MaxBackoff, "p2p.max-backoff", time.Minute*10, "maximum p2p backoff duration")
 	fs.DurationVar(&m.Node.Protocol.PollInterval, "p2p.poll-interval", pubsub.DiscoveryPollInterval, "how long the discovery system will waits for more peers")
-	fs.StringVar(&m.Node.Protocol.RdvpMaddrs, "p2p.rdvp", ":default:", `list of rendezvous point maddr, ":dev:" will add the default devs servers, ":none:" will disable rdvp`)
+	fs.StringVar(&m.Node.Protocol.RdvpMaddrs, "p2p.rdvp", KeywordDefault, "list of rendezvous point maddr, `:dev:` will add the default devs servers, `:none:` will disable rdvp")
 	fs.BoolVar(&m.Node.Protocol.Ble.Enable, "p2p.ble", ble.Supported, "if true Bluetooth Low Energy will be enabled")
 	fs.BoolVar(&m.Node.Protocol.Nearby.Enable, "p2p.nearby", nb.Supported, "if true Android Nearby will be enabled")
 	fs.BoolVar(&m.Node.Protocol.MultipeerConnectivity, "p2p.multipeer-connectivity", mc.Supported, "if true Multipeer Connectivity will be enabled")
 	fs.StringVar(&m.Node.Protocol.Tor.Mode, "tor.mode", defaultTorMode, "changes the behavior of libp2p regarding tor, see advanced help for more details")
 	fs.StringVar(&m.Node.Protocol.Tor.BinaryPath, "tor.binary-path", "", "if set berty will use this external tor binary instead of his builtin one")
 	fs.BoolVar(&m.Node.Protocol.DisableIPFSNetwork, "p2p.disable-ipfs-network", false, "disable as much networking feature as possible, useful during development")
-	fs.BoolVar(&m.Node.Protocol.RelayHack, "p2p.relay-hack", false, "*temporary flag*; if set, Berty will use relays from the config optimistically")
 	m.longHelp = append(m.longHelp, [2]string{
 		"-p2p.swarm-listeners=:default:,CUSTOM",
 		fmt.Sprintf("equivalent to -p2p.swarm-listeners=%s,CUSTOM", strings.Join(ipfsutil.DefaultSwarmListeners, ",")),
@@ -576,9 +575,9 @@ func (m *Manager) getRdvpMaddrs() ([]*peer.AddrInfo, error) {
 	var addrs []string
 	for _, v := range strings.Split(m.Node.Protocol.RdvpMaddrs, ",") {
 		switch v {
-		case ":default:":
+		case KeywordDefault:
 			addrs = append(addrs, defaultMaddrs...)
-		case ":none:":
+		case KeywordNone:
 			return nil, nil
 		default:
 			addrs = append(addrs, v)
@@ -596,9 +595,9 @@ func (m *Manager) getStaticRelays() ([]*peer.AddrInfo, error) {
 	var addrs []string
 	for _, v := range strings.Split(m.Node.Protocol.RdvpMaddrs, ",") {
 		switch v {
-		case ":default:":
+		case KeywordDefault:
 			addrs = append(addrs, defaultMaddrs...)
-		case ":none:", "":
+		case KeywordNone, "":
 			continue
 		default:
 			addrs = append(addrs, v)
@@ -616,9 +615,9 @@ func (m *Manager) getBootstrapAddrs() []string {
 	bootstrapAddrs := []string{}
 	for _, addr := range strings.Split(m.Node.Protocol.Bootstrap, ",") {
 		switch addr {
-		case ":default:":
+		case KeywordDefault:
 			bootstrapAddrs = append(bootstrapAddrs, ipfs_cfg.DefaultBootstrapAddresses...)
-		case ":none:", "":
+		case KeywordNone, "":
 			continue
 		default:
 			bootstrapAddrs = append(bootstrapAddrs, addr)
@@ -636,9 +635,9 @@ func (m *Manager) getSwarmAddrs() []string {
 	swarmAddrs := []string{}
 	for _, addr := range strings.Split(m.Node.Protocol.SwarmListeners, ",") {
 		switch addr {
-		case ":default:":
+		case KeywordDefault:
 			swarmAddrs = append(swarmAddrs, ipfsutil.DefaultSwarmListeners...)
-		case ":none:":
+		case KeywordNone:
 			return nil
 		default:
 			swarmAddrs = append(swarmAddrs, addr)

--- a/go/internal/initutil/logger.go
+++ b/go/internal/initutil/logger.go
@@ -60,7 +60,7 @@ func (m *Manager) getLogger() (*zap.Logger, error) {
 		return m.Logging.zapLogger, nil
 	}
 
-	m.Logging.Filters = strings.ReplaceAll(m.Logging.Filters, ":default:", defaultLoggingFilters)
+	m.Logging.Filters = strings.ReplaceAll(m.Logging.Filters, KeywordDefault, defaultLoggingFilters)
 
 	tracerFlush := tracer.InitTracer(m.Logging.Tracer, m.Logging.Service)
 	streams := []logutil.Stream{

--- a/go/internal/initutil/manager.go
+++ b/go/internal/initutil/manager.go
@@ -37,6 +37,11 @@ import (
 	"berty.tech/berty/v2/go/pkg/protocoltypes"
 )
 
+const (
+	KeywordDefault string = ":default:"
+	KeywordNone    string = ":none:"
+)
+
 type Manager struct {
 	Logging struct {
 		Format      string `json:"Format,omitempty"`
@@ -80,7 +85,7 @@ type Manager struct {
 			MDNS              bool   `json:"LocalDiscovery,omitempty"`
 			TinderDHTDriver   bool   `json:"TinderDHTDriver,omitempty"`
 			TinderRDVPDriver  bool   `json:"TinderRDVPDriver,omitempty"`
-			UseStaticRelays   bool   `json:"UseStaticRelays,omitempty"`
+			StaticRelays      string `json:"StaticRelays,omitempty"`
 			Ble               struct {
 				Enable bool                   `json:"Enable,omitempty"`
 				Driver proximity.NativeDriver `json:"Driver,omitempty"`
@@ -101,8 +106,6 @@ type Manager struct {
 				Mode       string `json:"Mode,omitempty"`
 				BinaryPath string `json:"BinaryPath,omitempty"`
 			} `json:"Tor,omitempty"`
-			// FIXME: Remove this option, this is a temporary fix
-			RelayHack bool `json:"RelayHack,omitempty"`
 
 			// internal
 			needAuth          bool

--- a/go/internal/initutil/manager.go
+++ b/go/internal/initutil/manager.go
@@ -73,11 +73,13 @@ type Manager struct {
 			IPFSAPIListeners  string `json:"IPFSAPIListeners,omitempty"`
 			IPFSWebUIListener string `json:"IPFSWebUIListener,omitempty"`
 			Announce          string `json:"Announce,omitempty"`
+			Bootstrap         string `json:"Bootstrap,omitempty"`
+			DHT               string `json:"DHT,omitempty"`
 			NoAnnounce        string `json:"NoAnnounce,omitempty"`
 			LocalDiscovery    bool   `json:"LocalDiscovery,omitempty"`
 			TinderDHTDriver   bool   `json:"TinderDHTDriver,omitempty"`
 			TinderRDVPDriver  bool   `json:"TinderRDVPDriver,omitempty"`
-			StaticRelays      string `json:"StaticRelays,omitempty"`
+			UseStaticRelays   bool   `json:"UseStaticRelays,omitempty"`
 			Ble               struct {
 				Enable bool                   `json:"Enable,omitempty"`
 				Driver proximity.NativeDriver `json:"Driver,omitempty"`

--- a/go/internal/initutil/manager.go
+++ b/go/internal/initutil/manager.go
@@ -77,7 +77,7 @@ type Manager struct {
 			DHT               string `json:"DHT,omitempty"`
 			DHTRandomWalk     bool   `json:"DHTRandomWalk,omitempty"`
 			NoAnnounce        string `json:"NoAnnounce,omitempty"`
-			LocalDiscovery    bool   `json:"LocalDiscovery,omitempty"`
+			MDNS              bool   `json:"LocalDiscovery,omitempty"`
 			TinderDHTDriver   bool   `json:"TinderDHTDriver,omitempty"`
 			TinderRDVPDriver  bool   `json:"TinderRDVPDriver,omitempty"`
 			UseStaticRelays   bool   `json:"UseStaticRelays,omitempty"`

--- a/go/internal/initutil/manager.go
+++ b/go/internal/initutil/manager.go
@@ -75,6 +75,7 @@ type Manager struct {
 			Announce          string `json:"Announce,omitempty"`
 			Bootstrap         string `json:"Bootstrap,omitempty"`
 			DHT               string `json:"DHT,omitempty"`
+			DHTRandomWalk     bool   `json:"DHTRandomWalk,omitempty"`
 			NoAnnounce        string `json:"NoAnnounce,omitempty"`
 			LocalDiscovery    bool   `json:"LocalDiscovery,omitempty"`
 			TinderDHTDriver   bool   `json:"TinderDHTDriver,omitempty"`

--- a/go/internal/initutil/node.go
+++ b/go/internal/initutil/node.go
@@ -116,7 +116,7 @@ func (m *Manager) applyPreset() error {
 		// FIXME: raise an error if tor is not available on the node
 
 		// Disable proximity communications
-		m.Node.Protocol.LocalDiscovery = false
+		m.Node.Protocol.MDNS = false
 		m.Node.Protocol.MultipeerConnectivity = false
 		m.Node.Protocol.Ble.Enable = false
 		m.Node.Protocol.Nearby.Enable = false

--- a/go/internal/initutil/node.go
+++ b/go/internal/initutil/node.go
@@ -75,7 +75,7 @@ func (m *Manager) SetupPresetFlags(fs *flag.FlagSet) {
 		"better performance: current development defaults",
 	}, [2]string{
 		"-preset=" + AnonymityPreset,
-		"better privacy: -tor.mode=" + TorRequired + " -p2p.local-discovery=false -p2p.multipeer-connectivity=false -p2p.ble=false -p2p.nearby=false",
+		"better privacy: -tor.mode=" + TorRequired + " -p2p.mdns=false -p2p.multipeer-connectivity=false -p2p.ble=false -p2p.nearby=false",
 	}, [2]string{
 		"-preset=" + VolatilePreset,
 		"similar to " + PerformancePreset + ` but optimize for a quick throwable node: -store.inmem=true -p2p.ipfs-api-listeners="" -p2p.swarm-listeners="" -p2p.webui-listener=""`,

--- a/js/packages/go-bridge/defaults.ts
+++ b/js/packages/go-bridge/defaults.ts
@@ -6,9 +6,8 @@ export const GoBridgeDefaultOpts: GoBridgeOpts = {
 		'--store.lowmem=true',
 		'--node.listeners=/ip4/127.0.0.1/tcp/0/grpcws',
 		'--p2p.swarm-listeners=/ip4/0.0.0.0/tcp/0,/ip6/::/tcp/0',
-		'--p2p.local-discovery=false',
+		'--p2p.mdns=false',
 		'--p2p.webui-listener=:3000',
-		'--p2p.relay-hack=true',
 	],
 	persistence: true,
 }

--- a/tool/compose-integration/docker-compose.yml
+++ b/tool/compose-integration/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       mv /shared/testbot_daemon1.txt.tmp /shared/testbot_daemon1.txt;
       berty daemon
         -node.listeners=/ip4/0.0.0.0/tcp/9091/grpc
-        -p2p.local-discovery=false
+        -p2p.mdns=false
         -p2p.rdvp=/dns4/rdvp/tcp/4040/p2p/`cat /shared/rdvp-pub.txt`
       "
     depends_on:
@@ -78,7 +78,7 @@ services:
       mv /shared/testbot_daemon2.txt.tmp /shared/testbot_daemon2.txt;
       berty daemon
         -node.listeners=/ip4/0.0.0.0/tcp/9091/grpc
-        -p2p.local-discovery=false
+        -p2p.mdns=false
         -p2p.rdvp=/dns4/rdvp/tcp/4040/p2p/`cat /shared/rdvp-pub.txt`
       "
     depends_on:

--- a/tool/tyber/go/parser/header.go
+++ b/tool/tyber/go/parser/header.go
@@ -48,7 +48,6 @@ type Header struct {
 					Mode       string `json:"mode,omitempty"`
 					BinaryPath string `json:"binaryPath,omitempty"`
 				} `json:"tor,omitempty"`
-				RelayHack bool `json:"relayHack,omitempty"`
 			}
 			Messenger struct {
 				DisableGroupMonitor  bool   `json:"disableGroupMonitor,omitempty"`


### PR DESCRIPTION
- `p2p.bootstrap`: ipfs bootstrap node, `:default:` will set ipfs default bootstrap node
- `p2p.dht`: dht mode, can be: `client`, `server`, `auto`, `autoserver`,
- `p2p.dht-randomwalk`: if `true` dht will have dht randomwalk enable

<!-- Thank you for your contribution! ❤️ -->