### PR TITLE
fix: In subscribeToMessages, use a goroutine to call HandleAppMessage

### DIFF
--- a/go/pkg/bertymessenger/subscriptions.go
+++ b/go/pkg/bertymessenger/subscriptions.go
@@ -235,13 +235,13 @@ func (svc *service) subscribeToMessages(ctx, tyberCtx context.Context, gpkb []by
 				eventHandler = eventHandler.WithContext(tyber.ContextWithConstantTraceID(svc.eventHandler.Ctx(), "msgrcvd-"+cid.String()))
 			}
 
-			svc.handlerMutex.Lock()
-			if err := eventHandler.HandleAppMessage(messengerutil.B64EncodeBytes(gpkb), gme, &am); err != nil {
-				_ = tyber.LogFatalError(eventHandler.Ctx(), eventHandler.Logger(), "Failed to handle AppMessage", err)
-			} else {
-				eventHandler.Logger().Debug("AppMessage handler succeeded", tyber.FormatStepLogFields(eventHandler.Ctx(), []tyber.Detail{}, tyber.EndTrace)...)
-			}
-			svc.handlerMutex.Unlock()
+			go func() {
+				if err := eventHandler.HandleAppMessage(messengerutil.B64EncodeBytes(gpkb), gme, &am); err != nil {
+					_ = tyber.LogFatalError(eventHandler.Ctx(), eventHandler.Logger(), "Failed to handle AppMessage", err)
+				} else {
+					eventHandler.Logger().Debug("AppMessage handler succeeded", tyber.FormatStepLogFields(eventHandler.Ctx(), []tyber.Detail{}, tyber.EndTrace)...)
+				}
+			}()
 		}
 	}()
 	return nil


### PR DESCRIPTION

In `subscribeToMessages` there is a goroutine to subscribe to messages from `GroupMessageList` . It is a requirement that a subscriber should return quickly and not block. Therefore, we put the call to `HandleAppMessage` in a goroutine so that the subscriber returns quickly. Also, after testing, it is not necessary to use `handlerMutex` and the lock can block, so we remove it in this case.

With these changes, it is possible to send thousands of messages between two Berty mini instances without freezing.