### PR TITLE
chore(ci): add runners' lambda

### DIFF
--- a/tool/scw-funcs/ghrunners/.gitignore
+++ b/tool/scw-funcs/ghrunners/.gitignore
@@ -1,0 +1,2 @@
+.serverless
+package-lock.json

--- a/tool/scw-funcs/ghrunners/Makefile
+++ b/tool/scw-funcs/ghrunners/Makefile
@@ -1,0 +1,12 @@
+test:
+	go test -v .
+
+invoke:
+	serverless invoke --function runners
+
+deploy:
+	serverless deploy
+
+deps:
+	npm install -g serverless
+	serverless plugin install -n serverless-scaleway-functions

--- a/tool/scw-funcs/ghrunners/README.md
+++ b/tool/scw-funcs/ghrunners/README.md
@@ -1,0 +1,5 @@
+# ghrunners
+
+Serverless function that fetches the runners status without providing a privileged GITHUB_TOKEN.
+
+Based on https://github.com/scaleway/serverless-scaleway-functions/tree/master/examples/go.

--- a/tool/scw-funcs/ghrunners/go.mod
+++ b/tool/scw-funcs/ghrunners/go.mod
@@ -1,0 +1,3 @@
+module handler
+
+go 1.18

--- a/tool/scw-funcs/ghrunners/handler.go
+++ b/tool/scw-funcs/ghrunners/handler.go
@@ -1,0 +1,26 @@
+package handler
+
+import (
+	"io"
+	"net/http"
+	"os"
+)
+
+func Runners(w http.ResponseWriter, r *http.Request) {
+	req, err := http.NewRequest("GET", "https://api.github.com/orgs/berty/actions/runners", nil)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		panic(err)
+	}
+	req.Header.Set("Authorization", "token "+os.Getenv("GITHUB_TOKEN"))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		panic(err)
+	}
+	defer resp.Body.Close()
+
+	w.WriteHeader(resp.StatusCode)
+	w.Header().Set("Content-Type", "application/json")
+	io.Copy(w, resp.Body)
+}

--- a/tool/scw-funcs/ghrunners/handler_test.go
+++ b/tool/scw-funcs/ghrunners/handler_test.go
@@ -1,0 +1,35 @@
+package handler
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRunners(t *testing.T) {
+	req, err := http.NewRequest("GET", "/Runners", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rr := httptest.NewRecorder()
+	handler := http.HandlerFunc(Runners)
+	handler.ServeHTTP(rr, req)
+
+	{
+		got := rr.Code
+		expected := http.StatusOK
+		if expected != got {
+			t.Errorf("expected %v, got %v.", expected, got)
+		}
+	}
+
+	{
+		got := rr.Body.String()
+		t.Log("got: ", got)
+		// expected := `{...}`
+		// if expected != got {
+		//     t.Errorf("expected %v, got %v.", expected, got)
+		// }
+	}
+}

--- a/tool/scw-funcs/ghrunners/package.json
+++ b/tool/scw-funcs/ghrunners/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "ghrunners",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {},
+  "devDependencies": {
+    "serverless-scaleway-functions": "^0.4.1"
+  },
+  "description": ""
+}

--- a/tool/scw-funcs/ghrunners/serverless.yml
+++ b/tool/scw-funcs/ghrunners/serverless.yml
@@ -1,0 +1,19 @@
+service: ghrunners
+configValidationMode: off
+provider:
+  name: scaleway
+  runtime: go118
+
+plugins:
+  - serverless-scaleway-functions
+
+package:
+  patterns:
+    - '!node_modules/**'
+    - '!.gitignore'
+    - '!.git/**'
+    - '!*_test.go'
+
+functions:
+  runners:
+    handler: 'Runners'


### PR DESCRIPTION
Deployed here: https://ghrunners-lambda.berty.io/

```json
{"total_count":3,"runners":[{"id":149,"name":"ci-macos-2.berty.io","os":"macOS","status":"online","busy":false,"labels":[{"id":5,"name":"self-hosted","type":"read-only"},{"id":6,"name":"macOS","type":"read-only"},{"id":7,"name":"ARM64","type":"read-only"},{"id":8,"name":"public","type":"custom"}]},{"id":150,"name":"ci-macos-1.berty.io","os":"macOS","status":"online","busy":false,"labels":[{"id":5,"name":"self-hosted","type":"read-only"},{"id":6,"name":"macOS","type":"read-only"},{"id":7,"name":"ARM64","type":"read-only"},{"id":8,"name":"public","type":"custom"}]},{"id":151,"name":"ci-macos-3.berty.io","os":"macOS","status":"online","busy":false,"labels":[{"id":5,"name":"self-hosted","type":"read-only"},{"id":6,"name":"macOS","type":"read-only"},{"id":7,"name":"ARM64","type":"read-only"},{"id":8,"name":"public","type":"custom"}]}]}
```
