### PR TITLE
fix: CI Runners with XCode 14.3

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -51,7 +51,7 @@ jobs:
     name: Build for iOS
     runs-on: ${{ matrix.runner }}
     env:
-      E2E_TESTING_IOS_DEVICE: iPhone 11
+      E2E_TESTING_IOS_DEVICE: iPhone 14
       # TODO: fix hetzner
       # E2E_TESTING_IOS_VERSION: 15.5
       CACHE_DIRS: js/android/.gomobile-cache; js/ios/.gomobile-cache; js/ios/.xcodegen-cache


### PR DESCRIPTION
When we run e2e CI tests, we try to run them with an iPhone 11 but with XCode 14, only iPhone 14 simulators are available by default.

<!-- Thank you for your contribution! ❤️ -->
