### PR TITLE
feat: move uiReducer to redux

### DIFF
--- a/js/ios/Podfile.lock
+++ b/js/ios/Podfile.lock
@@ -658,7 +658,7 @@ SPEC CHECKSUMS:
   CocoaAsyncSocket: 065fd1e645c7abab64f7a6a2007a48038fdc6a99
   DoubleConversion: cf9b38bf0b2d048436d9a82ad2abe1404f11e7de
   FBLazyVector: e686045572151edef46010a6f819ade377dfeb4b
-  FBReactNativeSpec: 98f63b5449aa8f7d75b7329a4ddb985945705d92
+  FBReactNativeSpec: 5a5d71317d9e3201eae1844d59b74729dbd8b22f
   Flipper: 1bd2db48dcc31e4b167b9a33ec1df01c2ded4893
   Flipper-DoubleConversion: 38631e41ef4f9b12861c67d17cb5518d06badc41
   Flipper-Folly: 755929a4f851b2fb2c347d533a23f191b008554c

--- a/js/packages/components/AttachmentImage.tsx
+++ b/js/packages/components/AttachmentImage.tsx
@@ -1,16 +1,17 @@
 import React, { useState, useEffect } from 'react'
 import { Image, ImageProps, ActivityIndicator, View, TouchableOpacity } from 'react-native'
 
-import { useMessengerContext } from '@berty-tech/store'
 import { useNavigation } from '@berty-tech/navigation'
 import { useMedia } from '@berty-tech/react-redux'
 
 import { getSource } from './utils'
