### PR TITLE
fix: rexml gem is missing when running project on a fresh install

### DIFF
--- a/js/ios/Gemfile
+++ b/js/ios/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
 gem "cocoapods", "~> 1.10.O"
+
+gem "rexml", "~> 3.2"

--- a/js/ios/Gemfile.lock
+++ b/js/ios/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
     nap (1.1.0)
     netrc (0.11.0)
     public_suffix (4.0.6)
+    rexml (3.2.5)
     ruby-macho (1.4.0)
     thread_safe (0.3.6)
     typhoeus (1.4.0)
@@ -88,6 +89,7 @@ PLATFORMS
 
 DEPENDENCIES
   cocoapods (~> 1.10.O)
+  rexml (~> 3.2)
 
 BUNDLED WITH
-   2.1.4
+   2.2.15


### PR DESCRIPTION
I'm not sure why this problem occurs but installing pods fails on a freshly reinstalled Macbook.
It should be a deps from cocoapods then, no idea why it doesn't install with it.

Error fixed:
```term
> make ios.release
(...)
Downloading dependencies
Installing BVLinearGradient (2.5.6)
Installing CocoaAsyncSocket (7.6.5)
(...)
Generating Pods project
LoadError - cannot load such file -- rexml/document
```

Signed-off-by: aeddi <antoine.e.b@gmail.com>