### PR TITLE
fix: js: In README, remove unneeded/outdated gomobile install instructions

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -91,7 +91,6 @@ $ make web.debug
 - [iOS dev reqs](#ios-dev-requirements) **and/or** [Android dev reqs](#android-dev-requirements)
 - [Watchman](https://facebook.github.io/watchman/docs/install/) to enable live reloading
 - [Docker Desktop](https://docs.docker.com/docker-for-mac/install/)
-- The [gomobile package](https://godoc.org/golang.org/x/mobile/cmd/gomobile): `go get golang.org/x/mobile/cmd/gomobile/... && gomobile init`
 
 💡 `$GOPATH` may need to be set explicitly (usually `$HOME/go`)
 


### PR DESCRIPTION
With go 1.18, the instructions for `go get golang.org/x/mobile/cmd/gomobile/...` don't work anymore. But the Makefile already does gomobile init, right? On a fresh macOS, I am able to do make and run android.debug without explicitly doing gomobile init. So, remove the unneeded and outdated install instructions.

(If I'm wrong and it is necessary to do gomobile init, outside of running make, then we can close this pull request.)