### PR TITLE
fix: remove undesired characters from Sharing Contact message

### DIFF
--- a/js/packages/utils/react-native/share.ts
+++ b/js/packages/utils/react-native/share.ts
@@ -7,13 +7,13 @@ export const shareBertyID = async (url: string | null | undefined, t: TFunction<
 		console.warn('Share Berty ID, url is null or undefined')
 		return
 	}
-	const message = `${t('share.sharing-id-message')} ${url}`
 	try {
 		if (Platform.OS === 'web') {
 			Clipboard.setString(url)
 		} else {
-			// i18n doesn't support this url value in argument
-			await Share.share({ url: message, message })
+			const message = `${t('share.sharing-id-message')}`
+			const content = Platform.OS === 'ios' ? { url, message } : { message: `${message} ${url}` }
+			await Share.share(content)
 		}
 	} catch (e) {
 		console.warn(e)


### PR DESCRIPTION
The Share.share API has a different payload for ios and android which was not used properly.

Fix #4682

Signed-off-by: Iuri Pereira <iuricmp@gmail.com>

<!-- Thank you for your contribution! ❤️ -->

![Simulator Screenshot - iPhone 14 - 2023-05-17 at 14 45 58](https://github.com/berty/berty/assets/689440/de3946c1-6bb2-43fc-8e26-705a36807df9)


![Simulator Screenshot - iPhone 14 - 2023-05-17 at 14 46 33](https://github.com/berty/berty/assets/689440/cc0684d7-2543-4d71-9ee0-3da9c666c4e4)



