### PR TITLE
fix: disalbe `embed_swift` for Notification Service

### DIFF
--- a/js/ios/berty.yaml
+++ b/js/ios/berty.yaml
@@ -212,6 +212,7 @@ targets:
       Yolo Release: Configs/Yolo.xcconfig
     settings:
       base:
+        ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES: false
         PRODUCT_NAME: NotificationService
         CODE_SIGN_STYLE: Automatic
         INFOPLIST_FILE: NotificationService/Info.plist


### PR DESCRIPTION
we need to set this to false to avoid a `Validation Error` while submitting
the build to apple