### PR TITLE
fix: berty version

### DIFF
--- a/go/Makefile
+++ b/go/Makefile
@@ -13,7 +13,7 @@ CI ?= false
 BUILD_DATE ?= `date +%s`
 VCS_REF ?= `git rev-parse --short HEAD`
 VERSION ?= `go run github.com/mdomke/git-semver/v5`
-LDFLAGS ?= -ldflags="-X berty.tech/berty/v2/go/pkg/bertyversion.VcsRef=$(VCS_REF) -X berty.tech/berty/v2/go/pkg/bertyversion.Version=$(VERSION)"
+LDFLAGS ?= -ldflags="-X berty.tech/berty/v2/go/internal/bertyversion.VcsRef=$(VCS_REF) -X berty.tech/berty/v2/go/internal/bertyversion.Version=$(VERSION)"
 
 # @FIXME(gfanton): on macOS Monterey (12.0.x) we currently need to set the
 # environment variable `MallocNanoZone` to 0 to avoid a SIGABRT or SIGSEGV

--- a/go/gen.sum
+++ b/go/gen.sum
@@ -4,4 +4,4 @@ e53f08e68280e1d345b419731c6a13c26c7890a5  ../api/berty/errcode.proto
 f61e300fb23e02f14c27147496286e3e8daa7a6a  ../api/directorytypes/bertydirectory.proto
 851d354abf878a3afd1e1759511b7b3ce297330f  ../api/go-internal/testutil.proto
 d78a1e60c7f29ac353982fc702dbd951db3ddc89  ../api/messengertypes/messengertypes.proto
-5096db5d386b619e012640bcc6f73109e93e064f  Makefile
+a2c69dfac9a551150af66c5020fefd543cdd4cf0  Makefile


### PR DESCRIPTION
The version of Berty was n/a.

<!-- Thank you for your contribution! ❤️ -->
