### PR TITLE
chore: configure GitHub Actions’ concurrency

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -21,6 +21,10 @@ on:
       - "js/**"
       - "!js/packages/i18n/locale/*/*.json"
       - ".github/workflows/ios.yml"
+      
+concurrency:
+   group: ${{ github.workflow }}-${{ github.ref }}
+   cancel-in-progress: true
 
 jobs:
   mac_runner_matrix_builder:


### PR DESCRIPTION
Should be better than current ways of handling concurrency.

If it works well, I suggest to port it on every other relevant workflow.