### PR TITLE
fix: booleanize variable

### DIFF
--- a/js/packages/components/main/home/Home.tsx
+++ b/js/packages/components/main/home/Home.tsx
@@ -269,7 +269,7 @@ export const Home: React.FC<ScreenProps.Main.Home> = () => {
 							onLayout={onLayoutConvs}
 						/>
 						{layoutRequests.height + layoutHeader.height + layoutConvs.height < windowHeight &&
-							requests.length && (
+							!!requests.length && (
 								<View
 									style={{
 										height:


### PR DESCRIPTION
This fixes the black screen on account creation. Was due to a variable being interpreted as text outside of a Text component