### PR TITLE
chore(bot): remove trailing space in commands

### DIFF
--- a/go/pkg/bertybot/handlers.go
+++ b/go/pkg/bertybot/handlers.go
@@ -93,7 +93,7 @@ func (b *Bot) handleEvent(ctx context.Context, event *messengertypes.StreamEvent
 			context.UserMessage = receivedMessage.GetBody()
 			if len(b.commands) > 0 && len(context.UserMessage) > 1 && strings.HasPrefix(context.UserMessage, "/") {
 				if !context.IsMine && !context.IsReplay && !context.IsAck {
-					context.CommandArgs = strings.Split(context.UserMessage[1:], " ")
+					context.CommandArgs = strings.Split(strings.TrimSpace(context.UserMessage[1:]), " ")
 					command, found := b.commands[context.CommandArgs[0]]
 					if found {
 						b.logger.Debug("found handler", zap.Strings("args", context.CommandArgs))


### PR DESCRIPTION
Currently, when we register a command on a bot, if we carry out this command, the space trailings will be taken into account as argument.

For example if I register the command /test which takes a parameter and displays it

If I execute the command **with a space at the end**: ``/test Mikael`` 
then I would have two arguments Mikael and a space.

This is problematic in case like for example my phone adds a space at the end of a sentence if there is no dot.

For this I propose that we remove the trailing space.

Here is a screenshot with an example :

![IMG_2414](https://user-images.githubusercontent.com/71339153/185092958-e5082723-4c0a-4858-8dcc-930c10b36142.png)