### PR TITLE
fix: BLE crashes

### DIFF
--- a/go/internal/ble-driver/BleInterface_darwin.m
+++ b/go/internal/ble-driver/BleInterface_darwin.m
@@ -16,7 +16,6 @@ extern int BLEHandleFoundPeer(char *);
 extern void BLEHandleLostPeer(char *);
 extern void BLEReceiveFromPeer(char *, void *, unsigned long);
 
-static BleManager *manager = nil;
 os_log_t OS_LOG_BLE = nil;
 
 void handleException(NSException* exception) {
@@ -24,11 +23,15 @@ void handleException(NSException* exception) {
 }
 
 BleManager* getManager(void) {
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        os_log(OS_LOG_BLE, "🟢 getManager() initialize");
-        manager = [[[BleManager alloc] initScannerAndAdvertiser] autorelease];
-    });
+    static BleManager *manager = nil;
+
+    @synchronized([BleManager class])
+    {
+        if(!manager) {
+            os_log(OS_LOG_BLE, "BleManager: initialization");
+            manager = [[BleManager alloc] initScannerAndAdvertiser];
+        }
+    }
     return manager;
 }
 

--- a/go/internal/ble-driver/BleManager_darwin.h
+++ b/go/internal/ble-driver/BleManager_darwin.h
@@ -39,6 +39,7 @@
 @property (nonatomic, readwrite, strong) CountDownLatch* __nonnull bleOn;
 @property (nonatomic, readwrite, strong) CountDownLatch* __nonnull serviceAdded;
 @property (nonatomic, strong, nullable) NSTimer *scannerTimer;
+@property (nonatomic, readwrite, getter=isScanning) BOOL scanning;
 
 - (instancetype __nonnull) initScannerAndAdvertiser;
 - (void)addService;

--- a/js/android/app/src/main/java/tech/berty/gobridge/bledriver/BleDriver.java
+++ b/js/android/app/src/main/java/tech/berty/gobridge/bledriver/BleDriver.java
@@ -260,6 +260,7 @@ public class BleDriver {
         stopBleDriver();
         if (mBroadcastReceiverRegistered) {
             mAppContext.unregisterReceiver(mBroadcastReceiver);
+			mBroadcastReceiverRegistered = false;
         }
     }
 


### PR DESCRIPTION
# iOS
* change BleManager singleton for non-ARC version (crashed when switching account)
* stop scanner timer in the main thread (crashed when stopping the node)

# Android
* Track correctly the broadcast receiver register status to avoid to unregister it multiple times (crashed when switching account)

Signed-off-by: D4ryl00 <d4ryl00@gmail.com>