### PR TITLE
feat: add none routing opt

### DIFF
--- a/js/packages/go-bridge/defaults.ts
+++ b/js/packages/go-bridge/defaults.ts
@@ -2,6 +2,7 @@ import { GoBridgeOpts } from './types'
 
 export const GoBridgeDefaultOpts: GoBridgeOpts = {
 	cliArgs: [
+		'--p2p.dht=client',
 		'--node.display-name=',
 		'--store.lowmem=true',
 		'--node.listeners=/ip4/127.0.0.1/tcp/0/grpcws',


### PR DESCRIPTION
Add `none` opt to `-p2p.dht` flag to disable ipfs routing (DHT)