### PR TITLE
fix: push notifications

### DIFF
--- a/go/pkg/bertymessenger/api.go
+++ b/go/pkg/bertymessenger/api.go
@@ -1748,8 +1748,8 @@ func (svc *service) interactionDelayedActions(id ipfscid.Cid, groupPK []byte) {
 		return
 	}
 
-	// TODO: lower delay?
-	time.Sleep(time.Second * 2)
+	// TODO: check ack before sending push
+	// time.Sleep(time.Second * 2)
 
 	i, err := svc.db.GetInteractionByCID(id.String())
 	if err != nil {

--- a/go/pkg/bertymessenger/api.go
+++ b/go/pkg/bertymessenger/api.go
@@ -696,6 +696,7 @@ func (svc *service) ConversationCreate(ctx context.Context, req *messengertypes.
 		if err != nil {
 			return nil, errcode.ErrDeserialization.Wrap(err)
 		}
+
 		go svc.interactionDelayedActions(cid, gpk)
 	}
 
@@ -1031,7 +1032,9 @@ func (svc *service) Interact(ctx context.Context, req *messengertypes.Interact_R
 		tyber.LogTraceEnd(ctx, svc.logger, "Interacted successfully", tyber.WithDetail("CID", cid.String()))
 	}
 
-	go svc.interactionDelayedActions(cid, gpkb)
+	if payloadType == messengertypes.AppMessage_TypeUserMessage || payloadType == messengertypes.AppMessage_TypeGroupInvitation {
+		go svc.interactionDelayedActions(cid, gpkb)
+	}
 
 	return &messengertypes.Interact_Reply{CID: cid.String()}, nil
 }
@@ -1751,25 +1754,13 @@ func (svc *service) interactionDelayedActions(id ipfscid.Cid, groupPK []byte) {
 	// TODO: check ack before sending push
 	// time.Sleep(time.Second * 2)
 
-	i, err := svc.db.GetInteractionByCID(id.String())
-	if err != nil {
-		svc.logger.Error("unable to retrieve interaction", zap.Error(err), logutil.PrivateString("cid", id.String()))
-		return
-	}
-
-	if i.Type != messengertypes.AppMessage_TypeUserMessage && i.Type != messengertypes.AppMessage_TypeGroupInvitation {
-		// Nothing to do, move along
-		svc.logger.Debug("push: nothing to send, invalid interaction type", logutil.PrivateString("cid", id.String()), zap.String("type", i.Type.String()))
-		return
-	}
-
 	// TODO: avoid pushing acknowledged events
 	// TODO: watch for currently active devices?
 	// svc.handlerMutex.Lock()
 	// defer svc.handlerMutex.Unlock()
 
 	svc.logger.Info("attempting to push interaction", logutil.PrivateString("cid", id.String()))
-	_, err = svc.protocolClient.PushSend(svc.ctx, &protocoltypes.PushSend_Request{
+	_, err := svc.protocolClient.PushSend(svc.ctx, &protocoltypes.PushSend_Request{
 		CID:            id.Bytes(),
 		GroupPublicKey: groupPK,
 	})

--- a/go/pkg/bertyprotocol/api_push.go
+++ b/go/pkg/bertyprotocol/api_push.go
@@ -76,12 +76,12 @@ func (s *service) getPushClient(host string) (pushtypes.PushServiceClient, error
 	// retry policies
 	connectParams := grpc.WithConnectParams(grpc.ConnectParams{
 		Backoff: backoff.Config{
-			BaseDelay:  time.Second * 5,
+			BaseDelay:  1.0 * time.Second,
 			Multiplier: 1.5,
-			Jitter:     2,
-			MaxDelay:   time.Second * 60,
+			Jitter:     0.2,
+			MaxDelay:   60 * time.Second,
 		},
-		MinConnectTimeout: time.Second * 20,
+		MinConnectTimeout: time.Second * 10,
 	})
 
 	cc, err := grpc.DialContext(s.ctx, host, creds, connectParams)
@@ -150,7 +150,7 @@ func (s *service) PushSend(ctx context.Context, request *protocoltypes.PushSend_
 				Envelope:  sealedMessageEnvelope,
 				Priority:  pushtypes.PushServicePriority_PushPriorityNormal,
 				Receivers: pushTokens,
-			})
+			}, grpc.WaitForReady(true))
 			if err != nil {
 				s.logger.Error("error while dialing push server", logutil.PrivateString("push-server", serverAddr), zap.Error(err))
 				return

--- a/go/pkg/bertyprotocol/api_push.go
+++ b/go/pkg/bertyprotocol/api_push.go
@@ -8,12 +8,14 @@ import (
 	"encoding/base64"
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/ipfs/go-cid"
 	"github.com/libp2p/go-libp2p-core/crypto"
 	"go.uber.org/zap"
 	"golang.org/x/crypto/nacl/box"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/backoff"
 	"google.golang.org/grpc/credentials"
 
 	"berty.tech/berty/v2/go/internal/cryptoutil"
@@ -71,10 +73,22 @@ func (s *service) getPushClient(host string) (pushtypes.PushServiceClient, error
 		creds = grpc.WithTransportCredentials(tlsconfig)
 	}
 
-	cc, err := grpc.DialContext(s.ctx, host, creds)
+	// retry policies
+	connectParams := grpc.WithConnectParams(grpc.ConnectParams{
+		Backoff: backoff.Config{
+			BaseDelay:  time.Second * 5,
+			Multiplier: 1.5,
+			Jitter:     2,
+			MaxDelay:   time.Second * 60,
+		},
+		MinConnectTimeout: time.Second * 20,
+	})
+
+	cc, err := grpc.DialContext(s.ctx, host, creds, connectParams)
 	if err != nil {
 		return nil, err
 	}
+	s.pushClients[host] = cc
 
 	// monitor push client state
 	go monitorPushServer(s.ctx, cc, s.logger)


### PR DESCRIPTION
- [x] Add a timer on the onboarding screen to skip the push server registration to avoid hangs
- [x] Add some retry policies (backoff) on the GRPC client that sends push notifications
- [x] Remove a sleep of 2 seconds before sending a push

<!-- Thank you for your contribution! ❤️ -->