### PR TITLE
fix: properly handle close signal on main

### DIFF
--- a/go/cmd/berty/daemon.go
+++ b/go/cmd/berty/daemon.go
@@ -132,7 +132,7 @@ func daemonCommand() *ffcli.Command {
 				})
 			}
 
-			return manager.RunWorkers()
+			return manager.RunWorkers(ctx)
 		},
 	}
 }

--- a/go/cmd/berty/directory_service.go
+++ b/go/cmd/berty/directory_service.go
@@ -76,7 +76,7 @@ func directoryServiceCommand() *ffcli.Command {
 				return err
 			}
 
-			return manager.RunWorkers()
+			return manager.RunWorkers(ctx)
 		},
 	}
 }

--- a/go/cmd/berty/main.go
+++ b/go/cmd/berty/main.go
@@ -103,6 +103,7 @@ func runMain(args []string) error {
 			process.Add(func() error {
 				return root.ParseAndRun(ctx, args)
 			}, func(error) {
+				fmt.Println("interrupted, closing...")
 				ctxCancel()
 			})
 		}

--- a/go/cmd/berty/push.go
+++ b/go/cmd/berty/push.go
@@ -104,7 +104,7 @@ func pushServerCommand() *ffcli.Command {
 				return err
 			}
 
-			return manager.RunWorkers()
+			return manager.RunWorkers(ctx)
 		},
 	}
 }

--- a/go/cmd/berty/replication.go
+++ b/go/cmd/berty/replication.go
@@ -78,7 +78,7 @@ func replicationServerCommand() *ffcli.Command {
 				return err
 			}
 
-			return manager.RunWorkers()
+			return manager.RunWorkers(ctx)
 		},
 	}
 }

--- a/go/internal/initutil/manager.go
+++ b/go/internal/initutil/manager.go
@@ -316,11 +316,17 @@ func (m *Manager) getContext() context.Context {
 	return m.ctx
 }
 
-func (m *Manager) RunWorkers() error {
+func (m *Manager) RunWorkers(ctx context.Context) error {
 	m.workers.Add(func() error {
-		<-m.getContext().Done()
-		return m.getContext().Err()
+		select {
+		case <-m.getContext().Done():
+			return m.getContext().Err()
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+
 	}, func(err error) {
+
 		m.ctxCancel()
 	})
 	return m.workers.Run()

--- a/go/internal/initutil/manager.go
+++ b/go/internal/initutil/manager.go
@@ -324,9 +324,7 @@ func (m *Manager) RunWorkers(ctx context.Context) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		}
-
 	}, func(err error) {
-
 		m.ctxCancel()
 	})
 	return m.workers.Run()

--- a/go/internal/initutil/manager_test.go
+++ b/go/internal/initutil/manager_test.go
@@ -162,6 +162,9 @@ func Example_noflags() {
 }
 
 func TestTwoConcurrentManagers(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
 	var man1, man2 *initutil.Manager
 
 	// FIXME: automatically find an available port
@@ -202,7 +205,7 @@ func TestTwoConcurrentManagers(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, server)
 
-		go man1.RunWorkers()
+		go man1.RunWorkers(ctx)
 		time.Sleep(time.Second * 2)
 	}
 

--- a/go/pkg/bertyaccount/service_account.go
+++ b/go/pkg/bertyaccount/service_account.go
@@ -243,7 +243,7 @@ func (s *service) openAccount(ctx context.Context, req *accounttypes.OpenAccount
 
 	if initManager.Session.Kind != "mobile" {
 		go func() {
-			if err := initManager.RunWorkers(); err != nil {
+			if err := initManager.RunWorkers(ctx); err != nil {
 				s.logger.Error("error in workers", zap.Error(err))
 			}
 		}()


### PR DESCRIPTION
properly handle close signal when berty run in daemon mode