### PR TITLE
fix: crash when iOS BLE driver stops

### DIFF
--- a/go/internal/ble-driver/BertyDevice_darwin.m
+++ b/go/internal/ble-driver/BertyDevice_darwin.m
@@ -52,7 +52,7 @@ CBService *getService(NSArray *services, NSString *uuid) {
             _serverSideIdentifier = [identifier retain];
         }
         
-        _logger = logger;
+        _logger = [logger retain];
         _peripheral = nil;
         _manager = manager;
         _remotePeerID = nil;

--- a/go/internal/ble-driver/BleInterface_darwin.m
+++ b/go/internal/ble-driver/BleInterface_darwin.m
@@ -39,6 +39,7 @@ void releaseManager(void) {
         if(manager) {
             NSLog(@"releaseManager");
             [manager release];
+            manager = nil;
         }
     }
 }

--- a/go/internal/ble-driver/BleManager_darwin.m
+++ b/go/internal/ble-driver/BleManager_darwin.m
@@ -150,16 +150,15 @@ static inline char itoh(int i) {
 }
 
 - (void)addService {
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        [self.logger d:@"addService: service=%@", [self.serviceUUID UUIDString]];
+    [self.logger d:@"addService: service=%@", [self.serviceUUID UUIDString]];
 
-        [self.bleOn await];
-        if (self.cmEnable && self.pmEnable) {
-            [self.pManager addService:self.bertyService];
-            [self.serviceAdded await];
-        }
-    });
+    [self.bleOn await:5 withCancelBlock:^{
+        [self.logger e:@"addService error: timeout"];
+    }];
+    if (self.cmEnable && self.pmEnable) {
+        [self.pManager addService:self.bertyService];
+        [self.serviceAdded await];
+    }
 }
 
 - (void)peripheralManager:(CBPeripheralManager *)peripheral didAddService:(CBService *)service error:(nullable NSError *)error {
@@ -190,6 +189,8 @@ static inline char itoh(int i) {
             }  else {
                 [self.logger e:@"startScanning error: localPID is null"];
             }
+        } else {
+            [self.logger i:@"startScanning: scanner is already enabled"];
         }
     }
 }

--- a/go/internal/ble-driver/BleQueue.m
+++ b/go/internal/ble-driver/BleQueue.m
@@ -17,7 +17,7 @@
     if (self) {
         _tasks = [[NSMutableArray alloc] init];
         _queue = [queue retain];
-        _logger = logger;
+        _logger = [logger retain];
     }
     
     return self;

--- a/go/internal/ble-driver/CountDownLatch_darwin.h
+++ b/go/internal/ble-driver/CountDownLatch_darwin.h
@@ -16,11 +16,13 @@
 @property (nonatomic, assign, readwrite) NSInteger count;
 @property (atomic, strong, readwrite) dispatch_semaphore_t semaphore;
 @property (nonatomic, strong) dispatch_queue_t dispatch_queue;
+@property (readwrite) BOOL timeout;
 
 - (instancetype)initCount:(NSInteger)count;
 - (void)incrementCount;
 - (void)countDown;
 - (void)await;
+- (void)await:(NSUInteger)timeout withCancelBlock:(void (^)(void))callback;
 
 @end
 

--- a/go/internal/ble-driver/CountDownLatch_darwin.m
+++ b/go/internal/ble-driver/CountDownLatch_darwin.m
@@ -54,4 +54,17 @@
     dispatch_semaphore_wait(self.semaphore, DISPATCH_TIME_FOREVER);
 }
 
+- (void)await:(NSUInteger)timeout withCancelBlock:(void (^)(void))callback {
+    self.timeout = TRUE;
+    dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(timeout * NSEC_PER_SEC));
+    dispatch_after(popTime, self.dispatch_queue, ^(void){
+        if (self.timeout) {
+            callback();
+            dispatch_semaphore_signal(self.semaphore);
+        }
+    });
+    dispatch_semaphore_wait(self.semaphore, DISPATCH_TIME_FOREVER);
+    self.timeout = FALSE;
+}
+
 @end

--- a/go/internal/ble-driver/PeerManager.m
+++ b/go/internal/ble-driver/PeerManager.m
@@ -15,7 +15,7 @@
     self = [super init];
     
     if (self) {
-        _logger = logger;
+        _logger = [logger retain];
         _connectedPeers = [[NSMutableDictionary alloc] init];
     }
     


### PR DESCRIPTION
Signed-off-by: D4ryl00 <d4ryl00@gmail.com>

Fix a crash when the iOS BLE driver is stopping.
Fix a stuck when the iOS BLE driver starts on simulators.