### PR TITLE
docs: Delete icon from bug template title

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.yml
+++ b/.github/ISSUE_TEMPLATE/bug_template.yml
@@ -1,4 +1,4 @@
-name: "🐛 Bug report"
+name: "Bug report"
 description: Report a bug found while using the Berty apps or packages.
 labels: ["bug", "🔍 Ready for Review"]
 assignees:


### PR DESCRIPTION
Deleting unnecessary icon from bug template title