### PR TITLE
WIP fix: add push notification permission

### DIFF
--- a/js/android/app/src/main/AndroidManifest.xml
+++ b/js/android/app/src/main/AndroidManifest.xml
@@ -14,6 +14,7 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE"/>
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <!-- Extra permissions for Android Nearby -->
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />


### PR DESCRIPTION
- fix push notification on android 11 by adding notification permission on AndroidManifest file.

Reference: https://developer.android.com/develop/ui/views/notifications/notification-permission