### PR TITLE
fix: unset Android env var to prevent gomobile error on init

### DIFF
--- a/js/Makefile
+++ b/js/Makefile
@@ -354,7 +354,7 @@ _write_gen_sum:
 ios/Frameworks/Bertybridge.framework: $(bridge_src)
 	cd .. && $(GO) mod download
 	cd .. && $(GO) install golang.org/x/mobile/cmd/gobind
-	cd .. && $(GO) run golang.org/x/mobile/cmd/gomobile init
+	cd .. && ANDROID_HOME= ANDROID_NDK_HOME= $(GO) run golang.org/x/mobile/cmd/gomobile init
 	mkdir -p ios/Frameworks
 	cd .. && \
 		PATH="$(PATH):`go env GOPATH`/bin" \


### PR DESCRIPTION
Signed-off-by: aeddi <antoine.e.b@gmail.com>

<!-- Thank you for your contribution! ❤️ -->