### PR TITLE
chore: rename Unstable to Flappy for testing utilities

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -28,7 +28,7 @@ jobs:
     needs: golangci-lint
     strategy:
       matrix:
-        golang: ['1.16.x']
+        golang: ['1.17.x']
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.5
@@ -68,21 +68,21 @@ jobs:
           args: --timeout=10m
           # only-new-issues: true
 
-  # this is unusual to have a job that checks the unstable tests.
+  # this is not very common to have a job that checks the flappy tests.
   #
-  # reason: some tests are unstable, they works, but not always;
+  # reason: some tests are flappy, they works, but not always;
   #         this job checks that they are working sometimes.
-  #         if this job fails, then a tests switched from "unstable" to "broken".
+  #         if this job fails, then a test is "broken", not "flappy".
   #
-  #         summary: this job checks that "unstable tests" do not become "broken tests".
+  #         summary: this job checks that "flappy tests" do not become "broken tests".
   #
-  # we hope we can remove this job because all the tests are stable 100% of the time :)
-  unstable-tests:
-    name: "Unstable tests"
+  # we hope we can remove this job because all the tests are stable 100% of the time
+  flappy-tests:
+    name: "Flappy tests"
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        golang: ['1.16.x']
+        golang: ['1.17.x']
     env:
       OS: ubuntu-latest
       GOLANG: ${{ matrix.golang }}
@@ -112,12 +112,12 @@ jobs:
           go mod tidy -v
           git --no-pager diff go.mod go.sum
           git --no-pager diff --quiet go.mod go.sum
-      - name: Run fast unstable tests
+      - name: Run fast flappy tests
         working-directory: go
         env:
           TEST_SPEED: fast
-          TEST_STABILITY: unstable
-        run: make go.unstable-tests
+          TEST_STABILITY: flappy
+        run: make go.flappy-tests
       # FIXME: coverage
 
   go-tests-on-linux:
@@ -187,7 +187,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        golang: ['1.16.x']
+        golang: ['1.17.x']
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.5
@@ -238,7 +238,7 @@ jobs:
     runs-on: macos-latest
     strategy:
       matrix:
-        golang: ['1.16.x']
+        golang: ['1.17.x']
     steps:
       - name: Checkout
         uses: actions/checkout@v2.3.5

--- a/go/Makefile
+++ b/go/Makefile
@@ -104,11 +104,13 @@ go.unittest: pb.generate
 .PHONY: go.unittest
 
 
-go.unstable-tests: pb.generate
-	TEST_STABILITY=unstable go run moul.io/testman test -v -timeout=600s -retry=10 -run ^TestUnstable ./pkg/bertymessenger
-	TEST_STABILITY=unstable go run moul.io/testman test -v -test.v -timeout=600s -retry=10 -run ^TestScenario_ ./pkg/bertyprotocol # FIXME: run on other unstable functions too
+go.flappy-tests: pb.generate
+	TEST_STABILITY=flappy go run moul.io/testman test -v -test.v -timeout=600s -retry=10 -run ^TestFlappy ./pkg/bertymessenger
+	TEST_STABILITY=flappy go run moul.io/testman test -v -test.v -timeout=600s -retry=10 -run ^TestFlappy ./pkg/bertybot
+	TEST_STABILITY=flappy go run moul.io/testman test -v -test.v -timeout=600s -retry=10 -run ^TestFlappy ./pkg/bertyprotocol
+	TEST_STABILITY=flappy go run moul.io/testman test -v -test.v -timeout=600s -retry=10 -run ^TestScenario_ ./pkg/bertyprotocol
 	# FIXME: run on other packages too
-.PHONY: go.unstable-tests
+.PHONY: go.flappy-tests
 
 
 go.broken-tests: pb.generate
@@ -173,14 +175,14 @@ $(gen_sum): $(gen_src)
 	  set -xe; \
 	  $(GO) mod download; \
 	  docker run \
