### PR TITLE
fix: unset Android env var to prevent gomobile error on bind

### DIFF
--- a/js/Makefile
+++ b/js/Makefile
@@ -358,7 +358,7 @@ ios/Frameworks/Bertybridge.framework: $(bridge_src)
 	mkdir -p ios/Frameworks
 	cd .. && \
 		PATH="$(PATH):`go env GOPATH`/bin" \
-		GO111MODULE=on \
+		GO111MODULE=on ANDROID_HOME= ANDROID_NDK_HOME= \
 		$(GO) run golang.org/x/mobile/cmd/gomobile bind \
 			-o js/$@ \
 			-v $(ext_ldflags) \


### PR DESCRIPTION
Forgot to add this change in #3412 

Signed-off-by: aeddi <antoine.e.b@gmail.com>

<!-- Thank you for your contribution! ❤️ -->