### PR TITLE
feat: update deprecated golangci linters: golint/scopelint 

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -63,7 +63,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2.5.2
         with:
-          version: v1.31
+          version: v1.43
           working-directory: go
           args: --timeout=10m
           # only-new-issues: true

--- a/go/.golangci.yml
+++ b/go/.golangci.yml
@@ -43,7 +43,7 @@ linters:
     - gofmt
     - gofumpt
     - goimports
-    - golint
+    - revive
     #- gomnd         # nice to have
     - gomodguard
     - gosec
@@ -54,7 +54,7 @@ linters:
     - nakedret
     - noctx
     #- nolintlint
-    - scopelint
+    - exportloopref
     - sqlclosecheck
     - staticcheck
     - structcheck

--- a/go/cmd/berty/peers.go
+++ b/go/cmd/berty/peers.go
@@ -14,7 +14,7 @@ import (
 )
 
 func peersCommand() *ffcli.Command {
-	var refreshEveryFlag time.Duration = time.Second
+	refreshEveryFlag := time.Second
 	fsBuilder := func() (*flag.FlagSet, error) {
 		fs := flag.NewFlagSet("peers", flag.ExitOnError)
 		fs.String("config", "", "config file (optional)")

--- a/go/cmd/rdvp/main.go
+++ b/go/cmd/rdvp/main.go
@@ -124,11 +124,11 @@ func main() {
 			// load existing or generate new identity
 			var priv libp2p_ci.PrivKey
 			if servePK != "" {
-				kBytes, err := base64.StdEncoding.DecodeString(servePK)
+				kbytes, err := base64.StdEncoding.DecodeString(servePK)
 				if err != nil {
 					return errcode.TODO.Wrap(err)
 				}
-				priv, err = libp2p_ci.UnmarshalPrivateKey(kBytes)
+				priv, err = libp2p_ci.UnmarshalPrivateKey(kbytes)
 				if err != nil {
 					return errcode.TODO.Wrap(err)
 				}
@@ -243,11 +243,11 @@ func main() {
 				return flag.ErrHelp
 			}
 
-			kBytes, err := base64.StdEncoding.DecodeString(sharekeyPK)
+			kbytes, err := base64.StdEncoding.DecodeString(sharekeyPK)
 			if err != nil {
 				return errcode.TODO.Wrap(err)
 			}
-			priv, err := libp2p_ci.UnmarshalPrivateKey(kBytes)
+			priv, err := libp2p_ci.UnmarshalPrivateKey(kbytes)
 			if err != nil {
 				return errcode.TODO.Wrap(err)
 			}
@@ -278,12 +278,12 @@ func main() {
 				return errcode.TODO.Wrap(err)
 			}
 
-			kBytes, err := libp2p_ci.MarshalPrivateKey(priv)
+			kbytes, err := libp2p_ci.MarshalPrivateKey(priv)
 			if err != nil {
 				return errcode.TODO.Wrap(err)
 			}
 
-			fmt.Println(base64.StdEncoding.EncodeToString(kBytes))
+			fmt.Println(base64.StdEncoding.EncodeToString(kbytes))
 			return nil
 		},
 	}

--- a/go/internal/grpcutil/lazy_client.go
+++ b/go/internal/grpcutil/lazy_client.go
@@ -9,8 +9,8 @@ import (
 )
 
 var (
-	lazyCodec        = NewLazyCodec()
-	streamids uint64 = 0
+	lazyCodec = NewLazyCodec()
+	streamids uint64
 )
 
 type LazyClient struct {

--- a/go/internal/grpcutil/server.go
+++ b/go/internal/grpcutil/server.go
@@ -16,10 +16,10 @@ import (
 const BertyCustomPrefix = 0xbe00
 
 const (
-	P_GRPC           = BertyCustomPrefix + 0x0002 //nolint:golint
-	P_GRPC_WEB       = BertyCustomPrefix + 0x0004 //nolint:golint
-	P_GRPC_WEBSOCKET = BertyCustomPrefix + 0x0008 //nolint:golint
-	P_GRPC_GATEWAY   = BertyCustomPrefix + 0x0016 //nolint:golint
+	P_GRPC           = BertyCustomPrefix + 0x0002 //nolint:revive
+	P_GRPC_WEB       = BertyCustomPrefix + 0x0004 //nolint:revive
+	P_GRPC_WEBSOCKET = BertyCustomPrefix + 0x0008 //nolint:revive
+	P_GRPC_GATEWAY   = BertyCustomPrefix + 0x0016 //nolint:revive
 )
 
 var protos = []ma.Protocol{

--- a/go/internal/initutil/ipfs.go
+++ b/go/internal/initutil/ipfs.go
@@ -167,7 +167,7 @@ func (m *Manager) getLocalIPFS() (ipfsutil.ExtendedCoreAPI, *ipfs_core.IpfsNode,
 		return nil, nil, errcode.ErrIPFSInit.Wrap(err)
 	}
 
-	var dhtmode p2p_dht.ModeOpt = 0
+	var dhtmode p2p_dht.ModeOpt
 	switch m.Node.Protocol.DHT {
 	case FlagValueP2PDHTClient:
 		dhtmode = p2p_dht.ModeClient

--- a/go/internal/omnisearch/config.go
+++ b/go/internal/omnisearch/config.go
@@ -17,8 +17,8 @@ func (c *coordinatorConfig) usingConstructorMake(constructor interface{}, target
 	if typ.Kind() != reflect.Func {
 		return nil, fmt.Errorf("got a %s", typ.Name())
 	}
-	var iTgt int = -1
-	var iError int = -1
+	iTgt := -1
+	iError := -1
 	// Finding the index of the returns we want.
 	{
 		i := typ.NumOut()

--- a/go/pkg/bertymessenger/service.go
+++ b/go/pkg/bertymessenger/service.go
@@ -457,7 +457,7 @@ func (svc *service) subscribeToMessages(tctx context.Context, gpkb []byte) error
 	return nil
 }
 
-var monitorCounter uint64 = 0
+var monitorCounter uint64
 
 func (svc *service) subscribeToGroupMonitor(groupPK []byte) error {
 	cl, err := svc.protocolClient.MonitorGroup(svc.ctx, &protocoltypes.MonitorGroup_Request{

--- a/go/pkg/bertyprotocol/api_event.go
+++ b/go/pkg/bertyprotocol/api_event.go
@@ -36,8 +36,8 @@ func checkParametersConsistency(sinceID, untilID []byte, sinceNow, untilNow, rev
 func (s *service) GroupMetadataList(req *protocoltypes.GroupMetadataList_Request, sub protocoltypes.ProtocolService_GroupMetadataListServer) error {
 	var (
 		newEvents            <-chan events.Event
-		sentEvents                = map[string]bool{}
-		firstReplicatedFound bool = true
+		sentEvents           = map[string]bool{}
+		firstReplicatedFound = true
 	)
 
 	// Get group context / check if the group is opened
@@ -131,8 +131,8 @@ func (s *service) GroupMetadataList(req *protocoltypes.GroupMetadataList_Request
 func (s *service) GroupMessageList(req *protocoltypes.GroupMessageList_Request, sub protocoltypes.ProtocolService_GroupMessageListServer) error {
 	var (
 		newEvents            <-chan events.Event
-		sentEvents                = map[string]bool{}
-		firstReplicatedFound bool = true
+		sentEvents           = map[string]bool{}
+		firstReplicatedFound = true
 	)
 
 	// Get group context / check if the group is opened

--- a/go/pkg/tyber/format.go
+++ b/go/pkg/tyber/format.go
@@ -49,7 +49,7 @@ const (
 	SubscribeType LogType = "subcribe"
 )
 
-var KnownLogTypes []LogType = []LogType{TraceType, StepType, EventType, SubscribeType}
+var KnownLogTypes = []LogType{TraceType, StepType, EventType, SubscribeType}
 
 func (lt LogType) IsKnown() bool {
 	for _, vlt := range KnownLogTypes {


### PR DESCRIPTION
- update deprecated `golint` -> `revive`
- update deprecated `scopelint` -> `exportloopref`