### PR TITLE
chore(README.md): add links to Google Play and App Store.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@
 
 ### Mobile
 
+To use the latest released version, install it from [Google Play](https://play.google.com/store/apps/details?id=tech.berty.android)
+or [Apple App Store](https://apps.apple.com/tt/app/berty/id1535500412).
+
 To compile and run the mobile application on your device, see [js/README.md](js/README.md).
 
 ### CLI


### PR DESCRIPTION
The [Berty web page](https://berty.tech/) has links to install from Google Play and the App Store. But a user may first land on this README which only says how to compile. Add the same links to Google Play and the App Store if the user just wants to install.

Signed-off-by: jefft0 <jeff@thefirst.org>