-	    --user="$$uid" \
-	    --volume="`go env GOPATH`/pkg/mod:/go/pkg/mod" \
-	    --volume="$(PWD)/..:/go/src/berty.tech/berty" \
-	    --workdir="/go/src/berty.tech/berty/go" \
-	    --entrypoint="sh" \
-	    --rm \
-	    bertytech/protoc:28 \
-	    -xec 'make generate_local'; \
+		--user="$$uid" \
+		--volume="`go env GOPATH`/pkg/mod:/go/pkg/mod" \
+		--volume="$(PWD)/..:/go/src/berty.tech/berty" \
+		--workdir="/go/src/berty.tech/berty/go" \
+		--entrypoint="sh" \
+		--rm \
+		bertytech/protoc:28 \
+		-xec 'make generate_local'; \
 	  $(MAKE) tidy \
 	)
 .PHONY: pb.generate

--- a/go/gen.sum
+++ b/go/gen.sum
@@ -8,4 +8,4 @@ c314cc3d08e8849bd0693039e42da117c39efef5  ../api/go-internal/handshake.proto
 8bc041c2fb6a37f34dd77d523e69283a8b1b5936  ../api/messengertypes.proto
 42eb4693b303b95a9f309670cbfb51053282634d  ../api/protocoltypes.proto
 a658b3797030d0f3ada12d122f460f87071e9d88  ../api/pushtypes.proto
-d56517eb5ad572dd10b7c57a1bf617567bb10218  Makefile
+d7eb3486ba9cfa4f4958d983db76d8d677ef1c63  Makefile

--- a/go/internal/testutil/skip.go
+++ b/go/internal/testutil/skip.go
@@ -12,7 +12,7 @@ type Stability string
 
 const (
 	Stable       Stability = "stable"
-	Unstable     Stability = "unstable"
+	Flappy       Stability = "flappy"
 	Broken       Stability = "broken"
 	AnyStability Stability = "any"
 )
