### PR TITLE
fix: go/mini: Clarify message for compatibility with the app.

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -115,7 +115,7 @@ USAGE
 
 SUBCOMMANDS
   daemon        start a full Berty instance (Berty Protocol + Berty Messenger)
-  mini          start a terminal-based mini berty client (not fully compatible with the app)
+  mini          start a terminal-based mini berty client (some messaging features not compatible with the app)
   banner        print the Berty banner of the day
   version       print software version
   info          display system info

--- a/go/cmd/berty/mini.go
+++ b/go/cmd/berty/mini.go
@@ -27,7 +27,7 @@ func miniCommand() *ffcli.Command {
 
 	return &ffcli.Command{
 		Name:           "mini",
-		ShortHelp:      "start a terminal-based mini berty client (not fully compatible with the app)",
+		ShortHelp:      "start a terminal-based mini berty client (some messaging features not compatible with the app)",
 		ShortUsage:     "berty [global flags] mini [flags]",
 		FlagSetBuilder: fsBuilder,
 		Options:        ffSubcommandOptions(),


### PR DESCRIPTION
When I read "not fully compatible with the app" I thought that maybe they use different crypto protocols, or maybe I couldn't exchange contact invitations. But it is not that bad. This pull requests softens the message.