+import { useSelector } from 'react-redux'
+import { selectProtocolClient } from '@berty-tech/redux/reducers/ui.reducer'
 
 const AttachmentImage: React.FC<{ cid: string; pressable?: boolean } & Omit<ImageProps, 'source'>> =
 	React.memo(props => {
 		const { navigate } = useNavigation()
-		const { protocolClient } = useMessengerContext()
+		const protocolClient = useSelector(selectProtocolClient)
 		const [source, setSource] = useState('')
 		const { cid, ...imageProps } = props
 		const media = useMedia(cid)

--- a/js/packages/components/chat/DeviceList.tsx
+++ b/js/packages/components/chat/DeviceList.tsx
@@ -7,8 +7,9 @@ import { useStyles } from '@berty-tech/styles'
 import {
 	getDevicesForConversationAndMember,
 	getSharedPushTokensForConversation,
-	useMessengerContext,
 } from '@berty-tech/store'
+import { useSelector } from 'react-redux'
+import { selectClient } from '@berty-tech/redux/reducers/ui.reducer'
 
 const UserDevicesList: React.FC<{ memberPk: string; conversationPk: string }> = ({
 	memberPk,
@@ -17,27 +18,25 @@ const UserDevicesList: React.FC<{ memberPk: string; conversationPk: string }> = 
 	const cutoff = 16
 	const [{ padding }] = useStyles()
 	const { t } = useTranslation()
-	const ctx = useMessengerContext()
 	const [tokens, setTokens] = useState<berty.messenger.v1.ISharedPushToken[]>([])
 	const [devices, setDevices] = useState<berty.messenger.v1.IDevice[]>([])
+	const client = useSelector(selectClient)
 
 	useEffect(() => {
-		if (!ctx.client) {
+		if (!client) {
 			return
 		}
 
-		getSharedPushTokensForConversation(ctx.client, conversationPk)
-			.then(setTokens)
-			.catch(console.warn)
-	}, [conversationPk, ctx.client, setTokens])
+		getSharedPushTokensForConversation(client, conversationPk).then(setTokens).catch(console.warn)
+	}, [conversationPk, client, setTokens])
 
 	useEffect(() => {
-		if (!ctx.client) {
+		if (!client) {
 			return
 		}
 
-		getDevicesForConversationAndMember(ctx.client, conversationPk, memberPk).then(setDevices)
-	}, [conversationPk, ctx.client, memberPk, setDevices])
+		getDevicesForConversationAndMember(client, conversationPk, memberPk).then(setDevices)
+	}, [conversationPk, client, memberPk, setDevices])
 
 	const tokensMap = Object.fromEntries(tokens.map(t => [t.devicePublicKey, t.token]))
 

--- a/js/packages/components/chat/MultiMember.tsx
+++ b/js/packages/components/chat/MultiMember.tsx
@@ -24,6 +24,7 @@ import {
 	useMessengerContext,
 	useThemeColor,
 	pbDateToNum,
+	useMessengerClient,
 } from '@berty-tech/store'
 import beapi from '@berty-tech/api'
 import { IOSOnlyKeyboardAvoidingView } from '@berty-tech/rnutil/keyboardAvoiding'
@@ -60,13 +61,14 @@ export const MultiMember: ScreenFC<'Chat.Group'> = ({ route: { params }, navigat
 	const { t } = useTranslation()
 	const ctx = useMessengerContext()
 	const insets = useSafeAreaInsets()
+	const client = useMessengerClient()
 
 	const [editValue, setEditValue] = useState(conv?.displayName || '')
 	const [isEdit, setIsEdit] = useState(false)
 	const [keyboardIsHidden, setKeyboardIsHidden] = useState(false)
 	const editDisplayName = async () => {
 		const buf = beapi.messenger.AppMessage.SetGroupInfo.encode({ displayName: editValue }).finish()
-		await ctx.client?.interact({
+		await client?.interact({
 			conversationPublicKey: conv?.publicKey,
 			type: beapi.messenger.AppMessage.Type.TypeSetGroupInfo,
 			payload: buf,
@@ -245,7 +247,7 @@ export const MultiMember: ScreenFC<'Chat.Group'> = ({ route: { params }, navigat
 									<EmojiBoard
 										showBoard={true}
 										onClick={(emoji: any) => {
-											ctx.client
+											client
 												?.interact({
 													conversationPublicKey: conv?.publicKey,
 													type: beapi.messenger.AppMessage.Type.TypeUserReaction,
@@ -260,7 +262,7 @@ export const MultiMember: ScreenFC<'Chat.Group'> = ({ route: { params }, navigat
 													setActivePopoverCid(null)
 													setActiveEmojiKeyboardCid(null)
 												})
-												.catch(e => {
+												.catch((e: unknown) => {
 													console.warn('e sending message:', e)
 												})
 										}}

--- a/js/packages/components/chat/MultiMemberSettings.tsx
+++ b/js/packages/components/chat/MultiMemberSettings.tsx
@@ -8,7 +8,7 @@ import QRCode from 'react-native-qrcode-svg'
 import beapi from '@berty-tech/api'
 import { useStyles } from '@berty-tech/styles'
 import { ScreenFC, useNavigation } from '@berty-tech/navigation'
-import { Maybe, useMessengerContext, useThemeColor } from '@berty-tech/store'
+import { Maybe, useMessengerClient, useThemeColor } from '@berty-tech/store'
 import { useConversationMembersDict, useConversation } from '@berty-tech/react-redux'
 
 import { ButtonSetting, FactionButtonSetting } from '../shared-components/SettingsButtons'
@@ -18,18 +18,18 @@ import EnableNotificationsButton from '@berty-tech/components/chat/EnableNotific
 
 const GroupChatSettingsHeader: React.FC<{ publicKey: Maybe<string> }> = ({ publicKey }) => {
 	const conv = useConversation(publicKey)
-	const ctx = useMessengerContext()
 	const [picture, setPicture] = useState<ImageOrVideo | undefined>(undefined)
 	const [{ text, padding, border, row }, { scaleSize, scaleHeight, windowWidth, windowHeight }] =
 		useStyles()
 	const colors = useThemeColor()
 	const qrCodeSize = Math.min(windowHeight, windowWidth) * 0.4
 	const { navigate } = useNavigation()
+	const client = useMessengerClient()
 
 	const handleSave = React.useCallback(async () => {
 		try {
 			if (picture) {
-				const stream = await ctx.client?.mediaPrepare({})
+				const stream = await client?.mediaPrepare({})
 				if (!stream) {
 					throw new Error('failed to open prepareAttachment stream')
 				}
@@ -52,7 +52,7 @@ const GroupChatSettingsHeader: React.FC<{ publicKey: Maybe<string> }> = ({ publi
 				const buf = beapi.messenger.AppMessage.SetGroupInfo.encode({
 					avatarCid: reply.cid,
 				}).finish()
-				await ctx.client?.interact({
+				await client?.interact({
 					conversationPublicKey: conv?.publicKey,
 					type: beapi.messenger.AppMessage.Type.TypeSetGroupInfo,
 					payload: buf,
@@ -63,7 +63,7 @@ const GroupChatSettingsHeader: React.FC<{ publicKey: Maybe<string> }> = ({ publi
 		} catch (err) {
 			console.warn(err)
 		}
-	}, [conv?.publicKey, ctx.client, picture])
+	}, [conv?.publicKey, client, picture])
 
 	React.useEffect(() => {
 		if (picture !== undefined) {

--- a/js/packages/components/chat/OneToOne.tsx
+++ b/js/packages/components/chat/OneToOne.tsx
@@ -16,6 +16,7 @@ import {
 	useNotificationsInhibitor,
 	useThemeColor,
 	pbDateToNum,
+	useMessengerClient,
 } from '@berty-tech/store'
 import { CustomTitleStyle } from '@berty-tech/navigation/stacks'
 import { IOSOnlyKeyboardAvoidingView } from '@berty-tech/rnutil/keyboardAvoiding'
@@ -55,6 +56,7 @@ export const OneToOne: ScreenFC<'Chat.OneToOne'> = React.memo(
 		const conv = useConversation(params?.convId)
 		const contact = useContact(conv?.contactPublicKey)
 		const ctx = useMessengerContext()
+		const client = useMessengerClient()
 		const { navigate } = navigation
 
 		const isIncoming = contact?.state === beapi.messenger.Contact.State.IncomingRequest
@@ -152,7 +154,7 @@ export const OneToOne: ScreenFC<'Chat.OneToOne'> = React.memo(
 										<EmojiBoard
 											showBoard={true}
 											onClick={(emoji: { name: string }) => {
-												ctx.client
+												client
 													?.interact({
 														conversationPublicKey: conv?.publicKey,
 														type: beapi.messenger.AppMessage.Type.TypeUserReaction,
@@ -167,7 +169,7 @@ export const OneToOne: ScreenFC<'Chat.OneToOne'> = React.memo(
 														setActivePopoverCid(null)
 														setActiveEmojiKeyboardCid(null)
 													})
-													.catch(e => {
+													.catch((e: unknown) => {
 														console.warn('e sending message:', e)
 													})
 											}}

--- a/js/packages/components/chat/ReplicateGroupSettings.tsx
+++ b/js/packages/components/chat/ReplicateGroupSettings.tsx
@@ -6,18 +6,20 @@ import { Layout } from '@ui-kitten/components'
 import { useStyles } from '@berty-tech/styles'
 import { ScreenFC } from '@berty-tech/navigation'
 import {
-	useMessengerContext,
 	Maybe,
 	useThemeColor,
 	servicesAuthViaDefault,
 	useAccountServices,
 	serviceTypes,
 	replicateGroup,
+	useMessengerClient,
 } from '@berty-tech/store'
 import beapi from '@berty-tech/api'
 import { useConversation } from '@berty-tech/react-redux'
 
 import { ButtonSetting, FactionButtonSetting } from '../shared-components'
+import { useSelector } from 'react-redux'
+import { selectProtocolClient } from '@berty-tech/redux/reducers/ui.reducer'
 
 enum replicationServerStatus {
 	KnownServerEnabled,
@@ -96,12 +98,13 @@ const ReplicateGroupContent: React.FC<{
 	conversationPublicKey?: Maybe<string>
 	navigation: ComponentProps<typeof ReplicateGroupSettings>['navigation']
 }> = ({ conversationPublicKey, navigation }) => {
-	const ctx = useMessengerContext()
+	const client = useMessengerClient()
 	const conversation = useConversation(conversationPublicKey)
 	const services = useAccountServices()
 	const [{ margin, flex, padding }] = useStyles()
 	const colors = useThemeColor()
 	const { t } = useTranslation()
+	const protocolClient = useSelector(selectProtocolClient)
 
 	const replicationStatus = getAllReplicationStatusForConversation(conversation, services)
 
@@ -121,7 +124,7 @@ const ReplicateGroupContent: React.FC<{
 									return
 								}
 
-								return replicateGroup(ctx, conversationPublicKey || '', t.service.tokenId || '')
+								return replicateGroup(conversationPublicKey || '', t.service.tokenId || '', client)
 							}}
 						/>
 					))}
@@ -141,7 +144,7 @@ const ReplicateGroupContent: React.FC<{
 				iconColor={colors['background-header']}
 				alone={true}
 				onPress={async () => {
-					await servicesAuthViaDefault(ctx)
+					await servicesAuthViaDefault(protocolClient)
 				}}
 			/>
 			<ButtonSetting

--- a/js/packages/components/chat/SharedMedias.tsx
+++ b/js/packages/components/chat/SharedMedias.tsx
@@ -22,7 +22,6 @@ import beapi from '@berty-tech/api'
 import { useStyles } from '@berty-tech/styles'
 import { ScreenFC } from '@berty-tech/navigation'
 import {
-	useMessengerContext,
 	useMessengerClient,
 	useThemeColor,
 	pbDateToNum,
@@ -34,6 +33,8 @@ import { useConversationInteractions } from '@berty-tech/react-redux'
 import { getSource } from '../utils'
 import { timeFormat } from '../helpers'
 import { isBertyDeepLink } from '../chat/message/UserMessageComponents'
+import { useSelector } from 'react-redux'
+import { selectProtocolClient } from '@berty-tech/redux/reducers/ui.reducer'
 
 const initialLayout = { width: Dimensions.get('window').width }
 const linkify = LinkifyIt().tlds(tlds, true)
@@ -60,7 +61,7 @@ export const SharedMedias: ScreenFC<'Chat.SharedMedias'> = ({
 	const colors = useThemeColor()
 	const { t }: { t: any } = useTranslation()
 	const [activeIndex, setActiveIndex] = useState(0)
-	const { protocolClient } = useMessengerContext()
+	const protocolClient = useSelector(selectProtocolClient)
 	const [images, setImages] = useState<any[]>([])
 	const client = useMessengerClient()
 

--- a/js/packages/components/chat/footer/record/RecordComponent.tsx
+++ b/js/packages/components/chat/footer/record/RecordComponent.tsx
@@ -17,7 +17,7 @@ import { WelshMessengerServiceClient } from '@berty-tech/grpc-bridge/welsh-clien
 import { useStyles } from '@berty-tech/styles'
 import beapi from '@berty-tech/api'
 import { playSound } from '@berty-tech/store/sounds'
-import { useMessengerContext, useThemeColor } from '@berty-tech/store'
+import { useMessengerClient, useThemeColor } from '@berty-tech/store'
 import rnutil from '@berty-tech/rnutil'
 import { AppDispatch } from '@berty-tech/redux/store'
 import { useAppDispatch } from '@berty-tech/react-redux'
@@ -153,7 +153,6 @@ export const RecordComponent: React.FC<{
 	setSending,
 }) => {
 	const dispatch = useAppDispatch()
-	const ctx = useMessengerContext()
 	const recorder = React.useRef<Recorder | undefined>(undefined)
 	const [recorderFilePath, setRecorderFilePath] = useState('')
 	const { t } = useTranslation()
@@ -185,6 +184,7 @@ export const RecordComponent: React.FC<{
 	const recordingColorVal = React.useRef(new Animated.Value(0)).current
 	const meteredValuesRef = useRef<number[]>([])
 	const [recordDuration, setRecordDuration] = useState<number | null>(null)
+	const client = useMessengerClient()
 
 	const isRecording =
 		recordingState === RecordingState.RECORDING ||
@@ -258,12 +258,12 @@ export const RecordComponent: React.FC<{
 				}
 				setSending(true)
 				Vibration.vibrate(400)
-				if (!ctx.client) {
+				if (!client) {
 					return
 				}
 				const startDate = new Date(start)
 				const displayName = audioMessageDisplayName(startDate)
-				const medias = await attachMedias(ctx.client, [
+				const medias = await attachMedias(client, [
 					{
 						displayName,
 						filename: displayName + '.aac',
@@ -291,13 +291,13 @@ export const RecordComponent: React.FC<{
 					},
 				])
 
-				await sendMessage(ctx.client!, convPk, dispatch, { medias })
+				await sendMessage(client!, convPk, dispatch, { medias })
 			} catch (e) {
 				console.warn(e)
 			}
 			setSending(false)
 		},
-		[convPk, ctx.client, recorderFilePath, dispatch, sending, setSending],
+		[convPk, client, recorderFilePath, dispatch, sending, setSending],
 	)
 
 	useEffect(() => {
@@ -351,7 +351,7 @@ export const RecordComponent: React.FC<{
 		clearRecording,
 		minAudioDuration,
 		setHelpMessageValue,
-		ctx.client,
+		client,
 		recorderFilePath,
 		convPk,
 		t,

--- a/js/packages/components/chat/message/AudioMessage.tsx
+++ b/js/packages/components/chat/message/AudioMessage.tsx
@@ -6,9 +6,10 @@ import { useThemeColor } from '@berty-tech/store/hooks'
 import { useStyles } from '@berty-tech/styles'
 import { useMusicPlayer } from '@berty-tech/components/music-player'
 import beapi from '@berty-tech/api'
-import { useMessengerContext } from '@berty-tech/store'
 
 import { normalizeVolumeIntensities, WaveForm } from '../audioMessageCommon'
+import { useSelector } from 'react-redux'
+import { selectProtocolClient } from '@berty-tech/redux/reducers/ui.reducer'
 
 const AudioPreview: React.FC<{
 	media: beapi.messenger.IMedia
@@ -64,7 +65,7 @@ export const AudioMessage: React.FC<{
 	isMine: boolean
 }> = ({ medias, onLongPress, isHighlight, isMine }) => {
 	const colors = useThemeColor()
-	const { protocolClient } = useMessengerContext()
+	const protocolClient = useSelector(selectProtocolClient)
 	const [{ padding, border, margin }, { windowWidth, scaleSize }] = useStyles()
 	const {
 		player: globalPlayer,

--- a/js/packages/components/chat/message/FileMessage.tsx
+++ b/js/packages/components/chat/message/FileMessage.tsx
@@ -2,10 +2,12 @@ import React, { useEffect, useState } from 'react'
 import { TouchableOpacity } from 'react-native'
 import { Text, Icon } from '@ui-kitten/components'
 
-import { useMessengerContext, useThemeColor } from '@berty-tech/store'
+import { useThemeColor } from '@berty-tech/store'
 import { useStyles } from '@berty-tech/styles'
 
 import { getSource } from '../../utils'
+import { useSelector } from 'react-redux'
+import { selectProtocolClient } from '@berty-tech/redux/reducers/ui.reducer'
 
 export const FileMessage: React.FC<{
 	medias: any
@@ -13,7 +15,8 @@ export const FileMessage: React.FC<{
 	isHighlight: boolean
 }> = ({ medias, onLongPress, isHighlight }) => {
 	const colors = useThemeColor()
-	const { protocolClient } = useMessengerContext()
+	const protocolClient = useSelector(selectProtocolClient)
+
 	const [, setSource] = useState('')
 	const [isLoading, setLoading] = useState(false)
 	const [isDownloaded] = useState(false)

--- a/js/packages/components/chat/message/PictureMessage.tsx
+++ b/js/packages/components/chat/message/PictureMessage.tsx
@@ -1,12 +1,14 @@
 import React, { useState, useEffect } from 'react'
 import { View, TouchableOpacity, Image, ActivityIndicator } from 'react-native'
 
-import { useMessengerContext, useThemeColor } from '@berty-tech/store'
+import { useThemeColor } from '@berty-tech/store'
 import { useStyles } from '@berty-tech/styles'
 import { useNavigation } from '@berty-tech/navigation'
 
 import { getSource } from '../../utils'
 import { ImageCounter } from '../ImageCounter'
+import { useSelector } from 'react-redux'
+import { selectProtocolClient } from '@berty-tech/redux/reducers/ui.reducer'
 
 export const PictureMessage: React.FC<{
 	medias: any
@@ -15,7 +17,7 @@ export const PictureMessage: React.FC<{
 }> = ({ medias, onLongPress, isHighlight }) => {
 	const [{ border }] = useStyles()
 	const colors = useThemeColor()
-	const { protocolClient } = useMessengerContext()
+	const protocolClient = useSelector(selectProtocolClient)
 	const [images, setImages] = useState<any[]>([])
 	const navigation = useNavigation()
 	useEffect(() => {

--- a/js/packages/components/chat/message/QuickReplyOptions.tsx
+++ b/js/packages/components/chat/message/QuickReplyOptions.tsx
@@ -5,14 +5,14 @@ import Long from 'long'
 
 import beapi from '@berty-tech/api'
 import { useStyles } from '@berty-tech/styles'
-import { useThemeColor, useMessengerContext } from '@berty-tech/store'
+import { useThemeColor, useMessengerClient } from '@berty-tech/store'
 import { useAppDispatch } from '@berty-tech/react-redux'
 
 const QuickReplyOption: React.FC<{
 	convPk: string
 	option: beapi.messenger.IReplyOption
 }> = ({ convPk, option }) => {
-	const ctx = useMessengerContext()
+	const client = useMessengerClient()
 	const colors = useThemeColor()
 	const [{ padding, border, margin }] = useStyles()
 	const dispatch = useAppDispatch()
@@ -21,12 +21,12 @@ const QuickReplyOption: React.FC<{
 		<TouchableOpacity
 			onPress={async () => {
 				try {
-					if (!ctx.client) {
+					if (!client) {
 						return
 					}
 					const usermsg: beapi.messenger.AppMessage.IUserMessage = { body: option.payload }
 					const buf = beapi.messenger.AppMessage.UserMessage.encode(usermsg).finish()
-					const reply = await ctx.client.interact({
+					const reply = await client.interact({
 						conversationPublicKey: convPk,
 						type: beapi.messenger.AppMessage.Type.TypeUserMessage,
 						payload: buf,

--- a/js/packages/components/chat/message/UserMessage.tsx
+++ b/js/packages/components/chat/message/UserMessage.tsx
@@ -14,6 +14,7 @@ import {
 	InteractionUserMessage,
 	ParsedInteraction,
 	pbDateToNum,
+	useMessengerClient,
 } from '@berty-tech/store'
 import { useStyles } from '@berty-tech/styles'
 import {
@@ -179,6 +180,7 @@ export const UserMessage: React.FC<{
 	const repliedTo = useInteractionAuthor(replyOf?.conversationPublicKey || '', replyOf?.cid || '')
 	const _styles = useStylesMessage()
 	const ctx = useMessengerContext()
+	const client = useMessengerClient()
 	const [{ row, margin, padding, column, text, border }, { scaleSize }] = useStyles()
 	const colors = useThemeColor()
 	const { t } = useTranslation()
@@ -528,7 +530,7 @@ export const UserMessage: React.FC<{
 											setActiveEmojiKeyboardCid(inte.cid)
 										}}
 										onSelectEmoji={emoji => {
-											ctx.client
+											client
 												?.interact({
 													conversationPublicKey: convPK,
 													type: beapi.messenger.AppMessage.Type.TypeUserReaction,
@@ -543,7 +545,7 @@ export const UserMessage: React.FC<{
 													setActivePopoverCid(null)
 													setActiveEmojiKeyboardCid(null)
 												})
-												.catch(e => {
+												.catch((e: unknown) => {
 													console.warn('e sending message:', e)
 												})
 										}}

--- a/js/packages/components/error.tsx
+++ b/js/packages/components/error.tsx
@@ -9,6 +9,8 @@ import { useStyles } from '@berty-tech/styles'
 import { useThemeColor, useMessengerContext } from '@berty-tech/store'
 
 import AppInspector from './debug/AppInspector'
+import { useSelector } from 'react-redux'
+import { selectEmbedded } from '@berty-tech/redux/reducers/ui.reducer'
 
 const Label: React.FC<{ title: string; type: 'error' }> = ({ title, type }) => {
 	const [{ padding, border }] = useStyles()
@@ -268,7 +270,8 @@ export const ErrorScreen: React.FC = ({ children }) => {
 
 	const [error, setError] = React.useState<Error | null>(null)
 
-	const { debugMode, embedded } = useMessengerContext()
+	const { debugMode } = useMessengerContext()
+	const embedded = useSelector(selectEmbedded)
 
 	const errorHandler = (err: Error) => {
 		setError(err)

--- a/js/packages/components/main/Permissions.tsx
+++ b/js/packages/components/main/Permissions.tsx
@@ -25,6 +25,8 @@ import p2pLottie from '@berty-tech/assets/p2p-lottie.json'
 import beapi from '@berty-tech/api'
 import { ScreenFC } from '@berty-tech/navigation'
 import rnutil from '@berty-tech/rnutil'
+import { useSelector } from 'react-redux'
+import { selectSelectedAccount } from '@berty-tech/redux/reducers/ui.reducer'
 
 const animations = {
 	audio: audioLottie,
@@ -38,7 +40,8 @@ export const Permissions: ScreenFC<'Main.Permissions'> = ({ route: { params }, n
 	const [{ text, border }] = useStyles()
 	const colors = useThemeColor()
 	const { t }: { t: any } = useTranslation()
-	const { persistentOptions, setPersistentOption, selectedAccount } = useMessengerContext()
+	const { persistentOptions, setPersistentOption } = useMessengerContext()
+	const selectedAccount = useSelector(selectSelectedAccount)
 	const { permissionType, permissionStatus, navigateNext, onComplete } = params
 
 	const handleOnComplete = useCallback(

--- a/js/packages/components/main/home/Home.tsx
+++ b/js/packages/components/main/home/Home.tsx
@@ -32,6 +32,8 @@ import { Conversations } from './Conversations'
 import { SearchComponent } from './Search'
 import { HomeHeader } from './Header'
 import { MultiAccount } from './MultiAccount'
+import { useSelector } from 'react-redux'
+import { selectClient } from '@berty-tech/redux/reducers/ui.reducer'
 
 const T = beapi.messenger.StreamEvent.Notified.Type
 
@@ -102,7 +104,7 @@ export const Home: ScreenFC<'Main.Home'> = ({ navigation: { navigate } }) => {
 
 	const [isLongPress, setIsLongPress] = useState<boolean>(false)
 
-	const { client } = useMessengerContext()
+	const client = useSelector(selectClient)
 
 	const [{ text, opacity, flex, margin }, { scaleSize, scaleHeight, windowHeight }] = useStyles()
 	const colors = useThemeColor()

--- a/js/packages/components/main/home/MultiAccount.tsx
+++ b/js/packages/components/main/home/MultiAccount.tsx
@@ -5,7 +5,6 @@ import { useTranslation } from 'react-i18next'
 
 import { useStyles } from '@berty-tech/styles'
 import {
-	MessengerActions,
 	useMessengerContext,
 	closeAccountWithProgress,
 	useThemeColor,
@@ -17,6 +16,11 @@ import { useAppDispatch } from '@berty-tech/react-redux'
 import beapi from '@berty-tech/api'
 
 import { GenericAvatar } from '../../avatars'
+import {
+	selectSelectedAccount,
+	setStateOnBoardingReady,
+} from '@berty-tech/redux/reducers/ui.reducer'
+import { useSelector } from 'react-redux'
 
 const AccountButton: React.FC<{
 	name: string | null | undefined
@@ -82,6 +86,7 @@ export const MultiAccount: React.FC<{ onPress: () => void }> = ({ onPress }) => 
 	const { dispatch } = useMessengerContext()
 	const { t } = useTranslation()
 	const reduxDispatch = useAppDispatch()
+	const selectedAccount = useSelector(selectSelectedAccount)
 
 	const [isHandlingPress, setIsHandlingPress] = React.useState(false)
 	const handlePress = async (account: beapi.account.IAccountMetadata) => {
@@ -89,9 +94,9 @@ export const MultiAccount: React.FC<{ onPress: () => void }> = ({ onPress }) => 
 			return
 		}
 		setIsHandlingPress(true)
-		if (ctx.selectedAccount !== account.accountId) {
+		if (selectedAccount !== account.accountId) {
 			return ctx.switchAccount(account.accountId || '')
-		} else if (ctx.selectedAccount === account.accountId && !account.error) {
+		} else if (selectedAccount === account.accountId && !account.error) {
 			return onPress()
 		}
 	}
@@ -129,7 +134,7 @@ export const MultiAccount: React.FC<{ onPress: () => void }> = ({ onPress }) => 
 										nameSeed={account?.name}
 									/>
 								}
-								selected={ctx.selectedAccount === account.accountId}
+								selected={selectedAccount === account.accountId}
 								incompatible={account?.error}
 							/>
 						)
@@ -138,7 +143,7 @@ export const MultiAccount: React.FC<{ onPress: () => void }> = ({ onPress }) => 
 					name={t('main.home.multi-account.create-button')}
 					onPress={async () => {
 						await closeAccountWithProgress(dispatch, reduxDispatch)
-						await dispatch({ type: MessengerActions.SetStateOnBoardingReady })
+						await reduxDispatch(setStateOnBoardingReady())
 					}}
 					avatar={
 						<View

--- a/js/packages/components/modals/EditProfile.tsx
+++ b/js/packages/components/modals/EditProfile.tsx
@@ -13,13 +13,15 @@ import { useTranslation } from 'react-i18next'
 import ImagePicker, { ImageOrVideo } from 'react-native-image-crop-picker'
 
 import { defaultStylesDeclaration, useStyles } from '@berty-tech/styles'
-import { useMessengerContext, useThemeColor } from '@berty-tech/store'
+import { useMessengerClient, useMessengerContext, useThemeColor } from '@berty-tech/store'
 import { setChecklistItemDone } from '@berty-tech/redux/reducers/checklist.reducer'
 import { useAppDispatch, useAccount } from '@berty-tech/react-redux'
 import { ScreenFC, useNavigation } from '@berty-tech/navigation'
 import { StackActions } from '@react-navigation/native'
 
 import { AccountAvatar } from '../avatars'
+import { useSelector } from 'react-redux'
+import { selectSelectedAccount } from '@berty-tech/redux/reducers/ui.reducer'
 
 //
 // Edit Profile
@@ -87,6 +89,8 @@ const EditMyProfile: React.FC = () => {
 	const { t }: any = useTranslation()
 	const dispatch = useAppDispatch()
 	const navigation = useNavigation()
+	const client = useMessengerClient()
+	const selectedAccount = useSelector(selectSelectedAccount)
 
 	const account = useAccount()
 
@@ -125,7 +129,7 @@ const EditMyProfile: React.FC = () => {
 
 			if (state.pic) {
 				console.log('opening stream', state.pic)
-				const stream = await ctx.client?.mediaPrepare({})
+				const stream = await client?.mediaPrepare({})
 				if (!stream) {
 					throw new Error('failed to open prepareAttachment stream')
 				}
@@ -160,10 +164,10 @@ const EditMyProfile: React.FC = () => {
 
 			if (updated) {
 				// update account in bertymessenger
-				await ctx.client?.accountUpdate(update)
+				await client?.accountUpdate(update)
 				// update account in bertyaccount
 				await ctx.updateAccount({
-					accountId: ctx.selectedAccount,
+					accountId: selectedAccount,
 					avatarCid: update.avatarCid,
 				})
 

--- a/js/packages/components/music-player.tsx
+++ b/js/packages/components/music-player.tsx
@@ -1,9 +1,9 @@
 import React, { createContext, useContext, useEffect, useState } from 'react'
 import { Player } from '@react-native-community/audio-toolkit'
 
-import { useMessengerContext } from '@berty-tech/store'
-
 import { getSource } from './utils'
+import { useSelector } from 'react-redux'
+import { selectProtocolClient } from '@berty-tech/redux/reducers/ui.reducer'
 
 type PlayerType = Player | undefined
 
@@ -58,7 +58,7 @@ export const MusicPlayerContext = createContext<{
 
 export const MusicPlayerProvider: React.FC = ({ children }) => {
 	const [player, setPlayer] = useState<PlayerState>(INITIAL_PLAYER_VALUE)
-	const { protocolClient } = useMessengerContext()
+	const protocolClient = useSelector(selectProtocolClient)
 	const [loading, setLoading] = useState(false)
 	const [playing, setPlaying] = useState(false)
 

--- a/js/packages/components/onboarding/AdvancedSettings.tsx
+++ b/js/packages/components/onboarding/AdvancedSettings.tsx
@@ -28,6 +28,7 @@ import {
 	useThemeColor,
 	serviceTypes,
 	useAccountServices,
+	useMessengerClient,
 } from '@berty-tech/store'
 import { useStyles } from '@berty-tech/styles'
 import { useAccount } from '@berty-tech/react-redux'
@@ -36,6 +37,8 @@ import { showNeedRestartNotification } from '../helpers'
 import { ButtonSetting } from '../shared-components'
 import { DropDownPicker, Item } from '../shared-components/DropDownPicker'
 import { CreateAccountBox } from './CreateAccountBox'
+import { useSelector } from 'react-redux'
+import { selectSelectedAccount } from '@berty-tech/redux/reducers/ui.reducer'
 
 const TitleBox: React.FC<{
 	title: string
@@ -237,10 +240,9 @@ const Proximity: React.FC<{
 	setNewConfig: React.Dispatch<beapi.account.INetworkConfig | null>
 	newConfig: beapi.account.INetworkConfig | null
 }> = ({ setNewConfig, newConfig }) => {
-	const ctx = useMessengerContext()
 	const { navigate } = useNavigation()
 	const colors = useThemeColor()
-	const { selectedAccount } = ctx
+	const selectedAccount = useSelector(selectSelectedAccount)
 	const { t } = useTranslation()
 
 	const setNewConfigProximityTransport = React.useCallback(() => {
@@ -464,6 +466,7 @@ const Services: React.FC<{
 		const services = useAccountServices()
 		const [{ margin, text }, { scaleSize }] = useStyles()
 		const ctx = useMessengerContext()
+		const client = useMessengerClient()
 
 		const replicationServices = services.filter(
 			(s: any) => s.serviceType === serviceTypes.Replication,
@@ -509,7 +512,7 @@ const Services: React.FC<{
 						if (replicationServices.length === 0) {
 							return
 						}
-						await ctx.client?.replicationSetAutoEnable({
+						await client?.replicationSetAutoEnable({
 							enabled: !account.replicateNewGroupsAutomatically,
 						})
 						showNeedRestartNotification(props.showNotification, ctx, t)
@@ -612,6 +615,7 @@ const ApplyChanges: React.FC<{ newConfig: beapi.account.INetworkConfig | null }>
 		const colors = useThemeColor()
 		const { t } = useTranslation()
 		const ctx = useMessengerContext()
+		const selectedAccount = useSelector(selectSelectedAccount)
 
 		return (
 			<View
@@ -621,7 +625,7 @@ const ApplyChanges: React.FC<{ newConfig: beapi.account.INetworkConfig | null }>
 					<TouchableOpacity
 						onPress={async () => {
 							await accountService.networkConfigSet({
-								accountId: ctx.selectedAccount,
+								accountId: selectedAccount,
 								config: newConfig,
 							})
 							await ctx.setNetworkConfig(newConfig)
@@ -660,6 +664,7 @@ export const AdvancedSettings: ScreenFC<'Onboarding.AdvancedSettings'> = ({
 	)
 	const [isNew, setIsNew] = React.useState<string | null>(null)
 	const { navigate } = useNavigation()
+	const selectedAccount = useSelector(selectSelectedAccount)
 
 	useMountEffect(() => {
 		ctx
@@ -727,7 +732,7 @@ export const AdvancedSettings: ScreenFC<'Onboarding.AdvancedSettings'> = ({
 					</View>
 				) : null}
 			</ScrollView>
-			{ctx.selectedAccount && isNew !== 'isNew' ? <ApplyChanges newConfig={newConfig} /> : null}
+			{selectedAccount && isNew !== 'isNew' ? <ApplyChanges newConfig={newConfig} /> : null}
 		</SafeAreaView>
 	)
 }

--- a/js/packages/components/settings/BertyServices.tsx
+++ b/js/packages/components/settings/BertyServices.tsx
@@ -16,6 +16,8 @@ import { useAppDispatch } from '@berty-tech/react-redux'
 
 import SwiperCard from '../onboarding/SwiperCard'
 import OnboardingWrapper from '../onboarding/OnboardingWrapper'
+import { useSelector } from 'react-redux'
+import { selectProtocolClient } from '@berty-tech/redux/reducers/ui.reducer'
 
 const ServicesAuthBody: React.FC<{ next: () => void }> = ({ next }) => {
 	const ctx = useMessengerContext()
@@ -23,6 +25,7 @@ const ServicesAuthBody: React.FC<{ next: () => void }> = ({ next }) => {
 	const { t }: any = useTranslation()
 	const { goBack } = useNavigation()
 	const dispatch = useAppDispatch()
+	const protocolClient = useSelector(selectProtocolClient)
 
 	return (
 		<View style={{ flex: 1 }}>
@@ -36,7 +39,7 @@ const ServicesAuthBody: React.FC<{ next: () => void }> = ({ next }) => {
 								text: t('settings.berty-services.button'),
 								onPress: async () => {
 									try {
-										await servicesAuthViaDefault(ctx)
+										await servicesAuthViaDefault(protocolClient)
 										await ctx.setPersistentOption({
 											type: PersistentOptionsKeys.Configurations,
 											payload: {

--- a/js/packages/components/settings/Home.tsx
+++ b/js/packages/components/settings/Home.tsx
@@ -14,10 +14,10 @@ import { useTranslation } from 'react-i18next'
 import { useStyles } from '@berty-tech/styles'
 import { ScreenFC, useNavigation } from '@berty-tech/navigation'
 import {
-	MessengerActions,
 	useMessengerContext,
 	closeAccountWithProgress,
 	useThemeColor,
+	useMessengerClient,
 } from '@berty-tech/store'
 import { useAppDispatch, useAccount } from '@berty-tech/react-redux'
 
@@ -26,6 +26,7 @@ import { AccountAvatar } from '../avatars'
 import logo from '../main/1_berty_picto.png'
 import { WelcomeChecklist } from './WelcomeChecklist'
 import { LoaderDots } from '../gates'
+import { setStateOnBoardingReady } from '@berty-tech/redux/reducers/ui.reducer'
 
 const _verticalOffset = 30
 
@@ -83,7 +84,7 @@ const HomeHeaderAvatar: React.FC = () => {
 	const { navigate } = useNavigation()
 	const [{ row, border, padding }, { windowWidth, windowHeight, scaleHeight, scaleSize }] =
 		useStyles()
-	const ctx = useMessengerContext()
+	const client = useMessengerClient()
 	const colors = useThemeColor()
 	const account = useAccount()
 	const qrCodeSize = Math.min(windowHeight, windowWidth) * 0.4
@@ -92,7 +93,7 @@ const HomeHeaderAvatar: React.FC = () => {
 	React.useEffect(() => {
 		const getAccountLink = async () => {
 			if (account.displayName) {
-				const ret = await ctx.client?.instanceShareableBertyID({
+				const ret = await client?.instanceShareableBertyID({
 					reset: false,
 					displayName: account.displayName,
 				})
@@ -187,7 +188,7 @@ const HomeBodySettings: React.FC = () => {
 				iconColor={colors['background-header']}
 				onPress={async () => {
 					await closeAccountWithProgress(dispatch, reduxDispatch)
-					await dispatch({ type: MessengerActions.SetStateOnBoardingReady })
+					await reduxDispatch(setStateOnBoardingReady())
 				}}
 			/>
 		</View>

--- a/js/packages/components/settings/Mode.tsx
+++ b/js/packages/components/settings/Mode.tsx
@@ -5,21 +5,22 @@ import { Text } from '@ui-kitten/components'
 import { useTranslation } from 'react-i18next'
 
 import { useStyles } from '@berty-tech/styles'
-import { useMessengerContext, useThemeColor, exportAccountToFile } from '@berty-tech/store'
+import { useThemeColor, exportAccountToFile } from '@berty-tech/store'
 import { ScreenFC, useNavigation } from '@berty-tech/navigation'
 
 import { ButtonSetting } from '../shared-components/SettingsButtons'
 import { useDispatch, useSelector } from 'react-redux'
 import { selectThemeIsDark, toggleDarkTheme } from '@berty-tech/redux/reducers/theme.reducer'
+import { selectSelectedAccount } from '@berty-tech/redux/reducers/ui.reducer'
 
 const BodyMode: React.FC = withInAppNotification(({ showNotification }: any) => {
 	const [{ flex, padding, margin }] = useStyles()
-	const ctx = useMessengerContext()
 	const { t }: any = useTranslation()
 	const colors = useThemeColor()
 	const navigation = useNavigation()
 	const dispatch = useDispatch()
 	const isDark = useSelector(selectThemeIsDark)
+	const selectedAccount = useSelector(selectSelectedAccount)
 
 	return (
 		<View style={[flex.tiny, padding.medium, margin.bottom.medium]}>
@@ -71,7 +72,7 @@ const BodyMode: React.FC = withInAppNotification(({ showNotification }: any) => 
 				iconColor={colors['background-header']}
 				actionIcon='arrow-ios-forward'
 				onPress={async () => {
-					await exportAccountToFile(ctx.selectedAccount)
+					await exportAccountToFile(selectedAccount)
 					if (Platform.OS === 'android') {
 						showNotification({
 							title: t('settings.mode.notification-file-saved.title'),

--- a/js/packages/components/settings/ServicesAuth.tsx
+++ b/js/packages/components/settings/ServicesAuth.tsx
@@ -17,12 +17,14 @@ import {
 
 import { ButtonSetting, FactionButtonSetting } from '../shared-components'
 import { showNeedRestartNotification } from '../helpers'
+import { useSelector } from 'react-redux'
+import { selectProtocolClient } from '@berty-tech/redux/reducers/ui.reducer'
 
 const BodyServicesAuth = withInAppNotification(({ showNotification }: any) => {
 	const [{ flex, padding, margin }] = useStyles()
 	const colors = useThemeColor()
 	const { t }: any = useTranslation()
-
+	const protocolClient = useSelector(selectProtocolClient)
 	const [url, setURL] = useState('')
 	const ctx = useMessengerContext()
 	const accountServices = useAccountServices()
@@ -36,7 +38,7 @@ const BodyServicesAuth = withInAppNotification(({ showNotification }: any) => {
 				iconColor={colors['background-header']}
 				alone={true}
 				onPress={async () => {
-					await servicesAuthViaDefault(ctx)
+					await servicesAuthViaDefault(protocolClient)
 				}}
 			/>
 			<FactionButtonSetting
@@ -63,7 +65,7 @@ const BodyServicesAuth = withInAppNotification(({ showNotification }: any) => {
 					alone={false}
 					onPress={async () => {
 						try {
-							await servicesAuthViaURL(ctx.protocolClient, url)
+							await servicesAuthViaURL(protocolClient, url)
 							showNeedRestartNotification(showNotification, ctx, t)
 						} catch (e) {
 							// ignoring

--- a/js/packages/messenger-app/App.tsx
+++ b/js/packages/messenger-app/App.tsx
@@ -46,7 +46,7 @@ export const App: React.FC = () => {
 		<SafeAreaProvider>
 			<StyleProvider>
 				<ReduxProvider store={reduxStore}>
-					<MessengerProvider embedded daemonAddress='http://localhost:1337'>
+					<MessengerProvider daemonAddress='http://localhost:1337'>
 						<IconRegistry icons={[EvaIconsPack, FeatherIconsPack, CustomIconsPack]} />
 						<ThemeProvider>
 							<Background>

--- a/js/packages/navigation/stacks.tsx
+++ b/js/packages/navigation/stacks.tsx
@@ -10,11 +10,13 @@ import { Icon } from '@ui-kitten/components'
 import mapValues from 'lodash/mapValues'
 
 import * as RawComponents from '@berty-tech/components'
-import { MessengerAppState, useMessengerContext, useThemeColor } from '@berty-tech/store'
+import { useMessengerContext, useThemeColor } from '@berty-tech/store'
 import { useStyles } from '@berty-tech/styles'
 
 import { dispatch } from './rootRef'
 import { ScreensParams } from './types'
+import { useSelector } from 'react-redux'
+import { MESSENGER_APP_STATE, selectAppState } from '@berty-tech/redux/reducers/ui.reducer'
 
 export const CustomTitleStyle: () => any = () => {
 	const [{}, { scaleSize }] = useStyles()
@@ -155,22 +157,22 @@ Components = mapValues(RawComponents, SubComponents =>
 const NavigationStack = createNativeStackNavigator<ScreensParams>()
 
 export const Navigation: React.FC = React.memo(() => {
-	const context = useMessengerContext()
+	const appState = useSelector(selectAppState)
 	const colors = useThemeColor()
 	const [, { scaleSize }] = useStyles()
 	const { t }: any = useTranslation()
 
 	useEffect(() => {
-		console.log('context app State', context.appState)
-		switch (context.appState) {
-			case MessengerAppState.Ready:
+		console.log('context app State', appState)
+		switch (appState) {
+			case MESSENGER_APP_STATE.READY:
 				dispatch(
 					CommonActions.reset({
 						routes: [{ name: 'Main.Home' }],
 					}),
 				)
 				return
-			case MessengerAppState.PreReady:
+			case MESSENGER_APP_STATE.PRE_READY:
 				dispatch(
 					CommonActions.reset({
 						routes: [{ name: 'Onboarding.SetupFinished' }],
@@ -178,12 +180,12 @@ export const Navigation: React.FC = React.memo(() => {
 				)
 				return
 		}
-	}, [context.appState])
+	}, [appState])
 
 	return (
 		<NavigationStack.Navigator
 			initialRouteName={
-				context.appState === MessengerAppState.GetStarted ? 'Onboarding.GetStarted' : 'Main.Home'
+				appState === MESSENGER_APP_STATE.GET_STARTED ? 'Onboarding.GetStarted' : 'Main.Home'
 			}
 		>
 			{/* OnBoarding */}

--- a/js/packages/redux/reducers/ui.reducer.ts
+++ b/js/packages/redux/reducers/ui.reducer.ts
@@ -1,0 +1,451 @@
+import { Platform } from 'react-native'
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
+
+import {
+	NotificationsInhibitor,
+	PersistentOptions,
+	PersistentOptionsKeys,
+	PersistentOptionsSuggestions,
+	StreamInProgress,
+	UpdatesProfileNotification,
+} from '@berty-tech/store'
+import { globals } from '@berty-tech/config'
+import beapi from '@berty-tech/api'
+import { ServiceClientType } from '@berty-tech/grpc-bridge/welsh-clients.gen'
+
+/**
+ *
+ * Types
+ *
+ */
+
+export const defaultPersistentOptions = (): PersistentOptions => {
+	let suggestions: PersistentOptionsSuggestions = {}
+	Object.values(globals.berty.contacts).forEach(async value => {
+		if (value.suggestion) {
+			suggestions = {
+				...suggestions,
+				[value.name]: {
+					link: value.link,
+					displayName: value.name,
+					state: 'unread',
+					pk: '',
+					icon: value.icon,
+				},
+			}
+		}
+	})
+	return {
+		[PersistentOptionsKeys.Notifications]: {
+			enable: true,
+		},
+		[PersistentOptionsKeys.Suggestions]: suggestions,
+		[PersistentOptionsKeys.Debug]: {
+			enable: false,
+		},
+		[PersistentOptionsKeys.Log]: {
+			format: 'json',
+		},
+		[PersistentOptionsKeys.Configurations]: {},
+		[PersistentOptionsKeys.LogFilters]: {
+			format: '*:bty*',
+		},
+		[PersistentOptionsKeys.TyberHost]: {
+			address: Platform.OS === 'android' ? '10.0.2.2:4242' : '127.0.0.1:4242',
+		},
+		[PersistentOptionsKeys.OnBoardingFinished]: {
+			isFinished: false,
+		},
+		[PersistentOptionsKeys.ProfileNotification]: {
+			[UpdatesProfileNotification]: 0,
+		},
+	}
+}
+
+export type UiState = {
+	appState: MESSENGER_APP_STATE[keyof MESSENGER_APP_STATE]
+	selectedAccount: string | null
+	nextSelectedAccount: string | null
+	client: ServiceClientType<beapi.messenger.MessengerService> | null
+	protocolClient: ServiceClientType<beapi.protocol.ProtocolService> | null
+	streamError: unknown
+	streamInProgress: StreamInProgress | null
+	notificationsInhibitors: NotificationsInhibitor[]
+	persistentOptions: PersistentOptions
+	daemonAddress: string
+	clearClients: (() => Promise<void>) | (() => void) | null
+	embedded: boolean
+	debugMode: boolean
+	accounts: beapi.account.IAccountMetadata[]
+	networkConfig: beapi.account.INetworkConfig
+	handledLink: boolean
+}
+
+export enum MESSENGER_APP_STATE {
+	INIT = 'init',
+	CLOSED = 'closed',
+	OPENING_WAITING_FOR_DAEMON = 'openingWaitingForDaemon',
+	OPENING_WAITING_FOR_CLIENTS = 'openingWaitingForClients',
+	OPENING_LISTING_EVENTS = 'openingListingEvents',
+	OPENING_GETTING_LOCAL_SETTINGS = 'openingGettingLocalSettings',
+	OPENING_MARK_CONVERSATIONS_AS_CLOSED = 'openingMarkConversationsAsClosed',
+	GET_STARTED = 'getStarted',
+	READY = 'ready',
+	CLOSING_DAEMON = 'closingDaemon',
+	DELETING_CLOSING_DAEMON = 'deletingClosingDaemon',
+	DELETING_CLEARING_STORAGE = 'deletingClearingStorage',
+	STREAM_DONE = 'streamDone',
+	PRE_READY = 'preReady',
+}
+
+const expectedAppStateChanges: {
+	[key: string]: MESSENGER_APP_STATE[keyof MESSENGER_APP_STATE][]
+} = {
+	[MESSENGER_APP_STATE.INIT]: [
+		MESSENGER_APP_STATE.OPENING_WAITING_FOR_CLIENTS,
+		MESSENGER_APP_STATE.OPENING_WAITING_FOR_DAEMON,
+		MESSENGER_APP_STATE.GET_STARTED,
+	],
+	[MESSENGER_APP_STATE.CLOSED]: [
+		MESSENGER_APP_STATE.OPENING_WAITING_FOR_CLIENTS,
+		MESSENGER_APP_STATE.OPENING_WAITING_FOR_DAEMON,
+		MESSENGER_APP_STATE.CLOSING_DAEMON,
+	],
+	[MESSENGER_APP_STATE.OPENING_WAITING_FOR_DAEMON]: [
+		MESSENGER_APP_STATE.STREAM_DONE,
+		MESSENGER_APP_STATE.OPENING_WAITING_FOR_CLIENTS,
+	],
+	[MESSENGER_APP_STATE.OPENING_WAITING_FOR_CLIENTS]: [
+		MESSENGER_APP_STATE.OPENING_WAITING_FOR_DAEMON,
+		MESSENGER_APP_STATE.OPENING_LISTING_EVENTS,
+		MESSENGER_APP_STATE.OPENING_MARK_CONVERSATIONS_AS_CLOSED,
+	],
+	[MESSENGER_APP_STATE.OPENING_LISTING_EVENTS]: [
+		MESSENGER_APP_STATE.OPENING_WAITING_FOR_DAEMON,
+		MESSENGER_APP_STATE.OPENING_GETTING_LOCAL_SETTINGS,
+	],
+	[MESSENGER_APP_STATE.OPENING_GETTING_LOCAL_SETTINGS]: [
+		MESSENGER_APP_STATE.OPENING_MARK_CONVERSATIONS_AS_CLOSED,
+	],
+	[MESSENGER_APP_STATE.OPENING_MARK_CONVERSATIONS_AS_CLOSED]: [
+		MESSENGER_APP_STATE.PRE_READY,
+		MESSENGER_APP_STATE.READY,
+	],
+	[MESSENGER_APP_STATE.GET_STARTED]: [MESSENGER_APP_STATE.OPENING_WAITING_FOR_DAEMON],
+	[MESSENGER_APP_STATE.READY]: [
+		MESSENGER_APP_STATE.OPENING_WAITING_FOR_DAEMON,
+		MESSENGER_APP_STATE.DELETING_CLOSING_DAEMON,
+		MESSENGER_APP_STATE.CLOSING_DAEMON,
+		MESSENGER_APP_STATE.OPENING_WAITING_FOR_CLIENTS,
+		MESSENGER_APP_STATE.STREAM_DONE,
+	],
+	[MESSENGER_APP_STATE.CLOSING_DAEMON]: [
+		MESSENGER_APP_STATE.CLOSED,
+		MESSENGER_APP_STATE.OPENING_WAITING_FOR_DAEMON,
+		MESSENGER_APP_STATE.OPENING_WAITING_FOR_CLIENTS,
+	],
+	[MESSENGER_APP_STATE.DELETING_CLOSING_DAEMON]: [MESSENGER_APP_STATE.DELETING_CLEARING_STORAGE],
+	[MESSENGER_APP_STATE.DELETING_CLEARING_STORAGE]: [
+		MESSENGER_APP_STATE.CLOSED,
+		MESSENGER_APP_STATE.OPENING_WAITING_FOR_DAEMON,
+	],
+	[MESSENGER_APP_STATE.PRE_READY]: [MESSENGER_APP_STATE.READY],
+	[MESSENGER_APP_STATE.STREAM_DONE]: [
+		MESSENGER_APP_STATE.OPENING_WAITING_FOR_DAEMON,
+		MESSENGER_APP_STATE.GET_STARTED,
+		MESSENGER_APP_STATE.OPENING_WAITING_FOR_CLIENTS,
+	],
+}
+
+export const isExpectedAppStateChange = (
+	former: MESSENGER_APP_STATE[keyof MESSENGER_APP_STATE],
+	next: MESSENGER_APP_STATE[keyof MESSENGER_APP_STATE],
+): boolean => {
+	console.log({ former, next })
+	if (former === next) {
+		return true
+	}
+	return (expectedAppStateChanges[former as string] || []).indexOf(next) !== -1
+}
+
+/**
+ *
+ * State
+ *
+ */
+
+export const sliceName = 'ui'
+
+const makeRoot = <T>(val: T) => ({
+	[sliceName]: val,
+})
+
+const initialState: UiState = {
+	appState: MESSENGER_APP_STATE.INIT,
+	selectedAccount: null,
+	nextSelectedAccount: null,
+	client: null,
+	protocolClient: null,
+	streamError: null,
+	streamInProgress: null,
+	notificationsInhibitors: [],
+	persistentOptions: defaultPersistentOptions(),
+	daemonAddress: '',
+	clearClients: null,
+	embedded: true,
+	debugMode: true,
+	accounts: [],
+	networkConfig: {},
+	handledLink: false,
+}
+
+const rootInitialState = makeRoot(initialState)
+type LocalRootState = typeof rootInitialState
+
+/**
+ *
+ * Actions
+ *
+ */
+
+const setStateOpeningFn = (state: UiState) => {
+	if (state.nextSelectedAccount === null) {
+		return
+	}
+
+	state.selectedAccount = state.nextSelectedAccount
+	state.nextSelectedAccount = null
+	state.embedded
+		? changeAppState(state, MESSENGER_APP_STATE.OPENING_WAITING_FOR_DAEMON)
+		: changeAppState(state, MESSENGER_APP_STATE.OPENING_WAITING_FOR_CLIENTS)
+}
+
+const setStateClosedFn = (state: UiState) => {
+	state.accounts = state.accounts
+	state.embedded = state.embedded
+	state.daemonAddress = state.daemonAddress
+	changeAppState(state, MESSENGER_APP_STATE.CLOSED)
+	state.nextSelectedAccount = state.embedded ? state.nextSelectedAccount : '0'
+
+	if (state.nextSelectedAccount !== null) {
+		setStateOpeningFn(state)
+	}
+}
+
+const changeAppState = (
+	state: UiState,
+	newAppState: MESSENGER_APP_STATE[keyof MESSENGER_APP_STATE],
+) => {
+	if (!isExpectedAppStateChange(state.appState, newAppState)) {
+		console.warn(`unexpected app state change from ${state.appState} to ${newAppState}`)
+	}
+	state.appState = newAppState
+}
+
+const slice = createSlice({
+	name: sliceName,
+	initialState,
+	reducers: {
+		setStreamError(state: UiState, { payload: { error } }: PayloadAction<{ error: unknown }>) {
+			state.streamError = error
+		},
+		// addFakeData(_: UiState, { payload: { interactions } }: PayloadAction<{ interactions: any }>) {
+		// 	// useless code
+		// 	let fakeInteractions: { [key: string]: unknown[] } = {}
+		// 	for (const inte of interactions || []) {
+		// 		if (!fakeInteractions[inte.conversationPublicKey]) {
+		// 			fakeInteractions[inte.conversationPublicKey] = []
+		// 			fakeInteractions[inte.conversationPublicKey].push(inte)
+		// 		}
+		// 	}
+		// },
+		deleteFakeData() {},
+		setDaemonAddress(state: UiState, { payload: { value } }: PayloadAction<{ value: string }>) {
+			state.daemonAddress = value
+		},
+		setPersistentOptions(state: UiState, { payload }: PayloadAction<PersistentOptions>) {
+			state.persistentOptions = payload
+		},
+		setStateOpeningListingEvents(
+			state: UiState,
+			{
+				payload,
+			}: PayloadAction<{
+				messengerClient?: ServiceClientType<beapi.messenger.MessengerService> | null
+				protocolClient?: ServiceClientType<beapi.protocol.ProtocolService> | null
+				clearClients?: (() => Promise<void>) | (() => void) | null
+			}>,
+		) {
+			state.client = payload.messengerClient || state.client
+			state.protocolClient = payload.protocolClient || state.protocolClient
+			state.clearClients = payload.clearClients || state.clearClients
+			changeAppState(state, MESSENGER_APP_STATE.OPENING_LISTING_EVENTS)
+		},
+		setStateClosed: setStateClosedFn,
+		setNextAccount(state: UiState, { payload }: PayloadAction<string | null | undefined>) {
+			if (payload === null || payload === undefined || !state.embedded) {
+				return
+			}
+			state.nextSelectedAccount = payload
+			setStateClosedFn(state)
+		},
+		setStateOpening: setStateOpeningFn,
+		setStateOpeningClients(state: UiState) {
+			state.appState = MESSENGER_APP_STATE.OPENING_WAITING_FOR_CLIENTS
+		},
+		setStateOpeningGettingLocalSettings(state: UiState) {
+			state.appState = MESSENGER_APP_STATE.OPENING_GETTING_LOCAL_SETTINGS
+		},
+		setStateOpeningMarkConversationsClosed(state: UiState) {
+			state.appState = MESSENGER_APP_STATE.OPENING_MARK_CONVERSATIONS_AS_CLOSED
+		},
+		setStatePreReady(state: UiState) {
+			state.appState = MESSENGER_APP_STATE.PRE_READY
+		},
+		setStateReady(state: UiState) {
+			state.appState = MESSENGER_APP_STATE.READY
+		},
+		setAccounts(state: UiState, { payload }: PayloadAction<beapi.account.IAccountMetadata[]>) {
+			state.accounts = payload
+		},
+		bridgeClosed(state: UiState) {
+			if (state.appState === MESSENGER_APP_STATE.DELETING_CLOSING_DAEMON) {
+				state.appState = MESSENGER_APP_STATE.DELETING_CLEARING_STORAGE
+			}
+			setStateClosedFn(state)
+		},
+		addNotificationInhibitor(
+			state: UiState,
+			{ payload: { inhibitor } }: PayloadAction<{ inhibitor: NotificationsInhibitor }>,
+		) {
+			if (state.notificationsInhibitors.includes(inhibitor)) {
+				return
+			}
+			state.notificationsInhibitors = [...state.notificationsInhibitors, inhibitor]
+		},
+		removeNotificationInhibitor(
+			state: UiState,
+			{ payload: { inhibitor } }: PayloadAction<{ inhibitor: NotificationsInhibitor }>,
+		) {
+			if (!state.notificationsInhibitors.includes(inhibitor)) {
+				return
+			}
+
+			state.notificationsInhibitors = state.notificationsInhibitors.filter(
+				(inh: any) => inh !== inhibitor,
+			)
+		},
+		setCreatedAccount(state: UiState, { payload }: PayloadAction<{ accountId: string | null }>) {
+			state.nextSelectedAccount = payload?.accountId
+			state.appState = MESSENGER_APP_STATE.OPENING_WAITING_FOR_CLIENTS
+			setStateClosedFn(state)
+		},
+		setStateStreamInProgress(state: UiState, { payload }: PayloadAction<StreamInProgress | null>) {
+			state.streamInProgress = payload
+		},
+		setStateStreamDone(state: UiState) {
+			state.appState = MESSENGER_APP_STATE.STREAM_DONE
+			state.streamInProgress = null
+		},
+		setStateOnBoardingReady(state: UiState) {
+			state.appState = MESSENGER_APP_STATE.GET_STARTED
+		},
+	},
+})
+
+/**
+ *
+ * Selectors
+ *
+ */
+
+const selectSlice = (state: LocalRootState) => state[sliceName]
+
+export const selectMessengerIsDeletingState = (state: LocalRootState): boolean =>
+	selectSlice(state).appState === MESSENGER_APP_STATE.DELETING_CLEARING_STORAGE ||
+	selectSlice(state).appState === MESSENGER_APP_STATE.DELETING_CLOSING_DAEMON
+
+export const selectMessengerisClosing = (state: LocalRootState): boolean =>
+	selectSlice(state).appState === MESSENGER_APP_STATE.DELETING_CLEARING_STORAGE ||
+	selectSlice(state).appState === MESSENGER_APP_STATE.DELETING_CLOSING_DAEMON ||
+	selectSlice(state).appState === MESSENGER_APP_STATE.CLOSING_DAEMON
+
+export const selectMessengerIsReadyingBasics = (state: LocalRootState): boolean =>
+	selectSlice(state).appState === MESSENGER_APP_STATE.OPENING_WAITING_FOR_DAEMON ||
+	selectSlice(state).appState === MESSENGER_APP_STATE.OPENING_WAITING_FOR_CLIENTS ||
+	selectSlice(state).appState === MESSENGER_APP_STATE.OPENING_LISTING_EVENTS ||
+	selectSlice(state).appState === MESSENGER_APP_STATE.OPENING_GETTING_LOCAL_SETTINGS ||
+	selectSlice(state).appState === MESSENGER_APP_STATE.CLOSED ||
+	selectSlice(state).appState === MESSENGER_APP_STATE.OPENING_MARK_CONVERSATIONS_AS_CLOSED ||
+	selectSlice(state).appState === MESSENGER_APP_STATE.STREAM_DONE ||
+	selectSlice(state).appState === MESSENGER_APP_STATE.INIT
+
+export const selectAppState = (
+	state: LocalRootState,
+): MESSENGER_APP_STATE[keyof MESSENGER_APP_STATE] => selectSlice(state).appState
+
+export const selectSelectedAccount = (state: LocalRootState): string | null =>
+	selectSlice(state).selectedAccount
+
+export const selectClient = (
+	state: LocalRootState,
+): ServiceClientType<beapi.messenger.MessengerService> | null => selectSlice(state).client
+
+export const selectProtocolClient = (
+	state: LocalRootState,
+): ServiceClientType<beapi.protocol.ProtocolService> | null => selectSlice(state).protocolClient
+
+export const selectNetworkConfig = (state: LocalRootState): beapi.account.INetworkConfig =>
+	selectSlice(state).networkConfig
+
+export const selectEmbedded = (state: LocalRootState): boolean => selectSlice(state).embedded
+
+export const selectDaemonAddress = (state: LocalRootState): string =>
+	selectSlice(state).daemonAddress
+
+export const selectPersistentOptions = (state: LocalRootState): PersistentOptions =>
+	selectSlice(state).persistentOptions
+
+export const selectDebugMode = (state: LocalRootState): boolean => selectSlice(state).debugMode
+
+export const selectStreamInProgress = (state: LocalRootState): StreamInProgress | null =>
+	selectSlice(state).streamInProgress
+
+export const selectStreamError = (state: LocalRootState): any => selectSlice(state).streamError
+
+export const selectNotificationsInhibitors = (state: LocalRootState): NotificationsInhibitor[] =>
+	selectSlice(state).notificationsInhibitors
+
+export const selectAccounts = (state: LocalRootState): beapi.account.IAccountMetadata[] =>
+	selectSlice(state).accounts
+
+export const selectClearClients = (
+	state: LocalRootState,
+): (() => Promise<void>) | (() => void) | null => selectSlice(state).clearClients
+
+export const {
+	setStreamError,
+	// addFakeData,
+	deleteFakeData,
+	setDaemonAddress,
+	setPersistentOptions,
+	setStateOpeningListingEvents,
+	setStateClosed,
+	setNextAccount,
+	setStateOpening,
+	setStateOpeningClients,
+	setStateOpeningGettingLocalSettings,
+	setStateOpeningMarkConversationsClosed,
+	setStatePreReady,
+	setStateReady,
+	setAccounts,
+	bridgeClosed,
+	addNotificationInhibitor,
+	removeNotificationInhibitor,
+	setCreatedAccount,
+	setStateStreamInProgress,
+	setStateStreamDone,
+	setStateOnBoardingReady,
+} = slice.actions
+
+export default makeRoot(slice.reducer)

--- a/js/packages/redux/store.ts
+++ b/js/packages/redux/store.ts
@@ -14,7 +14,8 @@ import accountSettingsRootReducer, {
 	sliceName as accountSettingsSliceName,
 } from './reducers/accountSettings.reducer'
 import themeReducer, { sliceName as themeSliceName } from './reducers/theme.reducer'
-import messengerRootReduceer from './reducers/messenger.reducer'
+import uiReducer from './reducers/ui.reducer'
+import messengerRootReducer from './reducers/messenger.reducer'
 
 const persistConfig = {
 	key: 'persistStore',
@@ -34,8 +35,9 @@ const rootReducer = combineReducers({
 	...chatInputsVolatileRootReducer,
 	...checklistRootReducer,
 	...accountSettingsRootReducer,
-	...messengerRootReduceer,
+	...messengerRootReducer,
 	...themeReducer,
+	...uiReducer,
 })
 
 const persistedReducer = persistReducer(persistConfig, rootReducer)

--- a/js/packages/store/context.ts
+++ b/js/packages/store/context.ts
@@ -4,98 +4,12 @@ import { Platform } from 'react-native'
 import { globals } from '@berty-tech/config'
 
 import {
-	MessengerAppState,
 	MessengerState as MessengerState,
 	PersistentOptions,
 	PersistentOptionsKeys,
 	PersistentOptionsSuggestions,
 	UpdatesProfileNotification,
 } from './types'
-
-export const isDeletingState = (state: MessengerAppState): boolean =>
-	state === MessengerAppState.DeletingClearingStorage ||
-	state === MessengerAppState.DeletingClosingDaemon
-
-export const isClosing = (state: MessengerAppState): boolean =>
-	isDeletingState(state) || state === MessengerAppState.ClosingDaemon
-
-export const isReadyingBasics = (state: MessengerAppState): boolean =>
-	state === MessengerAppState.OpeningWaitingForDaemon ||
-	state === MessengerAppState.OpeningWaitingForClients ||
-	state === MessengerAppState.OpeningListingEvents ||
-	state === MessengerAppState.OpeningGettingLocalSettings ||
-	state === MessengerAppState.Closed ||
-	state === MessengerAppState.OpeningMarkConversationsAsClosed ||
-	state === MessengerAppState.StreamDone ||
-	state === MessengerAppState.Init
-
-const expectedAppStateChanges: any = {
-	[MessengerAppState.Init]: [
-		MessengerAppState.OpeningWaitingForClients,
-		MessengerAppState.OpeningWaitingForDaemon,
-		MessengerAppState.GetStarted,
-	],
-	[MessengerAppState.Closed]: [
-		MessengerAppState.OpeningWaitingForClients,
-		MessengerAppState.OpeningWaitingForDaemon,
-		MessengerAppState.ClosingDaemon,
-	],
-	[MessengerAppState.OpeningWaitingForDaemon]: [
-		MessengerAppState.StreamDone,
-		MessengerAppState.OpeningWaitingForClients,
-	],
-	[MessengerAppState.OpeningWaitingForClients]: [
-		MessengerAppState.OpeningWaitingForDaemon,
-		MessengerAppState.OpeningListingEvents,
-		MessengerAppState.OpeningMarkConversationsAsClosed,
-	],
-	[MessengerAppState.OpeningListingEvents]: [
-		MessengerAppState.OpeningWaitingForDaemon,
-		MessengerAppState.OpeningGettingLocalSettings,
-	],
-	[MessengerAppState.OpeningGettingLocalSettings]: [
-		MessengerAppState.OpeningMarkConversationsAsClosed,
-	],
-	[MessengerAppState.OpeningMarkConversationsAsClosed]: [
-		MessengerAppState.PreReady,
-		MessengerAppState.Ready,
-	],
-	[MessengerAppState.GetStarted]: [MessengerAppState.OpeningWaitingForDaemon],
-	[MessengerAppState.Ready]: [
-		MessengerAppState.OpeningWaitingForDaemon,
-		MessengerAppState.DeletingClosingDaemon,
-		MessengerAppState.ClosingDaemon,
-		MessengerAppState.OpeningWaitingForClients,
-		MessengerAppState.StreamDone,
-	],
-	[MessengerAppState.ClosingDaemon]: [
-		MessengerAppState.Closed,
-		MessengerAppState.OpeningWaitingForDaemon,
-		MessengerAppState.OpeningWaitingForClients,
-	],
-	[MessengerAppState.DeletingClosingDaemon]: [MessengerAppState.DeletingClearingStorage],
-	[MessengerAppState.DeletingClearingStorage]: [
-		MessengerAppState.Closed,
-		MessengerAppState.OpeningWaitingForDaemon,
-	],
-	[MessengerAppState.PreReady]: [MessengerAppState.Ready],
-	[MessengerAppState.StreamDone]: [
-		MessengerAppState.OpeningWaitingForDaemon,
-		MessengerAppState.GetStarted,
-		MessengerAppState.OpeningWaitingForClients,
-	],
-}
-
-export const isExpectedAppStateChange = (
-	former: MessengerAppState,
-	next: MessengerAppState,
-): boolean => {
-	if (former === next) {
-		return true
-	}
-
-	return (expectedAppStateChanges[former] || []).indexOf(next) !== -1
-}
 
 export const defaultPersistentOptions = (): PersistentOptions => {
 	let suggestions: PersistentOptionsSuggestions = {}
@@ -141,25 +55,13 @@ export const defaultPersistentOptions = (): PersistentOptions => {
 }
 
 export const initialState = {
-	appState: MessengerAppState.Init,
-	selectedAccount: null,
-	nextSelectedAccount: null,
-	client: null,
-	protocolClient: null,
 	streamError: null,
-	streamInProgress: null,
-
 	addNotificationListener: () => {},
 	removeNotificationListener: () => {},
 	notificationsInhibitors: [],
-
 	persistentOptions: defaultPersistentOptions(),
 	daemonAddress: '',
-	clearClients: null,
-
-	embedded: true,
 	dispatch: () => {},
-
 	setPersistentOption: async () => {},
 	createNewAccount: async () => {},
 	importAccount: async () => {},
@@ -176,7 +78,6 @@ export const initialState = {
 	accounts: [],
 	addReaction: () => undefined,
 	removeReaction: () => undefined,
-
 	networkConfig: {},
 	setNetworkConfig: () => {},
 	handledLink: false,

--- a/js/packages/store/hooks.ts
+++ b/js/packages/store/hooks.ts
@@ -16,7 +16,6 @@ import { useStyles } from '@berty-tech/styles'
 import { useMessengerContext } from './context'
 import {
 	MessengerActions,
-	MessengerAppState,
 	NotificationsInhibitor,
 	PersistentOptionsKeys,
 	UpdatesProfileNotification,
@@ -29,6 +28,11 @@ import {
 	selectThemeIsDark,
 	selectThemeSelected,
 } from '@berty-tech/redux/reducers/theme.reducer'
+import {
+	MESSENGER_APP_STATE,
+	selectAppState,
+	selectClient,
+} from '@berty-tech/redux/reducers/ui.reducer'
 
 export type Maybe<T> = T | null | undefined
 
@@ -80,8 +84,7 @@ export const useStylesBertyId = ({
 }
 
 export const useMessengerClient = () => {
-	const ctx = useMessengerContext()
-	return ctx.client
+	return useSelector(selectClient)
 }
 
 export const usePersistentOptions = () => {
@@ -90,13 +93,13 @@ export const usePersistentOptions = () => {
 }
 
 export const useThemeColor = () => {
-	const ctx = useMessengerContext()
+	const appState = useSelector(selectAppState)
 	const themeIsDark = useSelector(selectThemeIsDark)
 	const themeSelected = useSelector(selectThemeSelected)
 	const themeCollection = useSelector(selectThemeCollection)
 
 	return React.useMemo(() => {
-		if (!Object.entries(themeCollection).length || ctx.appState === MessengerAppState.GetStarted) {
+		if (!Object.entries(themeCollection).length || appState === MESSENGER_APP_STATE.GET_STARTED) {
 			return colors
 		}
 
@@ -112,7 +115,7 @@ export const useThemeColor = () => {
 			}
 		}
 		return collectionColors
-	}, [ctx.appState, themeCollection, themeIsDark, themeSelected])
+	}, [appState, themeCollection, themeIsDark, themeSelected])
 }
 
 export const useProfileNotification = () => {
@@ -232,7 +235,7 @@ export const useReadEffect = (publicKey: Maybe<string>, timeout: Maybe<number>) 
 	// timeout is the duration (in ms) that the user must stay on the page to set messages as read
 	const navigation = useNavigation()
 
-	const ctx = useMessengerContext()
+	const client = useMessengerClient()
 
 	const conv = useConversation(publicKey)
 	const fake = (conv && (conv as any).fake) || false
@@ -250,7 +253,7 @@ export const useReadEffect = (publicKey: Maybe<string>, timeout: Maybe<number>) 
 				}
 				timeoutID = setTimeout(() => {
 					timeoutID = null
-					ctx.client?.conversationOpen({ groupPk: publicKey }).catch((err: unknown) => {
+					client?.conversationOpen({ groupPk: publicKey }).catch((err: unknown) => {
 						console.warn('failed to open conversation,', err)
 					})
 				}, t)
@@ -275,7 +278,7 @@ export const useReadEffect = (publicKey: Maybe<string>, timeout: Maybe<number>) 
 				}
 			}
 
-			ctx.client?.conversationClose({ groupPk: publicKey }).catch((err: unknown) => {
+			client?.conversationClose({ groupPk: publicKey }).catch((err: unknown) => {
 				console.warn('failed to close conversation,', err)
 			})
 		}
@@ -285,7 +288,7 @@ export const useReadEffect = (publicKey: Maybe<string>, timeout: Maybe<number>) 
 			unsubscribeBlur()
 			handleStop()
 		}
-	}, [ctx.client, fake, navigation, publicKey, timeout])
+	}, [client, fake, navigation, publicKey, timeout])
 }
 
 // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/js/packages/store/providerCallbacks.ts
+++ b/js/packages/store/providerCallbacks.ts
@@ -11,6 +11,7 @@ import {
 import { defaultPersistentOptions } from './context'
 import { accountService, storageRemove, storageGet, storageSet } from './accountService'
 import { MessengerActions, PersistentOptionsUpdate, reducerAction } from './types'
+import { setNextAccount, setStateOnBoardingReady } from '@berty-tech/redux/reducers/ui.reducer'
 
 export const importAccount = async (
 	embedded: boolean,
@@ -27,7 +28,7 @@ export const importAccount = async (
 
 	try {
 		await closeAccountWithProgress(dispatch, reduxDispatch)
-		resp = await importAccountWithProgress(path, dispatch)
+		resp = await importAccountWithProgress(path, dispatch, reduxDispatch)
 	} catch (e) {
 		console.warn('unable to import account', e)
 		return
@@ -43,10 +44,7 @@ export const importAccount = async (
 
 	await refreshAccountList(embedded, dispatch)
 
-	dispatch({
-		type: MessengerActions.SetNextAccount,
-		payload: resp.accountMetadata.accountId,
-	})
+	reduxDispatch(setNextAccount(resp.accountMetadata.accountId))
 }
 
 export const updateAccount = async (
@@ -96,7 +94,7 @@ export const switchAccount = async (
 		console.warn('unable to close account', e)
 		return
 	}
-	dispatch({ type: MessengerActions.SetNextAccount, payload: accountID })
+	reduxDispatch(setNextAccount(accountID))
 }
 
 export const deleteAccount = async (
@@ -122,7 +120,7 @@ export const deleteAccount = async (
 
 	if (!Object.values(accounts).length) {
 		// reset to OnBoarding
-		dispatch({ type: MessengerActions.SetStateOnBoardingReady })
+		reduxDispatch(setStateOnBoardingReady())
 	} else {
 		// open the last opened if an other account exist
 		let accountSelected: beapi.account.IAccountMetadata | null = null
@@ -138,7 +136,7 @@ export const deleteAccount = async (
 				accountSelected = account
 			}
 		}
-		dispatch({ type: MessengerActions.SetNextAccount, payload: accountSelected?.accountId })
+		reduxDispatch(setNextAccount(accountSelected?.accountId))
 	}
 }
 
@@ -158,7 +156,7 @@ export const restart = async (
 		console.warn('unable to close account')
 		return
 	}
-	dispatch({ type: MessengerActions.SetNextAccount, payload: accountID })
+	reduxDispatch(setNextAccount(accountID))
 }
 
 export const setPersistentOption = async (

--- a/js/packages/store/reducer/index.ts
+++ b/js/packages/store/reducer/index.ts
@@ -1,5 +1,4 @@
-import { isExpectedAppStateChange } from '../context'
-import { MessengerAppState, MessengerState, reducerAction } from '../types'
+import { MessengerState, reducerAction } from '../types'
 import { uiReducerActions } from './uiReducer'
 
 export const reducerActions: {
@@ -10,17 +9,7 @@ export const reducerActions: {
 
 export const reducer = (oldState: MessengerState, action: reducerAction): MessengerState => {
 	if (reducerActions[action.type]) {
-		const newState = reducerActions[action.type](oldState, action)
-
-		if (!isExpectedAppStateChange(oldState.appState, newState.appState)) {
-			console.warn(
-				`unexpected app state change from ${MessengerAppState[oldState.appState]} to ${
-					MessengerAppState[newState.appState]
-				}`,
-			)
-		}
-
-		return newState
+		return reducerActions[action.type](oldState, action)
 	}
 
 	console.warn('Unknown action type', action.type)

--- a/js/packages/store/reducer/uiReducer.ts
+++ b/js/packages/store/reducer/uiReducer.ts
@@ -1,5 +1,4 @@
-import { initialState, isExpectedAppStateChange } from '../context'
-import { MessengerAppState, MessengerActions, MessengerState, reducerAction } from '../types'
+import { MessengerActions, MessengerState, reducerAction } from '../types'
 
 export const uiReducerActions: {
 	[key: string]: (oldState: MessengerState, action: reducerAction) => MessengerState
@@ -50,101 +49,10 @@ export const uiReducerActions: {
 		...oldState,
 		persistentOptions: action.payload,
 	}),
-
-	[MessengerActions.SetStateOpeningListingEvents]: (oldState, action) => ({
-		...oldState,
-		client: action.payload.messengerClient || oldState.client,
-		protocolClient: action.payload.protocolClient || oldState.protocolClient,
-		clearClients: action.payload.clearClients || oldState.clearClients,
-		appState: MessengerAppState.OpeningListingEvents,
-	}),
-
-	[MessengerActions.SetStateClosed]: (oldState, _) => {
-		const ret = {
-			...initialState,
-			accounts: oldState.accounts,
-			embedded: oldState.embedded,
-			daemonAddress: oldState.daemonAddress,
-			appState: MessengerAppState.Closed,
-			nextSelectedAccount: oldState.embedded ? oldState.nextSelectedAccount : '0',
-		}
-
-		if (ret.nextSelectedAccount !== null) {
-			return uiReducer(ret, { type: MessengerActions.SetStateOpening })
-		}
-
-		return ret
-	},
-
-	[MessengerActions.SetNextAccount]: (oldState, action) => {
-		if (action.payload === null || action.payload === undefined || !oldState.embedded) {
-			return oldState
-		}
-
-		const ret = {
-			...oldState,
-			nextSelectedAccount: action.payload,
-		}
-
-		return uiReducer(ret, { type: MessengerActions.SetStateClosed })
-	},
-
-	[MessengerActions.SetStateOpening]: (oldState, _action) => {
-		if (oldState.nextSelectedAccount === null) {
-			return oldState
-		}
-		return {
-			...oldState,
-			selectedAccount: oldState.nextSelectedAccount,
-			nextSelectedAccount: null,
-			appState: oldState.embedded
-				? MessengerAppState.OpeningWaitingForDaemon
-				: MessengerAppState.OpeningWaitingForClients,
-		}
-	},
-
-	[MessengerActions.SetStateOpeningClients]: (oldState, _action) => ({
-		...oldState,
-		appState: MessengerAppState.OpeningWaitingForClients,
-	}),
-
-	[MessengerActions.SetStateOpeningGettingLocalSettings]: (oldState, _action) => ({
-		...oldState,
-		appState: MessengerAppState.OpeningGettingLocalSettings,
-	}),
-
-	[MessengerActions.SetStateOpeningMarkConversationsClosed]: (oldState, _) => ({
-		...oldState,
-		appState: MessengerAppState.OpeningMarkConversationsAsClosed,
-	}),
-
-	[MessengerActions.SetStatePreReady]: (oldState, _) => ({
-		...oldState,
-		appState: MessengerAppState.PreReady,
-	}),
-
-	[MessengerActions.SetStateReady]: (oldState, _) => {
-		return {
-			...oldState,
-			appState: MessengerAppState.Ready,
-		}
-	},
-
 	[MessengerActions.SetAccounts]: (oldState, action) => ({
 		...oldState,
 		accounts: action.payload,
 	}),
-
-	[MessengerActions.BridgeClosed]: (oldState, _) => {
-		if (oldState.appState === MessengerAppState.DeletingClosingDaemon) {
-			return {
-				...oldState,
-				appState: MessengerAppState.DeletingClearingStorage,
-			}
-		}
-		return uiReducer(oldState, { type: MessengerActions.SetStateClosed })
-	},
-
 	[MessengerActions.AddNotificationInhibitor]: (oldState, action) => {
 		if (oldState.notificationsInhibitors.includes(action.payload.inhibitor)) {
 			return oldState
@@ -166,45 +74,4 @@ export const uiReducerActions: {
 			),
 		}
 	},
-
-	[MessengerActions.SetCreatedAccount]: (oldState, action) => {
-		return uiReducer(
-			{
-				...oldState,
-				nextSelectedAccount: action?.payload?.accountId,
-				appState: MessengerAppState.OpeningWaitingForClients,
-			},
-			{ type: MessengerActions.SetStateClosed },
-		)
-	},
-
-	[MessengerActions.SetStateStreamInProgress]: (oldState, action) => ({
-		...oldState,
-		streamInProgress: action.payload,
-	}),
-
-	[MessengerActions.SetStateStreamDone]: (oldState, _) => ({
-		...oldState,
-		appState: MessengerAppState.StreamDone,
-		streamInProgress: null,
-	}),
-	[MessengerActions.SetStateOnBoardingReady]: (oldState, _) => ({
-		...oldState,
-		appState: MessengerAppState.GetStarted,
-	}),
-}
-
-export const uiReducer = (oldState: MessengerState, action: reducerAction): MessengerState => {
-	if (uiReducerActions[action.type]) {
-		const newState = uiReducerActions[action.type](oldState, action)
-
-		if (!isExpectedAppStateChange(oldState.appState, newState.appState)) {
-			console.warn(`unexpected app state change from ${oldState.appState} to ${newState.appState}`)
-		}
-
-		return newState
-	}
-
-	console.warn('Unknown action type', action.type)
-	return oldState
 }

--- a/js/packages/store/services.tsx
+++ b/js/packages/store/services.tsx
@@ -9,10 +9,12 @@ import beapi from '@berty-tech/api'
 import { Service } from '@berty-tech/grpc-bridge'
 import * as middleware from '@berty-tech/grpc-bridge/middleware'
 import { bridge as rpcBridge } from '@berty-tech/grpc-bridge/rpc'
-import { ServiceClientType } from '@berty-tech/grpc-bridge/welsh-clients.gen'
+import {
+	ServiceClientType,
+	WelshMessengerServiceClient,
+} from '@berty-tech/grpc-bridge/welsh-clients.gen'
 import { useAccount } from '@berty-tech/react-redux'
 
-import { MessengerState } from './types'
 import { berty } from '@berty-tech/api/root.pb'
 const { PushTokenRequester } = NativeModules
 
@@ -45,8 +47,10 @@ export const useAccountServices = (): Array<beapi.messenger.IServiceToken> => {
 	)
 }
 
-export const servicesAuthViaDefault = async (ctx: MessengerState): Promise<void> => {
-	return servicesAuthViaURL(ctx.protocolClient, bertyOperatedServer)
+export const servicesAuthViaDefault = async (
+	protocolClient: ServiceClientType<beapi.protocol.ProtocolService> | null,
+): Promise<void> => {
+	return servicesAuthViaURL(protocolClient, bertyOperatedServer)
 }
 
 export const servicesAuthViaURL = async (
@@ -119,9 +123,9 @@ export const servicesAuthViaURL = async (
 }
 
 export const replicateGroup = async (
-	ctx: MessengerState,
 	conversationPublicKey: string,
 	tokenID: string,
+	client: WelshMessengerServiceClient | null,
 ): Promise<void> => {
 	if (
 		!(await new Promise(resolve => {
@@ -143,12 +147,12 @@ export const replicateGroup = async (
 		return
 	}
 
-	if (!ctx.client) {
+	if (!client) {
 		return
 	}
 
 	try {
-		await ctx.client?.replicationServiceRegisterGroup({
+		await client?.replicationServiceRegisterGroup({
 			tokenId: tokenID,
 			conversationPublicKey: conversationPublicKey,
 		})

--- a/js/packages/store/types.ts
+++ b/js/packages/store/types.ts
@@ -1,24 +1,6 @@
 import { Dispatch } from 'react'
 
 import beapi from '@berty-tech/api'
-import { ServiceClientType } from '@berty-tech/grpc-bridge/welsh-clients.gen'
-
-export enum MessengerAppState {
-	Init = 0,
-	Closed,
-	OpeningWaitingForDaemon,
-	OpeningWaitingForClients,
-	OpeningListingEvents,
-	OpeningGettingLocalSettings,
-	OpeningMarkConversationsAsClosed,
-	GetStarted,
-	Ready,
-	ClosingDaemon,
-	DeletingClosingDaemon,
-	DeletingClearingStorage,
-	StreamDone,
-	PreReady,
-}
 
 // returns true if the notification should be inhibited
 export type NotificationsInhibitor = (
@@ -32,30 +14,17 @@ export type StreamInProgress = {
 }
 
 export type MessengerState = {
-	selectedAccount: string | null
-	nextSelectedAccount: string | null
 	daemonAddress: string
-	streamInProgress: StreamInProgress | null
-
-	appState: MessengerAppState
-	client: ServiceClientType<beapi.messenger.MessengerService> | null
-	protocolClient: ServiceClientType<beapi.protocol.ProtocolService> | null
 	streamError: any
-
 	addNotificationListener: (cb: (evt: any) => void) => void
 	removeNotificationListener: (cb: (...args: any[]) => void) => void
 	notificationsInhibitors: NotificationsInhibitor[]
-
 	persistentOptions: PersistentOptions
 	accounts: beapi.account.IAccountMetadata[]
-	clearClients: (() => Promise<void>) | null
-
-	embedded: boolean
 	dispatch: Dispatch<{
 		type: MessengerActions
 		payload?: any
 	}>
-
 	setPersistentOption: (arg0: PersistentOptionsUpdate) => Promise<void>
 	createNewAccount: (arg0?: beapi.account.INetworkConfig) => Promise<void>
 	importAccount: (arg0: string) => Promise<void>
@@ -75,7 +44,6 @@ export type MessengerState = {
 		targetCID: string,
 		emoji: string,
 	) => Promise<beapi.messenger.Interact.Reply> | undefined
-
 	debugMode: boolean
 	setDebugMode: (value: boolean) => void
 	networkConfig: beapi.account.INetworkConfig


### PR DESCRIPTION
 #### WIP

Move every ui reducers modifying the appState, all those states from messenger state are also modified and moved to Redux:
- appState
- streamInProgress
- clearClients
- protocolClient
- client
- embedded
- nextSelectedAccount
- selectedAccount


#### TODO

- find a name for this reducer or merge it with messenger reducer (currently "ui reducer")
- move rest of the messenger state to Redux
- convert functions of messenger state to Redux reducers
- move persistent option keys to corresponding Redux reducers
- move types from old store to Redux store
- clean old store files