### PR TITLE
make Makefile asdf target POSIX sh compatible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,7 @@ asdf.install_plugins:
 	@echo "Installing asdf plugins..."
 	@set -e; \
 	for PLUGIN in $$(cut -d' ' -f1 .tool-versions | grep "^[^\#]"); do \
-		asdf plugin add $$PLUGIN || [ $$? == 2 ] || exit 1; \
+		asdf plugin add $$PLUGIN || [ $$?==2 ] || exit 1; \
 	done
 
 asdf.install_tools: asdf.install_plugins


### PR DESCRIPTION
Ref: https://stackoverflow.com/a/3411105

Small change I had to make to get the Makefile commands work on my machine (`/bin/sh` is symlinked to dash on my PopOS).
This should still work the same with bash.

<!-- Thank you for your contribution! ❤️ -->
