### PR TITLE
fix: duplicated member entry

### DIFF
--- a/js/packages/redux/reducers/messenger.reducer.ts
+++ b/js/packages/redux/reducers/messenger.reducer.ts
@@ -195,20 +195,6 @@ const makeRoot = <T>(val: T) => ({
 const rootInitialState = makeRoot(initialState)
 type LocalRootState = typeof rootInitialState
 
-/**
- *
- * Actions
- *
- */
-
-const defaultDisplayName = (seed: string | null | undefined) => {
-	let suffix = '1337'
-	if (seed) {
-		suffix = seed.substring(0, 4)
-	}
-	return `anon#${suffix}`
-}
-
 const slice = createSlice({
 	name: 'messenger',
 	initialState,
@@ -351,7 +337,8 @@ const slice = createSlice({
 
 				const member = cloneDeep(payload.member)
 				if (!member.displayName) {
-					member.displayName = defaultDisplayName(member.publicKey)
+					// It fixes https://github.com/berty/berty/issues/4687
+					return
 				}
 
 				const membersBucket = selectMembersBucket(


### PR DESCRIPTION
Fix for duplicate member in group members list.

Disclaimer: This is a quick-fix solution. The proper solution came from understanding why `TypeMemberUpdated` event is being dispatched twice for the current user in the StreamEvent.

It is a Berty's Javascript issue since it's not reproducible on Berty's Mini.

Signed-off-by: Iuri Pereira <iuricmp@gmail.com>

fix #4687

<!-- Thank you for your contribution! ❤️ -->
