### PR TITLE
feat: auto make app deps from gradle

### DIFF
--- a/js/Makefile
+++ b/js/Makefile
@@ -33,8 +33,9 @@ android_gomobile_cache=android/.gomobile-cache
 ## if (PWD != Makefile directory) then exit
 
 makefile_dir = $(realpath $(dir $(realpath $(firstword $(MAKEFILE_LIST)))))
-ifneq ($(PWD),$(makefile_dir))
-    $(error make should be executed from '$(makefile_dir)' instead of '$(PWD)')
+real_pwd = $(realpath $(PWD))
+ifneq ($(real_pwd),$(makefile_dir))
+    $(error make should be executed from '$(makefile_dir)' instead of '$(real_pwd)')
 endif
 
 ## User commands

--- a/js/android/app/build.gradle
+++ b/js/android/app/build.gradle
@@ -211,6 +211,35 @@ android {
     }
 }
 
+// Auto-build gomobile.aar by running Makefile rule
+task makeDeps(description: 'Build gomobile.arr (Berty go core)') {
+    outputs.files fileTree(dir: "${rootDir.getPath()}/libs", include: ["*.jar", "*.aar"])
+
+    doLast {
+        if (System.properties['os.name'].toLowerCase().contains('windows')) {
+            logger.warn("Warning: can't run make on Windows, you must build gomobile.aar manually")
+            return
+        }
+
+        def checkMakeInPath = exec {
+            standardOutput = new ByteArrayOutputStream() // equivalent to '> /dev/null'
+            ignoreExitValue = true
+            commandLine 'bash', '-l', '-c', 'command -v make'
+        }
+
+        if (checkMakeInPath.getExitValue() == 0) {
+            exec {
+                def makefileDir = "${rootDir.getPath()}/.."
+                workingDir makefileDir
+                environment 'PWD', makefileDir
+                commandLine 'make', 'android.app_deps'
+            }
+        } else {
+            logger.warn('Warning: make command not found in PATH')
+        }
+    }
+}
+
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     //noinspection GradleDynamicVersion
@@ -249,7 +278,7 @@ dependencies {
         implementation jscFlavor
     }
 
-    implementation fileTree(dir: "../libs", include: ["*.jar", "*.aar"]) // go lib
+    implementation makeDeps.outputs.files
 }
 
 // Run this once to be able to run the application with BUCK

--- a/js/android/gradle/wrapper/gradle-wrapper.properties
+++ b/js/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Thu Mar 25 17:20:16 CET 2021
+#Wed May 05 12:11:29 CEST 2021
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip

--- a/js/android/settings.gradle
+++ b/js/android/settings.gradle
@@ -1,10 +1,18 @@
 rootProject.name = 'Berty'
+
+// install node_modules if directory doesn't exist
+if (!file("${rootDir.getPath()}/../node_modules").exists()) {
+    exec {
+        workingDir "${rootDir.getPath()}/.."
+        commandLine 'yarn'
+    }
+}
+
 apply from: file("../node_modules/@react-native-community/cli-platform-android/native_modules.gradle"); applyNativeModulesSettingsGradle(settings)
 
 // remove when https://github.com/wix/react-native-interactable/pull/288 is merged
 include ':react-native-interactable'
 project(':react-native-interactable').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-interactable/lib/android')
-//
 
 include ':react-native-share'
 project(':react-native-share').projectDir = new File(rootProject.projectDir,    '../node_modules/react-native-share/android')

--- a/js/package.json
+++ b/js/package.json
@@ -8,7 +8,7 @@
 		"start": "react-native start",
 		"test": "jest",
 		"lint": "eslint . --ext .js,.jsx,.ts,.tsx",
-		"postinstall": "patch-package"
+		"postinstall": "patch-package && npx jetify"
 	},
 	"dependencies": {
 		"@eva-design/eva": "^2.0.0",


### PR DESCRIPTION
This PR allows users who want to build the Android app to just click the "Run" button in Android Studio, without having to run a Makefile rule to build the deps.
- [x] If OS == Windows, print a warning and let user handle build manually
- [x] If make is not found in path, print a warning and let user handle build manually
- [x] If OS != Windows and make is found in path, gradle will run `make android.app_deps` for each build

Signed-off-by: aeddi <antoine.e.b@gmail.com>