### PR TITLE
fix(messenger): remove useless locks

### DIFF
--- a/go/pkg/bertymessenger/api.go
+++ b/go/pkg/bertymessenger/api.go
@@ -173,9 +173,6 @@ func (svc *service) ShareableBertyGroup(ctx context.Context, req *messengertypes
 		return nil, errcode.ErrInvalidInput
 	}
 
-	svc.handlerMutex.Lock()
-	defer svc.handlerMutex.Unlock()
-
 	grpInfo, err := svc.protocolClient.GroupInfo(ctx, &protocoltypes.GroupInfo_Request{
 		GroupPK: req.GroupPK,
 	})
@@ -206,9 +203,6 @@ func (svc *service) SendContactRequest(ctx context.Context, req *messengertypes.
 	if req == nil || req.BertyID == nil || req.BertyID.AccountPK == nil || req.BertyID.PublicRendezvousSeed == nil {
 		return nil, errcode.ErrMissingInput
 	}
-
-	svc.handlerMutex.Lock()
-	defer svc.handlerMutex.Unlock()
 
 	contactRequest := protocoltypes.ContactRequestSend_Request{
 		Contact: &protocoltypes.ShareableContact{
@@ -325,10 +319,8 @@ func (svc *service) SystemInfo(ctx context.Context, req *messengertypes.SystemIn
 	return &reply, nil
 }
 
+// Remove ?
 func (svc *service) SendAck(ctx context.Context, req *messengertypes.SendAck_Request) (*messengertypes.SendAck_Reply, error) {
-	svc.handlerMutex.Lock()
-	defer svc.handlerMutex.Unlock()
-
 	gInfo, err := svc.protocolClient.GroupInfo(ctx, &protocoltypes.GroupInfo_Request{
 		GroupPK: req.GroupPK,
 	})
@@ -901,9 +893,6 @@ func (svc *service) ContactRequest(ctx context.Context, req *messengertypes.Cont
 		return nil, errcode.ErrMessengerInvalidDeepLink.Wrap(err)
 	}
 
-	svc.handlerMutex.Lock()
-	defer svc.handlerMutex.Unlock()
-
 	acc, err := svc.db.getAccount()
 	if err != nil {
 		return nil, errcode.TODO.Wrap(err)
@@ -947,9 +936,6 @@ func (svc *service) ContactAccept(ctx context.Context, req *messengertypes.Conta
 		return nil, errcode.ErrInvalidInput
 	}
 
-	svc.handlerMutex.Lock()
-	defer svc.handlerMutex.Unlock()
-
 	svc.logger.Debug("retrieving contact", zap.String("contact_pk", pk))
 
 	c, err := svc.db.getContactByPK(pk)
@@ -991,9 +977,6 @@ func (svc *service) Interact(ctx context.Context, req *messengertypes.Interact_R
 		return nil, errcode.ErrInvalidInput.Wrap(err)
 	}
 
-	svc.handlerMutex.Lock()
-	defer svc.handlerMutex.Unlock()
-
 	medias, err := svc.db.getMedias(req.GetMediaCids())
 	if err != nil {
 		return nil, errcode.ErrDBRead.Wrap(err)
@@ -1021,9 +1004,6 @@ func (svc *service) Interact(ctx context.Context, req *messengertypes.Interact_R
 }
 
 func (svc *service) AccountGet(ctx context.Context, req *messengertypes.AccountGet_Request) (*messengertypes.AccountGet_Reply, error) {
-	svc.handlerMutex.Lock()
-	defer svc.handlerMutex.Unlock()
-
 	acc, err := svc.db.getAccount()
 	if err != nil {
 		return nil, err
@@ -1188,9 +1168,6 @@ func (svc *service) GetUsername(ctx context.Context, req *messengertypes.GetUser
 }
 
 func (svc *service) SendReplyOptions(ctx context.Context, req *messengertypes.SendReplyOptions_Request) (*messengertypes.SendReplyOptions_Reply, error) {
-	svc.handlerMutex.Lock()
-	defer svc.handlerMutex.Unlock()
-
 	payload, err := messengertypes.AppMessage_TypeReplyOptions.MarshalPayload(timestampMs(time.Now()), "", nil, req.Options)
 	if err != nil {
 		return nil, err

--- a/go/pkg/bertymessenger/db_test.go
+++ b/go/pkg/bertymessenger/db_test.go
@@ -700,7 +700,7 @@ func Test_dbWrapper_getAccount(t *testing.T) {
 
 	acc, err := db.getAccount()
 	require.Error(t, err)
-	require.True(t, errors.Is(err, gorm.ErrRecordNotFound))
+	require.True(t, errcode.Is(err, errcode.ErrNotFound))
 	require.Empty(t, acc)
 
 	db.db.Create(refAccount)

--- a/go/pkg/bertymessenger/service.go
+++ b/go/pkg/bertymessenger/service.go
@@ -207,7 +207,7 @@ func New(client protocoltypes.ProtocolServiceClient, opts *Opts) (Service, error
 	{
 		acc, err := svc.db.getAccount()
 		switch {
-		case err == gorm.ErrRecordNotFound: // account not found, create a new one
+		case errcode.Is(err, errcode.ErrNotFound): // account not found, create a new one
 			svc.logger.Debug("account not found, creating a new one", zap.String("pk", pkStr))
 			ret, err := svc.internalInstanceShareableBertyID(ctx, &mt.InstanceShareableBertyID_Request{})
 			if err != nil {


### PR DESCRIPTION
bench using Interact on multiple node in parallel with a TestingInfra (aka sending messages in spam conditions)
```
nodes: 10
messagesPerNode: 300
messagesTotal: 3000
```
1513081f0a43a11f26998ec69bea678e9cc359d9 (master)
```
avg: 8m4.866547189s
min: 7m24.719786834s
max: 8m49.098070929s
avg/msg: 1.616221823s
min/msg: 1.482399289s
max/msg: 1.763660236s
```
9747980998f6ab69d6ce41eda7866750397b0297 (this branch)
```
avg: 2m29.030747214s
min: 2m20.090942079s
max: 2m35.32906842s
avg/msg: 496.769157ms
min/msg: 466.969806ms
max/msg: 517.763561ms
```
summary: more than 3 times faster without the lock