### PR TITLE
feat: enable HolePunching and expose it as a flag

### DIFF
--- a/go/internal/initutil/manager.go
+++ b/go/internal/initutil/manager.go
@@ -135,6 +135,7 @@ type Manager struct {
 			DevicePushKeyPath      string        `json:"DevicePushKeyPath,omitempty"`
 			ServiceInsecureMode    bool          `json:"ServiceInsecureMode,omitempty"`
 			RendezvousRotationBase time.Duration `json:"RendezvousRotationBase,omitempty"`
+			EnableHolePunching     bool          `json:"EnableHolePunching,omitempty"`
 
 			// internal
 			DisableDiscoverFilterAddrs bool


### PR DESCRIPTION
This has been added in go-ipfs `v0.11.0` and will be defaulted to true in the soon to be released `v0.13.0`, you can safely enable this. (the reason it wasn't enabled by default is that the network first needed enough people to upgrade their nodes to a version that supports Circuit V2).

It has works more often than not efficiency in go-ipfs. It helps with non-symmetric nats that doesn't support UPNP (which covers most home networks). Many cellular carrier use symmetric nats but there is also a non negligible amount that use hole punchable NATs so it should help there too.

You can read more about it here: https://github.com/libp2p/specs/blob/master/relay/DCUtR.md

### Mobile:

I forgot how to do options to mobiles.

I don't think it's needed to expose that to the users.
But on mobile it should default to `true` (that is taken careoff by the flag framework right now which I recall if it runs on mobile or not).