### PR TITLE
fix: gomobile cached build error on ios

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -134,6 +134,6 @@ replace (
 	github.com/multiformats/go-multiaddr => github.com/berty/go-multiaddr v0.4.2-0.20220126184027-53e56f02fb68 // tmp, required for Android SDK30
 	github.com/mutecomm/go-sqlcipher/v4 => github.com/berty/go-sqlcipher/v4 v4.0.0-20211104165006-2c524b646cf0
 	github.com/peterbourgon/ff/v3 => github.com/moul/ff/v3 v3.0.1 // temporary, see https://github.com/peterbourgon/ff/pull/67, https://github.com/peterbourgon/ff/issues/68
-	golang.org/x/mobile => github.com/aeddi/mobile v0.0.4 // temporary, see https://github.com/golang/mobile/pull/58
+	golang.org/x/mobile => github.com/aeddi/mobile v0.0.6 // temporary, see https://github.com/golang/mobile/pull/58
 
 )

--- a/go.sum
+++ b/go.sum
@@ -107,8 +107,8 @@ github.com/VividCortex/gohistogram v1.0.0/go.mod h1:Pf5mBqqDxYaXu3hDrrU+w6nw50o/
 github.com/aead/ecdh v0.2.0 h1:pYop54xVaq/CEREFEcukHRZfTdjiWvYIsZDXXrBapQQ=
 github.com/aead/ecdh v0.2.0/go.mod h1:a9HHtXuSo8J1Js1MwLQx2mBhkXMT6YwUmVVEY4tTB8U=
 github.com/aead/siphash v1.0.1/go.mod h1:Nywa3cDsYNNK3gaciGTWPwHt0wlpNV15vwmswBAUSII=
-github.com/aeddi/mobile v0.0.4 h1:0Qw7lH+2Iqn/dxGcyKwoPIilYEqiTIUOfNgt4wkHTac=
-github.com/aeddi/mobile v0.0.4/go.mod h1:pe2sM7Uk+2Su1y7u/6Z8KJ24D7lepUjFZbhFOrmDfuQ=
+github.com/aeddi/mobile v0.0.6 h1:9nXV2jWJOTrrouxG539YnheQVa9/G0tdI/9bS5HkGE4=
+github.com/aeddi/mobile v0.0.6/go.mod h1:pe2sM7Uk+2Su1y7u/6Z8KJ24D7lepUjFZbhFOrmDfuQ=
 github.com/afex/hystrix-go v0.0.0-20180502004556-fa1af6a1f4f5/go.mod h1:SkGFH1ia65gfNATL8TAiHDNxPzPdmEL5uirI2Uyuz6c=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412 h1:w1UutsfOrms1J05zt7ISrnJIXKzwaspym5BTKGx93EI=
 github.com/agl/ed25519 v0.0.0-20170116200512-5312a6153412/go.mod h1:WPjqKcmVOxf0XSf3YxCJs6N6AOSrOx3obionmG7T0y0=


### PR DESCRIPTION
Changelog:
- Fixes `/var/folders/(...)/exe/gomobile: symlink A /Users/(...)/ios/iphoneos/Bertybridge.framework/Versions/Current: file exists`
- Modernize handling of Android SDK and NDK paths, now `ANDROID_HOME` has become optional and ANDROID_NDK_HOME is deprecated, see: https://github.com/golang/mobile/commit/8578da9835fd365e78a6e63048c103b27a53a82c

Signed-off-by: aeddi <antoine.e.b@gmail.com>

<!-- Thank you for your contribution! ❤️ -->
