### PR TITLE
fix: Berty mini: fix message spelling of opennd

### DIFF
--- a/go/cmd/berty/mini/view_group.go
+++ b/go/cmd/berty/mini/view_group.go
@@ -138,7 +138,7 @@ func (v *groupView) loop(ctx context.Context) {
 	}); err == nil {
 		v.messages.Append(&historyMessage{
 			messageType: messageTypeError,
-			payload:     []byte("conversation opnned " + gpk),
+			payload:     []byte("conversation opened " + gpk),
 		})
 	}
 


### PR DESCRIPTION
This is a low priority for a Berty mini message to fix the spelling of "opennd".