### PR TITLE
fix: js: In README, bump Node requirement to 14.x

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -97,7 +97,7 @@ $ make web.debug
 ### General React Native requirements
 
 - Homebrew or package manager of choice
-- Node >= 12.x
+- Node >= 14.x
 - The [yarn package manager](https://classic.yarnpkg.com/en/)
 
 ### iOS dev requirements


### PR DESCRIPTION
With Node 12.x installed (the default on Ubuntu 22.04), `make android.release` gives the following error. Due to the faker dependency, the minimum Node version should be 14.x.

`error @faker-js/faker@6.3.1: The engine "node" is incompatible with this module. Expected version ">=14.0.0". Got "12.22.9"`

Signed-off-by: jefft0 <jeff@thefirst.org>

<!-- Thank you for your contribution! ❤️ -->