### PR TITLE
fix: fix crash on MacOS with the BLE driver

### DIFF
--- a/go/internal/ble-driver/BleInterface_darwin.m
+++ b/go/internal/ble-driver/BleInterface_darwin.m
@@ -16,7 +16,7 @@ extern void BLEReceiveFromPeer(char *, void *, unsigned long);
 extern void BLELog(enum level level, const char *message);
 
 static BleManager *manager = nil;
-BOOL gBLEUseExternalLogger = FALSE;
+BOOL useExternalLogger = FALSE;
 
 void handleException(NSException* exception) {
     NSLog(@"Unhandled exception %@", exception);
@@ -27,7 +27,7 @@ BleManager* getManager(void) {
     {
         if(!manager) {
             NSLog(@"BleManager: initialization");
-            manager = [[BleManager alloc] initDriver:gBLEUseExternalLogger];
+            manager = [[BleManager alloc] initDriver:useExternalLogger];
         }
     }
     return manager;
@@ -122,7 +122,7 @@ void BLECloseConnWithPeer(char *remotePID) {
 
 // Use BLEBridgeLog to write logs to the external logger
 void BLEUseExternalLogger(void) {
-    gBLEUseExternalLogger = TRUE;
+    useExternalLogger = TRUE;
 }
 
 #pragma mark - outgoing API functions

--- a/go/internal/ble-driver/BleManager_darwin.h
+++ b/go/internal/ble-driver/BleManager_darwin.h
@@ -45,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nonnull) CBCentralManager* cManager;
 @property (nonatomic, strong, nonnull) CBPeripheralManager* pManager;
 @property (nonatomic, strong, nonnull) CountDownLatch *bleOn;
-@property (nonatomic, strong, nonnull) CountDownLatch *serviceAdded;
+@property (nonatomic, strong, nonnull) CountDownLatch *serviceLatch;
 @property (nonatomic, strong, nullable) NSTimer *scannerTimer;
 @property (nonatomic, readwrite, getter=isScanning) BOOL scanning;
 @property (nonatomic, strong, nullable) WriteDataCache *writeCache;

--- a/go/internal/ble-driver/BleQueue.h
+++ b/go/internal/ble-driver/BleQueue.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface BleQueue : NSObject
 
-@property (nonatomic, strong, nonnull) dispatch_queue_t queue;
+@property (nonatomic, assign, nonnull) dispatch_queue_t queue;
 @property (nonatomic, strong, nonnull) Logger *logger;
 @property (nonatomic, strong, nonnull) NSMutableArray *tasks;
 @property (readwrite) BOOL taskQueueBusy;

--- a/go/internal/ble-driver/BleQueue.m
+++ b/go/internal/ble-driver/BleQueue.m
@@ -16,7 +16,7 @@
     
     if (self) {
         _tasks = [[NSMutableArray alloc] init];
-        _queue = [queue retain];
+        _queue = queue;
         _logger = [logger retain];
     }
     
@@ -26,7 +26,6 @@
 - (void)dealloc {
     [_tasks removeAllObjects];
     [_tasks release];
-    [_queue release];
     [_logger release];
 
     [super dealloc];

--- a/go/internal/ble-driver/CountDownLatch_darwin.h
+++ b/go/internal/ble-driver/CountDownLatch_darwin.h
@@ -14,8 +14,8 @@
 @interface CountDownLatch : NSObject
 
 @property (nonatomic, assign, readwrite) NSInteger count;
-@property (atomic, strong, readwrite) dispatch_semaphore_t semaphore;
-@property (nonatomic, strong) dispatch_queue_t dispatch_queue;
+@property (atomic, assign, readwrite) dispatch_semaphore_t semaphore;
+@property (nonatomic, assign) dispatch_queue_t dispatch_queue;
 @property (readwrite) BOOL timeout;
 
 - (instancetype)initCount:(NSInteger)count;

--- a/go/internal/ble-driver/CountDownLatch_darwin.m
+++ b/go/internal/ble-driver/CountDownLatch_darwin.m
@@ -37,15 +37,19 @@
 
 - (void)incrementCount {
     dispatch_async(self.dispatch_queue, ^{
-        self.count++;
+        @synchronized (self.semaphore) {
+            self.count++;
+        }
     });
 }
 
 - (void)countDown {
     dispatch_async(self.dispatch_queue, ^{
-        self.count--;
-        if (self.count == 0) {
-            dispatch_semaphore_signal(self.semaphore);
+        @synchronized (self.semaphore) {
+            self.count--;
+            if (self.count == 0) {
+                dispatch_semaphore_signal(self.semaphore);
+            }
         }
     });
 }

--- a/go/internal/ble-driver/Logger.h
+++ b/go/internal/ble-driver/Logger.h
@@ -22,7 +22,7 @@ typedef NS_ENUM(uint8_t, level) {
 
 @interface BLE_Logger : NSObject
 
-@property (nonatomic, strong, nonnull) os_log_t logger;
+@property (nonatomic, assign, nonnull) os_log_t logger;
 @property (readwrite) BOOL showSensitiveData;
 @property (readwrite) BOOL useExternalLogger;
 


### PR DESCRIPTION
The crash is caused by CBCentralManager and CBPeripheralManager which don't allow a custom dispatch queue.

<!-- Thank you for your contribution! ❤️ -->