### PR TITLE
chore: bump golangci lint to 1.51.2

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -32,15 +32,10 @@ yarn 1.22.19
 ruby 3.1.3
 
 #-----
-# golangci-lint 1.46.2 is simply the most recent version available to date (07/22).
+# golangci-lint 1.51.2 is simply the most recent version available to date (07/22).
 #
-# The current version of golangci-lint also has a problem displaying logs on
-# Github actions, see: https://github.com/golangci/golangci-lint-action/issues/119
-#
-# It would be good to update it (when possible) to a version that fixes this log
-# issue and to update the golangci-lint Github Actions step accordingly.
 #-----
-golangci-lint 1.50.1
+golangci-lint 1.51.2
 
 #-----
 # jq 1.6 is simply the most recent version available to date (07/22).


### PR DESCRIPTION
fix diff problem on osx