### PR TITLE
fix: request camera and gallery permissions in chat menu footer

### DIFF
--- a/js/packages/berty-i18n/locale/en-US/messages.json
+++ b/js/packages/berty-i18n/locale/en-US/messages.json
@@ -622,6 +622,10 @@
 			"title": "Audio messages",
 			"desc": "To send audio message to your contacts, you need to allow microphone permission to Berty app."
 		},
+		"gallery": {
+			"title": "Image messaging",
+			"desc": "To send image message to your contacts, you need to allow gallery permission to Berty app."
+		},
 		"button-labels": {
 			"allow": "Allow",
 			"settings": "Go to Settings"

--- a/js/packages/berty-i18n/locale/fr-FR/messages.json
+++ b/js/packages/berty-i18n/locale/fr-FR/messages.json
@@ -616,6 +616,10 @@
 			"title": "Messages audio",
 			"desc": "Pour envoyer des messages audio à vos contacts, vous devez autoriser l'application Berty à accéder au microphone."
 		},
+		"gallery": {
+			"title": "Galerie d'images",
+			"desc": "Pour envoyer des messages images à vos contacts, vous devez autoriser l'application Berty à accéder à la galerie d'images."
+		},
 		"button-labels": {
 			"allow": "Autoriser",
 			"settings": "Accéder aux paramètres"

--- a/js/packages/components/chat/EnableNotificationsButton.tsx
+++ b/js/packages/components/chat/EnableNotificationsButton.tsx
@@ -99,10 +99,11 @@ const EnableNotificationsButton: React.FC<{
 			onPress={async () => {
 				try {
 					// Get or ask for permission
-					const status = await rnutil.checkPermissions('notification', navigate)
+					const status = await rnutil.checkPermissions('notification')
 					if (status !== RESULTS.GRANTED && status !== RESULTS.LIMITED) {
 						await new Promise(resolve =>
-							rnutil.checkPermissions('notification', navigate, {
+							rnutil.checkPermissions('notification', {
+								navigate,
 								navigateToPermScreenOnProblem: true,
 								onComplete: () =>
 									new Promise(subResolve => {

--- a/js/packages/components/chat/footer/ChatFooter.tsx
+++ b/js/packages/components/chat/footer/ChatFooter.tsx
@@ -19,13 +19,6 @@ import { useNavigation } from '@berty-tech/navigation'
 import rnutil from '@berty-tech/rnutil'
 import { useAppDispatch, useAppSelector, useMedias, useConversation } from '@berty-tech/react-redux'
 import { setChecklistItemDone } from '@berty-tech/redux/reducers/checklist.reducer'
-
-import { useReplyReaction } from '../ReplyReactionContext'
-import { CameraButton, MoreButton, RecordButton, SendButton } from './ChatFooterButtons'
-import { ChatTextInput } from './ChatTextInput'
-import { RecordComponent } from './record/RecordComponent'
-import { AddFileMenu } from './file-uploads/AddFileMenu'
-import { EmojiBanner } from './emojis/EmojiBanner'
 import {
 	selectChatInputIsFocused,
 	selectChatInputIsSending,
@@ -33,6 +26,13 @@ import {
 	setChatInputIsSending,
 	setChatInputSelection,
 } from '@berty-tech/redux/reducers/chatInputsVolatile.reducer'
+
+import { useReplyReaction } from '../ReplyReactionContext'
+import { CameraButton, MoreButton, RecordButton, SendButton } from './ChatFooterButtons'
+import { ChatTextInput } from './ChatTextInput'
+import { RecordComponent } from './record/RecordComponent'
+import { AddFileMenu } from './file-uploads/AddFileMenu'
+import { EmojiBanner } from './emojis/EmojiBanner'
 
 export type ChatFooterProps = {
 	convPK: string
@@ -67,7 +67,7 @@ export const ChatFooter: React.FC<ChatFooterProps> = React.memo(
 
 		// local
 		const isFocused = useAppSelector(state => selectChatInputIsFocused(state, convPK))
-		const [showAddFileMenu, setShowAddFileMenu] = React.useState(false)
+		const [addFileMenuVisible, setAddFileMenuVisible] = React.useState(false)
 
 		// computed
 		const isFake = !!(conversation as any)?.fake
@@ -148,7 +148,7 @@ export const ChatFooter: React.FC<ChatFooterProps> = React.memo(
 				if (newMedias) {
 					await sendMessageBouncy(newMedias)
 				}
-				setShowAddFileMenu(false)
+				setAddFileMenuVisible(false)
 			},
 			[sendMessageBouncy],
 		)
@@ -193,7 +193,8 @@ export const ChatFooter: React.FC<ChatFooterProps> = React.memo(
 		)
 
 		const handlePressCamera = React.useCallback(async () => {
-			const permissionStatus = await rnutil.checkPermissions('camera', navigate, {
+			const permissionStatus = await rnutil.checkPermissions('camera', {
+				navigate,
 				navigateToPermScreenOnProblem: true,
 			})
 			if (permissionStatus !== RESULTS.GRANTED) {
@@ -223,8 +224,8 @@ export const ChatFooter: React.FC<ChatFooterProps> = React.memo(
 		}, [navigate, prepareMediaAndSend])
 
 		const handlePressMore = React.useCallback(() => {
-			setShowAddFileMenu(true)
-		}, [setShowAddFileMenu])
+			setAddFileMenuVisible(true)
+		}, [setAddFileMenuVisible])
 
 		const handleTextChange = React.useCallback(
 			(text: string) => {
@@ -263,18 +264,17 @@ export const ChatFooter: React.FC<ChatFooterProps> = React.memo(
 						backgroundColor: colors['main-background'],
 					}}
 				>
-					{showAddFileMenu && (
-						<AddFileMenu
-							onClose={handleCloseFileMenu}
-							setSending={val => {
-								setSending(val)
-								if (val) {
-									setShowAddFileMenu(false)
-								}
-							}}
-							sending={sending}
-						/>
-					)}
+					<AddFileMenu
+						visible={addFileMenuVisible}
+						onClose={handleCloseFileMenu}
+						setSending={val => {
+							setSending(val)
+							if (val) {
+								setAddFileMenuVisible(false)
+							}
+						}}
+						sending={sending}
+					/>
 					<RecordComponent
 						component={recordIcon}
 						convPk={convPK}

--- a/js/packages/components/chat/footer/record/RecordComponent.tsx
+++ b/js/packages/components/chat/footer/record/RecordComponent.tsx
@@ -44,7 +44,8 @@ const voiceMemoSampleRate = 22050
 const voiceMemoFormat = 'aac'
 
 const acquireMicPerm = async (navigate: any): Promise<MicPermStatus> => {
-	const permissionStatus = await rnutil.checkPermissions('audio', navigate, {
+	const permissionStatus = await rnutil.checkPermissions('audio', {
+		navigate,
 		navigateToPermScreenOnProblem: true,
 	})
 	if (permissionStatus === RESULTS.GRANTED) {

--- a/js/packages/components/main/home/Home.tsx
+++ b/js/packages/components/main/home/Home.tsx
@@ -311,7 +311,8 @@ export const Home: ScreenFC<'Main.Home'> = ({ navigation: { navigate } }) => {
 					fill={colors['secondary-text']}
 					backgroundColor={colors['main-background']}
 					onPress={async () => {
-						await rnutil.checkPermissions('camera', navigate, {
+						await rnutil.checkPermissions('camera', {
+							navigate,
 							navigateNext: 'Main.Scan',
 							navigateToPermScreenOnProblem: true,
 							onComplete: async () =>

--- a/js/packages/components/onboarding/AdvancedSettings.tsx
+++ b/js/packages/components/onboarding/AdvancedSettings.tsx
@@ -287,7 +287,8 @@ const Proximity: React.FC<{
 								if (status === RESULTS.GRANTED) {
 									setNewConfigProximityTransport()
 								} else {
-									await rnutil.checkPermissions('p2p', navigate, {
+									await rnutil.checkPermissions('p2p', {
+										navigate,
 										navigateToPermScreenOnProblem: true,
 										onComplete: async () => setNewConfigProximityTransport(),
 									})

--- a/js/packages/components/onboarding/CreateAccount.tsx
+++ b/js/packages/components/onboarding/CreateAccount.tsx
@@ -130,7 +130,6 @@ const CreateAccountBody = () => {
 	const colors = useThemeColor()
 	const [defaultName, setDefaultName] = React.useState('')
 	const [isFinished, setIsFinished] = useState(false)
-	const { navigate } = useNavigation()
 	const { t } = useTranslation()
 	const headerHeight = useHeaderHeight()
 	const insets = useSafeAreaInsets()
@@ -164,9 +163,7 @@ const CreateAccountBody = () => {
 					loop={false}
 					onAnimationFinish={async () => {
 						Vibration.vibrate(500)
-						await rnutil.checkPermissions('p2p', navigate, {
-							navigateToPermScreenOnProblem: false,
-						})
+						await rnutil.checkPermissions('p2p')
 					}}
 					style={{ position: 'absolute', width: '100%' }}
 				/>

--- a/js/packages/navigation/types.ts
+++ b/js/packages/navigation/types.ts
@@ -3,6 +3,7 @@ import { PermissionStatus } from 'react-native-permissions'
 
 import beapi from '@berty-tech/api'
 import { StackScreenProps } from '@react-navigation/stack'
+import { PermissionType } from '@berty-tech/rnutil/checkPermissions'
 
 export type ScreensParams = {
 	// Onboarding
@@ -19,10 +20,10 @@ export type ScreensParams = {
 	'Main.ContactRequest': { contactId: string }
 	'Main.Scan': undefined
 	'Main.Permissions': {
-		permissionType: 'p2p' | 'audio' | 'notification' | 'camera'
+		permissionType: PermissionType
 		permissionStatus: PermissionStatus
 		navigateNext: keyof ScreensParams
-		onComplete?: () => Promise<void>
+		onComplete?: (() => Promise<void>) | (() => void)
 	}
 
 	// Create group

--- a/js/packages/rnutil/checkPermissions.ts
+++ b/js/packages/rnutil/checkPermissions.ts
@@ -1,52 +1,76 @@
 import { Platform } from 'react-native'
-import { check, checkNotifications, PERMISSIONS, RESULTS } from 'react-native-permissions'
+import {
+	check,
+	checkNotifications,
+	Permission,
+	PERMISSIONS,
+	PermissionStatus,
+	request,
+	requestNotifications,
+	RESULTS,
+} from 'react-native-permissions'
+
+export type PermissionType = 'p2p' | 'audio' | 'notification' | 'camera' | 'gallery'
+
+export const permissionsByDevice: Record<string, Permission> = {
+	p2p:
+		Platform.OS === 'ios'
+			? PERMISSIONS.IOS.BLUETOOTH_PERIPHERAL
+			: PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION,
+	camera: Platform.OS === 'ios' ? PERMISSIONS.IOS.CAMERA : PERMISSIONS.ANDROID.CAMERA,
+	audio: Platform.OS === 'ios' ? PERMISSIONS.IOS.MICROPHONE : PERMISSIONS.ANDROID.RECORD_AUDIO,
+	gallery:
+		Platform.OS === 'ios'
+			? PERMISSIONS.IOS.PHOTO_LIBRARY
+			: PERMISSIONS.ANDROID.READ_EXTERNAL_STORAGE,
+}
+
+export const getPermissionStatus = async (
+	permissionType: PermissionType,
+): Promise<PermissionStatus> => {
+	if (permissionType === 'notification') {
+		return (await checkNotifications()).status
+	}
+	return await check(permissionsByDevice[permissionType])
+}
+
+export const requestPermission = async (
+	permissionType: PermissionType,
+): Promise<PermissionStatus> => {
+	if (permissionType === 'notification') {
+		return (await requestNotifications(['alert', 'sound'])).status
+	}
+	return await request(permissionsByDevice[permissionType])
+}
 
 export const checkPermissions = async (
-	permissionType: 'p2p' | 'audio' | 'notification' | 'camera',
-	navigate: any,
+	permissionType: PermissionType,
 	options?: {
+		navigate: any
 		navigateToPermScreenOnProblem?: boolean
 		navigateNext?: string
-		onComplete?: () => Promise<void>
+		onComplete?: (() => Promise<void>) | (() => void)
 	},
-) => {
+): Promise<PermissionStatus | undefined> => {
 	let status
 	try {
-		if (permissionType === 'notification') {
-			const res = await checkNotifications()
-			status = res.status
-		} else if (permissionType === 'p2p') {
-			status = await check(
-				Platform.OS === 'ios'
-					? PERMISSIONS.IOS.BLUETOOTH_PERIPHERAL
-					: PERMISSIONS.ANDROID.ACCESS_FINE_LOCATION,
-			)
-		} else if (permissionType === 'camera') {
-			status = await check(
-				Platform.OS === 'ios' ? PERMISSIONS.IOS.CAMERA : PERMISSIONS.ANDROID.CAMERA,
-			)
-		} else if (permissionType === 'audio') {
-			status = await check(
-				Platform.OS === 'ios' ? PERMISSIONS.IOS.MICROPHONE : PERMISSIONS.ANDROID.RECORD_AUDIO,
-			)
-		}
+		status = await getPermissionStatus(permissionType)
 	} catch (err) {
 		console.warn('Check permission failed:', err)
 	}
 
-	console.log('Permission status:', status, options)
 	if (
 		(status === RESULTS.DENIED || status === RESULTS.BLOCKED) &&
 		options?.navigateToPermScreenOnProblem
 	) {
-		navigate('Main.Permissions', {
+		options.navigate('Main.Permissions', {
 			permissionType,
 			permissionStatus: status,
 			navigateNext: options?.navigateNext,
 			onComplete: options?.onComplete,
 		})
 	} else if (options?.navigateNext) {
-		navigate(options?.navigateNext, {})
+		options.navigate(options?.navigateNext, {})
 	}
 
 	return status

--- a/js/packages/store/effectableCallbacks.ts
+++ b/js/packages/store/effectableCallbacks.ts
@@ -10,6 +10,7 @@ import {
 	setStateStreamDone,
 	setStateStreamInProgress,
 } from '@berty-tech/redux/reducers/ui.reducer'
+import { RESULTS } from 'react-native-permissions'
 
 export const closeAccountWithProgress = async (
 	dispatch: (arg0: reducerAction) => void,
@@ -124,9 +125,7 @@ export const refreshAccountList = async (
 export const getNetworkConfigurationFromPreset = async (
 	preset: beapi.account.NetworkConfigPreset | null | undefined,
 ): Promise<beapi.account.INetworkConfig> => {
-	const hasBluetoothPermission =
-		(await rnutil.checkPermissions('p2p', null, { navigateToPermScreenOnProblem: false })) ===
-		'granted'
+	const hasBluetoothPermission = (await rnutil.checkPermissions('p2p')) === RESULTS.GRANTED
 
 	const configForPreset = await accountService.networkConfigGetPreset({
 		preset: preset || beapi.account.NetworkConfigPreset.Undefined,


### PR DESCRIPTION
This PR makes the user navigate to a permission screen after pressing on gallery and camera chat footer buttons (after clicking on "+") if he doesn't have those permissions.

It could need a lottie file for gallery permission, camera lottie file is temporary used instead.

The behavior can still be: asking for permission without navigating to permissions screen.

### before

![permissionBefore](https://user-images.githubusercontent.com/31244713/153576341-4c422164-d84c-4f86-a55b-b323f8536c26.gif)

### after

![permissionafter](https://user-images.githubusercontent.com/31244713/153576366-0894c2ea-6648-4c26-b46d-e295f93e11e9.gif)


