### PR TITLE
fix: cancel reply cross is outside box with long large text

### DIFF
--- a/js/packages/components/chat/footer/ChatTextInput.tsx
+++ b/js/packages/components/chat/footer/ChatTextInput.tsx
@@ -39,7 +39,8 @@ export const ReplyMessageBar: React.FC = () => {
 				{
 					backgroundColor: activeReplyInte?.backgroundColor,
 					paddingVertical: 4,
-					paddingHorizontal: 10,
+					paddingLeft: 10,
+					paddingRight: 18,
 					zIndex: 0,
 					flexDirection: 'row',
 					justifyContent: 'space-between',
@@ -110,7 +111,7 @@ export const ReplyMessageBar: React.FC = () => {
 					height={18}
 					width={18}
 					fill={activeReplyInte?.textColor}
-					style={{ marginTop: 4, transform: [{ rotate: '45deg' }] }}
+					style={{ marginTop: 2, transform: [{ rotate: '45deg' }] }}
 				/>
 			</TouchableOpacity>
 		</View>


### PR DESCRIPTION
Fix https://github.com/orgs/berty/projects/42#card-74695232

![signal-2021-12-13-185016](https://user-images.githubusercontent.com/33428384/145863024-7bcd4c57-6fbe-4c04-9d4c-2a73ac114efc.png)
![signal-2021-12-13-185021](https://user-images.githubusercontent.com/33428384/145863031-9fcd6002-7daa-4f6c-bdca-5a0b50ed43ad.png)

Signed-off-by: clegirar <clemntgirard@gmail.com>

<!-- Thank you for your contribution! ❤️ -->