### PR TITLE
chore: reame update

### DIFF
--- a/js/README.md
+++ b/js/README.md
@@ -25,7 +25,7 @@ $ make ios.debug
 $ IOS_DEVICE="your-emulator-id" make ios.debug
 
 # 💡 You can check available virtual iOS devices with
-$ xcrun simctl list
+$ xcrun xctrace list devices
 ```
 
 Run Android in debug mode:


### PR DESCRIPTION
Adds a better command to display the available devices to run Berty on dev mode.

`xcrun simctl list` list all devices, including apple watch, ipad, tv, etc.

while

`xcrun xctrace list devices` lists only the iphone devices and emulators