### PR TITLE
chore: prevent going back to InitialScreen for iOS & Android

### DIFF
--- a/js/packages/screens/account/InitialLaunch/InitialLaunch.tsx
+++ b/js/packages/screens/account/InitialLaunch/InitialLaunch.tsx
@@ -12,6 +12,7 @@ export const InitialLaunch: ScreenFC<'Account.InitialLaunch'> = () => {
 	React.useEffect(() => {
 		const f = async () => {
 			const navObject = await initialLaunch()
+			// Prevent user going back to the initial launch screen
 			reset({
 				index: 0,
 				routes: [


### PR DESCRIPTION
Hello everyone, 
This is my first contribution for Berty.

I did install the app and I was stuck at loading screen by swiping back. I believe this is an issue for many users so, I decide to fix it :)


https://user-images.githubusercontent.com/106549013/179646154-60495604-f380-489b-9d37-5ae083e5709d.mp4