### PR TITLE
Fix activateGroupContext logging

### DIFF
--- a/go/pkg/bertyprotocol/group_context.go
+++ b/go/pkg/bertyprotocol/group_context.go
@@ -110,7 +110,7 @@ func (gc *GroupContext) activateGroupContext(contact crypto.PubKey, selfAnnounce
 		go func() {
 			for pk := range chNewData {
 				if !pk.Equals(gc.memberDevice.PrivateDevice().GetPublic()) {
-					gc.logger.Warn("gc member device public key device doesn't match")
+					gc.logger.Warn("gc member device public key doesn't match")
 				}
 			}
 		}()
@@ -119,7 +119,7 @@ func (gc *GroupContext) activateGroupContext(contact crypto.PubKey, selfAnnounce
 		go func() {
 			for pk := range chMember {
 				if !pk.Equals(gc.memberDevice.PrivateMember().GetPublic()) {
-					gc.logger.Warn("gc member public key device doesn't match")
+					gc.logger.Warn("gc member device public key doesn't match")
 				}
 			}
 		}()
@@ -134,7 +134,7 @@ func (gc *GroupContext) activateGroupContext(contact crypto.PubKey, selfAnnounce
 		go func() {
 			for pk := range chPreviousData {
 				if !pk.Equals(gc.memberDevice.PrivateDevice().GetPublic()) {
-					gc.logger.Warn("gc member device public key device doesn't match")
+					gc.logger.Warn("gc member device public key doesn't match")
 				}
 			}
 
@@ -146,7 +146,7 @@ func (gc *GroupContext) activateGroupContext(contact crypto.PubKey, selfAnnounce
 		go func() {
 			for pk := range chSecrets {
 				if !pk.Equals(gc.memberDevice.PrivateMember().GetPublic()) {
-					gc.logger.Warn("gc member public key device doesn't match")
+					gc.logger.Warn("gc member device public key doesn't match")
 				}
 			}
 


### PR DESCRIPTION
This pull request has two commits. The first commit fixes some logic in `activateGroupContext` for printing log messages. Running `TestFlappyRestoreAccount` prints the log message "group_context.go:122 gc member public key device doesn't match". But the public key does match, so this commit changes to use `if !pk.Equals` [here](https://github.com/berty/berty/blob/master/go/pkg/bertyprotocol/group_context.go#L121), similar to the other log messages.

Also, the test prints "FillMessageKeysHolderUsingPreviousData took 373.982µs" . But this is the wrong value because the log message [is printed](https://github.com/berty/berty/blob/master/go/pkg/bertyprotocol/group_context.go#L144) immediately after the goroutine is started, not after the operation is completed. 

Also, the test prints "SendSecretsToExistingMembers took 2.881109ms". But this is the wrong value because the log message [is printed](https://github.com/berty/berty/blob/master/go/pkg/bertyprotocol/group_context.go#L161) after `wg.Wait()` which waits for both FillMessageKeysHolderUsingPreviousData and SendSecretsToExistingMembers to complete.

Therefore, this commit moves each log message statement inside the goroutine after each operation is complete. Now the test prints "FillMessageKeysHolderUsingPreviousData took 3.178739ms" and "SendSecretsToExistingMembers took 1.085377ms" which are more reasonable.

Finally, the second commit fixes typos in the log messages to say "gc member device public key doesn't match".