### PR TITLE
build: add `clean` to the top-level `Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,3 +53,14 @@ doctor:
 doctor.verbose:
 	cd go && $(MAKE) doctor.verbose
 .PHONY: doctor.verbose
+
+
+clean:
+	-cd tool/berty-mini-local-helper; $(MAKE) clean
+	-cd tool/tyber; $(MAKE) clean
+	-cd tool/deployments/welcomebot; $(MAKE) clean
+	-cd tool/deployments/testbot; $(MAKE) clean
+	-cd go; $(MAKE) clean
+	-cd docs; $(MAKE) clean
+	-cd js; $(MAKE) clean
+.PHONY: clean


### PR DESCRIPTION
Self descriptive.

Produced with:
```bash
find . -type f | grep Makefile$ | grep -v ^./Makefile$ | cut -c 3- | while read f; do [[ -z $(grep -i clean ${f} | head -n1) ]] || echo -e "\t-cd $(dirname ${f}); \$(MAKE) clean"; done
```
So I'm confident to not have missed any sub `clean`.