### PR TITLE
chore: fix typo in berty mini

### DIFF
--- a/go/cmd/berty/mini/view_group_incoming.go
+++ b/go/cmd/berty/mini/view_group_incoming.go
@@ -313,9 +313,9 @@ func groupMonitorEventHandler(logger *zap.Logger, v *groupView, e *protocoltypes
 	case protocoltypes.TypeEventMonitorPeerLeave:
 		peerleave := e.GetPeerLeave()
 		if peerleave.IsSelf {
-			payload = "you just leaved this group"
+			payload = "you just left this group"
 		} else {
-			payload = fmt.Sprintf("peer leaved <%.15s>", peerleave.GetPeerID())
+			payload = fmt.Sprintf("peer left <%.15s>", peerleave.GetPeerID())
 		}
 	case protocoltypes.TypeEventMonitorAdvertiseGroup:
 		advertisegroup := e.GetAdvertiseGroup()


### PR DESCRIPTION
Fixed a small grammatical error in Berty mini.

Before:
```
15:29:45 -------- peer joined <12D3KooWQg5mUwK> on: /ip4/147.75.195.153/udp/4001/quic/p2p/QmW9m57aiBDHA…
15:30:21 -------- peer leaved <12D3KooWQg5mUwK>
```

After
```
15:39:02 -------- peer joined <12D3KooWQg5mUwK> on: /ip4/192.168.1.86/tcp/37275
15:42:08 -------- peer left <12D3KooWMkpZWyW>
```

If necessary, I could add 2 spaces before the PeerId to line it up better. 


Signed-off-by: Mathis Van Eetvelde <mathis.vaneetvelde@protonmail.com>

<!-- Thank you for your contribution! ❤️ -->