### PR TITLE
fix: use SetMaxOpenConns to fix `database is locked` issue

### DIFF
--- a/go/internal/accountutils/utils.go
+++ b/go/internal/accountutils/utils.go
@@ -332,10 +332,14 @@ func GetGormDBForPath(dbPath string, key []byte, salt []byte, logger *zap.Logger
 		return nil, nil, errcode.TODO.Wrap(err)
 	}
 
+	sqlDB, err := db.DB()
+	if err != nil {
+		return nil, nil, fmt.Errorf("unable to gorm underlying db: %w", err)
+	}
+
+	sqlDB.SetMaxOpenConns(1)
+
 	return db, func() {
-		sqlDB, _ := db.DB()
-		if sqlDB != nil {
-			sqlDB.Close()
-		}
+		_ = sqlDB.Close()
 	}, nil
 }

--- a/go/internal/messengerdb/db.go
+++ b/go/internal/messengerdb/db.go
@@ -1758,7 +1758,7 @@ func (d *DBWrapper) MarkAccountDirectoryServiceRecordAsRevoked(serverAddr string
 	return d.db.Transaction(func(tx *gorm.DB) error {
 		record := &messengertypes.AccountDirectoryServiceRecord{}
 
-		query := d.db.Model(&messengertypes.AccountDirectoryServiceRecord{}).Where(record, &messengertypes.AccountDirectoryServiceRecord{
+		query := tx.Model(&messengertypes.AccountDirectoryServiceRecord{}).Where(record, &messengertypes.AccountDirectoryServiceRecord{
 			ServerAddr:           serverAddr,
 			DirectoryRecordToken: token,
 		}, "expiration_date <= ?", removalDate).Update("revoked", true)

--- a/go/internal/messengerdb/db_test_utils.go
+++ b/go/internal/messengerdb/db_test_utils.go
@@ -68,6 +68,8 @@ func GetInMemoryTestDB(t testing.TB, opts ...GetInMemoryTestDBOpts) (*DBWrapper,
 		t.Fatal(err)
 	}
 
+	d.SetMaxOpenConns(1)
+
 	return wrappedDB, db, func() {
 		_ = d.Close()
 		loggerCleanup()


### PR DESCRIPTION
fixes error "database is locked", caused by concurrent access from deal goroutines to a single sqlite3 db connection 
see: https://github.com/mattn/go-sqlite3#:~:text=Error%3A%20database%20is%20locked 
see: https://github.com/filecoin-project/boost/pull/657

taken from: https://github.com/filecoin-project/boost/blob/main/db/db.go#L29-L31
