### PR TITLE
chore: In issue template, remove label Ready for Review

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_template.yml
+++ b/.github/ISSUE_TEMPLATE/bug_template.yml
@@ -1,6 +1,6 @@
 name: "Bug report"
 description: Report a bug found while using the Berty apps or packages.
-labels: ["bug", "🔍 Ready for Review"]
+labels: ["bug"]
 body:
   - type: checkboxes
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature_template.yml
+++ b/.github/ISSUE_TEMPLATE/feature_template.yml
@@ -1,6 +1,6 @@
 name: "Feature request"
 description: Suggest an idea for this project.
-labels: [":rocket: feature-request", "🔍 Ready for Review"]
+labels: [":rocket: feature-request"]
 body:
   - type: checkboxes
     attributes:

--- a/.github/ISSUE_TEMPLATE/question_template.yml
+++ b/.github/ISSUE_TEMPLATE/question_template.yml
@@ -1,6 +1,6 @@
 name: "Question"
 description: Ask a question about this project.
-labels: ["question", "🔍 Ready for Review"]
+labels: ["question"]
 body:
   - type: checkboxes
     attributes:


### PR DESCRIPTION
QA reviews all new issues, so we don't need an extra label for this.
