### PR TITLE
fix: ignore fake cids while finding lazy-loading ref

### DIFF
--- a/js/packages/components/chat/MessageList.tsx
+++ b/js/packages/components/chat/MessageList.tsx
@@ -68,7 +68,13 @@ export const MessageList: React.FC<{
 		() => rawMessages.filter(message => !message.payload?.options?.length),
 		[rawMessages],
 	)
-	const oldestMessage = useMemo(() => messages[messages.length - 1], [messages])
+	const oldestMessage = useMemo(
+		() =>
+			messages.filter(msg => msg.type !== beapi.messenger.AppMessage.Type.TypeMonitorMetadata)[
+				messages.length - 1
+			],
+		[messages],
+	)
 
 	const [fetchingFrom, setFetchingFrom] = useState<string | null>(null)
 	const [fetchedFirst, setFetchedFirst] = useState(rawMessages.length === 0)


### PR DESCRIPTION
Loading of conversations is blocked if the last message is a MonitorMetadata
Fixes #3629 