### PR TITLE
fix: prevent proguard to strip inAppBrowser required symbols

### DIFF
--- a/js/android/app/proguard-rules.pro
+++ b/js/android/app/proguard-rules.pro
@@ -10,3 +10,10 @@
 # Add any project specific keep options here:
 -keep class com.shakebugs.** { *; }
 -keep public class com.horcrux.svg.** {*;}
+
+# For inAppBrowser
+-keepattributes *Annotation*
+-keepclassmembers class ** {
+  @org.greenrobot.eventbus.Subscribe <methods>;
+}
+-keep enum org.greenrobot.eventbus.ThreadMode { *; }


### PR DESCRIPTION
Signed-off-by: aeddi <antoine.e.b@gmail.com>

<!-- Thank you for your contribution! ❤️ -->