@@ -55,11 +55,11 @@ func parseEnv() {
 
 	for _, level := range strings.Split(stabFilter, ",") {
 		switch Stability(level) {
-		case Stable, Unstable, Broken:
+		case Stable, Flappy, Broken:
 			enabledStability[Stability(level)] = true
 		case AnyStability:
 			enabledStability[Stable] = true
-			enabledStability[Unstable] = true
+			enabledStability[Flappy] = true
 			enabledStability[Broken] = true
 		default:
 			panic(fmt.Sprintf("invalid stability level: %q", level))

--- a/go/pkg/bertybot/bot_test.go
+++ b/go/pkg/bertybot/bot_test.go
@@ -13,8 +13,8 @@ import (
 	"berty.tech/berty/v2/go/pkg/messengertypes"
 )
 
-func TestUnstableBotCommunication(t *testing.T) {
-	testutil.FilterStability(t, testutil.Unstable)
+func TestFlappyBotCommunication(t *testing.T) {
+	testutil.FilterStability(t, testutil.Flappy)
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 	logger, cleanup := testutil.Logger(t)

--- a/go/pkg/bertymessenger/service_test.go
+++ b/go/pkg/bertymessenger/service_test.go
@@ -91,8 +91,8 @@ func TestServiceSetNameAsync(t *testing.T) {
 	}
 }
 
-func TestUnstableServiceStreamCancel(t *testing.T) {
-	testutil.FilterStability(t, testutil.Unstable)
+func TestFlappyServiceStreamCancel(t *testing.T) {
+	testutil.FilterStability(t, testutil.Flappy)
 
 	ctx, ctxCancel := context.WithTimeout(context.Background(), 5*time.Second)
 	node, cleanup := testingNode(ctx, t)
@@ -1430,8 +1430,8 @@ func TestAccountUpdate(t *testing.T) {
 	logger.Error("test done")
 }
 
-func TestUnstableAccountUpdateGroup(t *testing.T) {
-	testutil.FilterStabilityAndSpeed(t, testutil.Unstable, testutil.Slow)
+func TestFlappyAccountUpdateGroup(t *testing.T) {
+	testutil.FilterStabilityAndSpeed(t, testutil.Flappy, testutil.Slow)
 
 	// PREPARE
 	logger, cleanup := testutil.Logger(t)

--- a/go/pkg/bertyprotocol/account_export_test.go
+++ b/go/pkg/bertyprotocol/account_export_test.go
@@ -118,8 +118,8 @@ func Test_service_exportAccountProofKey(t *testing.T) {
 	require.True(t, accountProofSK.Equals(sk))
 }
 
-func TestUnstableRestoreAccount(t *testing.T) {
-	testutil.FilterStability(t, testutil.Unstable)
+func TestFlappyRestoreAccount(t *testing.T) {
+	testutil.FilterStability(t, testutil.Flappy)
 
 	logger, cleanup := testutil.Logger(t)
 	defer cleanup()

--- a/go/pkg/bertyprotocol/scenario_test.go
+++ b/go/pkg/bertyprotocol/scenario_test.go
@@ -45,15 +45,15 @@ type testFunc func(context.Context, *testing.T, ...*bertyprotocol.TestingProtoco
 
 func TestScenario_CreateMultiMemberGroup(t *testing.T) {
 	cases := []testCase{
-		{"2 clients/connectAll", 2, bertyprotocol.ConnectAll, testutil.Fast, testutil.Unstable, time.Second * 10},
-		{"3 clients/connectAll", 3, bertyprotocol.ConnectAll, testutil.Fast, testutil.Unstable, time.Second * 10},
-		{"3 clients/connectInLine", 3, bertyprotocol.ConnectInLine, testutil.Fast, testutil.Unstable, time.Second * 10},
-		{"5 clients/connectAll", 5, bertyprotocol.ConnectAll, testutil.Slow, testutil.Unstable, time.Second * 20},
-		{"5 clients/connectInLine", 5, bertyprotocol.ConnectInLine, testutil.Slow, testutil.Unstable, time.Second * 20},
-		{"8 clients/connectAll", 8, bertyprotocol.ConnectAll, testutil.Slow, testutil.Unstable, time.Second * 30},
-		{"8 clients/connectInLine", 8, bertyprotocol.ConnectInLine, testutil.Slow, testutil.Unstable, time.Second * 30},
-		{"10 clients/connectAll", 10, bertyprotocol.ConnectAll, testutil.Slow, testutil.Unstable, time.Second * 40},
-		{"10 clients/connectInLine", 10, bertyprotocol.ConnectInLine, testutil.Slow, testutil.Unstable, time.Second * 40},
+		{"2 clients/connectAll", 2, bertyprotocol.ConnectAll, testutil.Fast, testutil.Flappy, time.Second * 10},
+		{"3 clients/connectAll", 3, bertyprotocol.ConnectAll, testutil.Fast, testutil.Flappy, time.Second * 10},
+		{"3 clients/connectInLine", 3, bertyprotocol.ConnectInLine, testutil.Fast, testutil.Flappy, time.Second * 10},
+		{"5 clients/connectAll", 5, bertyprotocol.ConnectAll, testutil.Slow, testutil.Flappy, time.Second * 20},
+		{"5 clients/connectInLine", 5, bertyprotocol.ConnectInLine, testutil.Slow, testutil.Flappy, time.Second * 20},
+		{"8 clients/connectAll", 8, bertyprotocol.ConnectAll, testutil.Slow, testutil.Flappy, time.Second * 30},
+		{"8 clients/connectInLine", 8, bertyprotocol.ConnectInLine, testutil.Slow, testutil.Flappy, time.Second * 30},
+		{"10 clients/connectAll", 10, bertyprotocol.ConnectAll, testutil.Slow, testutil.Flappy, time.Second * 40},
+		{"10 clients/connectInLine", 10, bertyprotocol.ConnectInLine, testutil.Slow, testutil.Flappy, time.Second * 40},
 	}
 
 	testingScenario(t, cases, func(ctx context.Context, t *testing.T, tps ...*bertyprotocol.TestingProtocol) {
@@ -63,15 +63,15 @@ func TestScenario_CreateMultiMemberGroup(t *testing.T) {
 
 func TestScenario_MessageMultiMemberGroup(t *testing.T) {
 	cases := []testCase{
-		{"2 clients/connectAll", 2, bertyprotocol.ConnectAll, testutil.Fast, testutil.Unstable, time.Second * 10},
-		{"3 clients/connectAll", 3, bertyprotocol.ConnectAll, testutil.Fast, testutil.Unstable, time.Second * 10},
-		{"3 clients/connectInLine", 3, bertyprotocol.ConnectInLine, testutil.Fast, testutil.Unstable, time.Second * 10},
-		{"5 clients/connectAll", 5, bertyprotocol.ConnectAll, testutil.Slow, testutil.Unstable, time.Second * 20},
-		{"5 clients/connectInLine", 5, bertyprotocol.ConnectInLine, testutil.Slow, testutil.Unstable, time.Second * 20},
-		{"8 clients/connectAll", 8, bertyprotocol.ConnectAll, testutil.Slow, testutil.Unstable, time.Second * 30},
-		{"8 clients/connectInLine", 8, bertyprotocol.ConnectInLine, testutil.Slow, testutil.Unstable, time.Second * 30},
-		{"10 clients/connectAll", 10, bertyprotocol.ConnectAll, testutil.Slow, testutil.Unstable, time.Second * 40},
-		{"10 clients/connectInLine", 10, bertyprotocol.ConnectInLine, testutil.Slow, testutil.Unstable, time.Second * 40},
+		{"2 clients/connectAll", 2, bertyprotocol.ConnectAll, testutil.Fast, testutil.Flappy, time.Second * 10},
+		{"3 clients/connectAll", 3, bertyprotocol.ConnectAll, testutil.Fast, testutil.Flappy, time.Second * 10},
+		{"3 clients/connectInLine", 3, bertyprotocol.ConnectInLine, testutil.Fast, testutil.Flappy, time.Second * 10},
+		{"5 clients/connectAll", 5, bertyprotocol.ConnectAll, testutil.Slow, testutil.Flappy, time.Second * 20},
+		{"5 clients/connectInLine", 5, bertyprotocol.ConnectInLine, testutil.Slow, testutil.Flappy, time.Second * 20},
+		{"8 clients/connectAll", 8, bertyprotocol.ConnectAll, testutil.Slow, testutil.Flappy, time.Second * 30},
+		{"8 clients/connectInLine", 8, bertyprotocol.ConnectInLine, testutil.Slow, testutil.Flappy, time.Second * 30},
+		{"10 clients/connectAll", 10, bertyprotocol.ConnectAll, testutil.Slow, testutil.Flappy, time.Second * 40},
+		{"10 clients/connectInLine", 10, bertyprotocol.ConnectInLine, testutil.Slow, testutil.Flappy, time.Second * 40},
 	}
 
 	testingScenario(t, cases, func(ctx context.Context, t *testing.T, tps ...*bertyprotocol.TestingProtocol) {
@@ -109,15 +109,15 @@ func TestScenario_MessageSeveralMultiMemberGroups(t *testing.T) {
 	const ngroup = 3
 
 	cases := []testCase{
-		{"2 clients/connectAll", 2, bertyprotocol.ConnectAll, testutil.Fast, testutil.Unstable, time.Second * 10},
-		{"3 clients/connectAll", 3, bertyprotocol.ConnectAll, testutil.Fast, testutil.Unstable, time.Second * 10},
-		{"3 clients/connectInLine", 3, bertyprotocol.ConnectInLine, testutil.Fast, testutil.Unstable, time.Second * 10},
-		{"5 clients/connectAll", 5, bertyprotocol.ConnectAll, testutil.Slow, testutil.Unstable, time.Second * 20},
-		{"5 clients/connectInLine", 5, bertyprotocol.ConnectInLine, testutil.Slow, testutil.Unstable, time.Second * 20},
-		{"8 clients/connectAll", 8, bertyprotocol.ConnectAll, testutil.Slow, testutil.Unstable, time.Second * 30},
-		{"8 clients/connectInLine", 8, bertyprotocol.ConnectInLine, testutil.Slow, testutil.Unstable, time.Second * 30},
-		{"10 clients/connectAll", 10, bertyprotocol.ConnectAll, testutil.Slow, testutil.Unstable, time.Second * 40},
-		{"10 clients/connectInLine", 10, bertyprotocol.ConnectInLine, testutil.Slow, testutil.Unstable, time.Second * 40},
+		{"2 clients/connectAll", 2, bertyprotocol.ConnectAll, testutil.Fast, testutil.Flappy, time.Second * 10},
+		{"3 clients/connectAll", 3, bertyprotocol.ConnectAll, testutil.Fast, testutil.Flappy, time.Second * 10},
+		{"3 clients/connectInLine", 3, bertyprotocol.ConnectInLine, testutil.Fast, testutil.Flappy, time.Second * 10},
+		{"5 clients/connectAll", 5, bertyprotocol.ConnectAll, testutil.Slow, testutil.Flappy, time.Second * 20},
+		{"5 clients/connectInLine", 5, bertyprotocol.ConnectInLine, testutil.Slow, testutil.Flappy, time.Second * 20},
+		{"8 clients/connectAll", 8, bertyprotocol.ConnectAll, testutil.Slow, testutil.Flappy, time.Second * 30},
+		{"8 clients/connectInLine", 8, bertyprotocol.ConnectInLine, testutil.Slow, testutil.Flappy, time.Second * 30},
+		{"10 clients/connectAll", 10, bertyprotocol.ConnectAll, testutil.Slow, testutil.Flappy, time.Second * 40},
+		{"10 clients/connectInLine", 10, bertyprotocol.ConnectInLine, testutil.Slow, testutil.Flappy, time.Second * 40},
 	}
 
 	testingScenario(t, cases, func(ctx context.Context, t *testing.T, tps ...*bertyprotocol.TestingProtocol) {
@@ -135,10 +135,10 @@ func TestScenario_MessageSeveralMultiMemberGroups(t *testing.T) {
 
 func TestScenario_AddContact(t *testing.T) {
 	cases := []testCase{
-		{"2 clients/connectAll", 2, bertyprotocol.ConnectAll, testutil.Fast, testutil.Unstable, time.Second * 20}, // marked as "unstable" because it failed multiple times on the CI recently
-		{"3 clients/connectAll", 3, bertyprotocol.ConnectAll, testutil.Fast, testutil.Unstable, time.Second * 20}, // marked as "unstable" because it failed multiple times on the CI recently
-		{"5 clients/connectAll", 5, bertyprotocol.ConnectAll, testutil.Slow, testutil.Unstable, time.Second * 30}, // marked as "unstable" because it failed multiple times on the CI recently
-		{"8 clients/connectAll", 8, bertyprotocol.ConnectAll, testutil.Slow, testutil.Unstable, time.Second * 40}, // marked as "unstable" because it failed multiple times on the CI recently
+		{"2 clients/connectAll", 2, bertyprotocol.ConnectAll, testutil.Fast, testutil.Flappy, time.Second * 20}, // marked as "flappy" because it failed multiple times on the CI recently
+		{"3 clients/connectAll", 3, bertyprotocol.ConnectAll, testutil.Fast, testutil.Flappy, time.Second * 20}, // marked as "flappy" because it failed multiple times on the CI recently
+		{"5 clients/connectAll", 5, bertyprotocol.ConnectAll, testutil.Slow, testutil.Flappy, time.Second * 30}, // marked as "flappy" because it failed multiple times on the CI recently
+		{"8 clients/connectAll", 8, bertyprotocol.ConnectAll, testutil.Slow, testutil.Flappy, time.Second * 40}, // marked as "flappy" because it failed multiple times on the CI recently
 		{"10 clients/connectAll", 10, bertyprotocol.ConnectAll, testutil.Slow, testutil.Broken, time.Second * 60},
 	}
 
@@ -149,9 +149,9 @@ func TestScenario_AddContact(t *testing.T) {
 
 func TestScenario_MessageContactGroup(t *testing.T) {
 	cases := []testCase{
-		{"2 clients/connectAll", 2, bertyprotocol.ConnectAll, testutil.Fast, testutil.Unstable, time.Second * 20},
-		{"3 clients/connectAll", 3, bertyprotocol.ConnectAll, testutil.Fast, testutil.Unstable, time.Second * 20},
-		{"5 clients/connectAll", 5, bertyprotocol.ConnectAll, testutil.Slow, testutil.Unstable, time.Second * 30},
+		{"2 clients/connectAll", 2, bertyprotocol.ConnectAll, testutil.Fast, testutil.Flappy, time.Second * 20},
+		{"3 clients/connectAll", 3, bertyprotocol.ConnectAll, testutil.Fast, testutil.Flappy, time.Second * 20},
+		{"5 clients/connectAll", 5, bertyprotocol.ConnectAll, testutil.Slow, testutil.Flappy, time.Second * 30},
 		{"8 clients/connectAll", 8, bertyprotocol.ConnectAll, testutil.Slow, testutil.Broken, time.Second * 40},
 		{"10 clients/connectAll", 10, bertyprotocol.ConnectAll, testutil.Slow, testutil.Broken, time.Second * 60},
 	}
@@ -334,13 +334,13 @@ func TestScenario_ReplicateMessage(t *testing.T) {
 	// require.NoError(t, err)
 	//
 	// _, err = nodeA.Service.(*service).accountGroup.MetadataStore.SendAccountServiceTokenAdded(ctx, &protocoltypes.ServiceToken{
-	// 	Token: token,
-	// 	SupportedServices: []*protocoltypes.ServiceTokenSupportedService{
-	// 		{
-	// 			ServiceType:     ServiceReplicationID,
-	// 			ServiceEndpoint: "", // TODO
-	// 		},
-	// 	},
+	//	Token: token,
+	//	SupportedServices: []*protocoltypes.ServiceTokenSupportedService{
+	//		{
+	//			ServiceType:     ServiceReplicationID,
+	//			ServiceEndpoint: "", // TODO
+	//		},
+	//	},
 	// })
 	// require.NoError(t, err)
 

--- a/go/pkg/bertyprotocol/store_message_test.go
+++ b/go/pkg/bertyprotocol/store_message_test.go
@@ -86,7 +86,7 @@ func Test_AddMessage_ListMessages_manually_supplying_secrets(t *testing.T) {
 	out, err = peers[1].GC.MessageStore().ListEvents(ctx, nil, nil, false)
 	require.NoError(t, err)
 
-	testutil.FilterStability(t, testutil.Unstable)
+	testutil.FilterStability(t, testutil.Flappy)
 
 	<-time.After(time.Second)
 

--- a/go/pkg/bertyprotocol/store_metadata_test.go
+++ b/go/pkg/bertyprotocol/store_metadata_test.go
@@ -179,7 +179,9 @@ func ipfsAPIUsingMockNet(ctx context.Context, t *testing.T) (ipfsutil.ExtendedCo
 	return node.API(), cleanupNode
 }
 
-func TestMetadataRendezvousPointLifecycle(t *testing.T) {
+func TestFlappyMetadataRendezvousPointLifecycle(t *testing.T) {
+	testutil.FilterStabilityAndSpeed(t, testutil.Flappy, testutil.Fast)
+
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -684,8 +686,8 @@ func TestMetadataGroupsLifecycle(t *testing.T) {
 	require.Equal(t, groups[0].GroupType, g2.GroupType)
 }
 
-func TestMultiDevices_Basic(t *testing.T) {
-	testutil.FilterStabilityAndSpeed(t, testutil.Unstable, testutil.Slow)
+func TestFlappyMultiDevices_Basic(t *testing.T) {
+	testutil.FilterStabilityAndSpeed(t, testutil.Flappy, testutil.Slow)
 
 	memberCount := 2
 	deviceCount := 3


### PR DESCRIPTION
* Rename Unstable to Flappy
* Bump go version on CI
* Fix various tests with invalid names (should contain Flappy if flappy)
* Set flappy tests as officially flappy in the tests