### PR TITLE
fix: Delete deep links handler from account's screens

### DIFF
--- a/js/packages/navigation/stacks.tsx
+++ b/js/packages/navigation/stacks.tsx
@@ -135,7 +135,9 @@ Components = mapValues(RawComponents, SubComponents =>
 		(Component: React.FC): React.FC =>
 			React.memo(props => (
 				<>
-					{Platform.OS !== 'web' ? <DeepLinkBridge /> : null}
+					{Platform.OS !== 'web' && !('OpeningAccount' in SubComponents) ? (
+						<DeepLinkBridge />
+					) : null}
 					<Component {...props} />
 				</>
 			)),


### PR DESCRIPTION
The direct link was not being entered in the chat screen.
This PR deletes the deep links handler from the account's screens because the messenger client is not initialized yet.


Signed-off-by: Iuri Pereira <iuricmp@gmail.com>

<!-- Thank you for your contribution! ❤️ -->
