### PR TITLE
fix: mini: Trim command spaces after TrimPrefix

### DIFF
--- a/go/cmd/berty/mini/view_group.go
+++ b/go/cmd/berty/mini/view_group.go
@@ -60,7 +60,7 @@ func (v *groupView) commandParser(ctx context.Context, input string) error {
 					return errors.New("not implemented")
 				}
 
-				trimmed := strings.TrimPrefix(input, prefix+" ")
+				trimmed := strings.TrimSpace(strings.TrimPrefix(input, prefix))
 				return attrs.cmd(ctx, v, trimmed)
 			}
 		}


### PR DESCRIPTION
In `func (v *groupView) commandParser`, the prefix of a command like "/debug store group_pk metadata" is removed with:

    strings.TrimPrefix(input, prefix+" ")

This is so that the `cmd` parameter for the command only has the args like "group_pk metadata" without the command prefix. But if the user simply enters "/debug store" then the call to `TrimPrefix` does not match. (There is no space after the prefix.) Therefore the `cmd` parameter for the command contains the prefix "/debug store". But `cmd` should be the empty string in this case. This commit changes to call `TrimPrefix` only with the prefix, and to trim the spaces after.

Signed-off-by: Jeff Thompson <jeff@thefirst.org>

<!-- Thank you for your contribution! ❤️ -->