### PR TITLE
chore: Don't run workflow jobs on forks

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -24,6 +24,8 @@ on:
 
 jobs:
   build:
+    # Check repository owner so that we don't run on a fork.
+    if: github.repository_owner == 'berty'
     name: Build for Android
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,6 +21,8 @@ on:
 
 jobs:
   benchmark:
+    # Check repository owner so that we don't run on a fork.
+    if: github.repository_owner == 'berty'
     name: Run benchmarks
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,6 +39,8 @@ on:
 
 jobs:
   analyze:
+    # Check repository owner so that we don't run on a fork.
+    if: github.repository_owner == 'berty'
     name: Analyze
     runs-on: ubuntu-latest
 

--- a/.github/workflows/dependent-issues.yml
+++ b/.github/workflows/dependent-issues.yml
@@ -17,6 +17,8 @@ on:
 
 jobs:
   check:
+    # Check repository owner so that we don't run on a fork.
+    if: github.repository_owner == 'berty'
     runs-on: ubuntu-latest
     steps:
       - uses: z0al/dependent-issues@v1.5.1

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,6 +21,8 @@ on:
 
 jobs:
   golangci-lint:
+    # Check repository owner so that we don't run on a fork.
+    if: github.repository_owner == 'berty'
     name: Golangci-lint
     runs-on: ubuntu-latest
     steps:
@@ -54,6 +56,8 @@ jobs:
   #
   # we hope we can remove this job because all the tests are stable 100% of the time
   flappy-tests:
+    # Check repository owner so that we don't run on a fork.
+    if: github.repository_owner == 'berty'
     name: Flappy tests (Linux)
     runs-on: ubuntu-latest
     steps:
@@ -105,6 +109,8 @@ jobs:
         run: make go.flappy-tests
 
   go-tests-on-linux:
+    # Check repository owner so that we don't run on a fork.
+    if: github.repository_owner == 'berty'
     name: Stable tests (Linux)
     runs-on: ubuntu-latest
     steps:
@@ -178,6 +184,8 @@ jobs:
           fail_ci_if_error: false
 
   go-tests-on-windows:
+    # Check repository owner so that we don't run on a fork.
+    if: github.repository_owner == 'berty'
     name: Stable tests (Windows)
     runs-on: windows-latest
     steps:
@@ -226,6 +234,8 @@ jobs:
         run: go.exe test ./... -tags "fts5 sqlite sqlite_unlock_notify" -buildmode=exe -timeout=600s -count=1
 
   go-tests-on-macos:
+    # Check repository owner so that we don't run on a fork.
+    if: github.repository_owner == 'berty'
     name: Stable tests (macOS)
     runs-on: macos-latest
     steps:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -24,6 +24,8 @@ on:
 
 jobs:
   mac_runner_matrix_builder:
+    # Check repository owner so that we don't run on a fork.
+    if: github.repository_owner == 'berty'
     name: macOS matrix builder
     runs-on: ubuntu-latest
     outputs:
@@ -47,6 +49,8 @@ jobs:
           node .github/workflows/utils/mac-runner-matrix-builder.js optimized
 
   build:
+    # Check repository owner so that we don't run on a fork.
+    if: github.repository_owner == 'berty'
     needs: mac_runner_matrix_builder
     name: Build for iOS
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/js.yml
+++ b/.github/workflows/js.yml
@@ -17,6 +17,8 @@ on:
 
 jobs:
   build-and-lint:
+    # Check repository owner so that we don't run on a fork.
+    if: github.repository_owner == 'berty'
     runs-on: ubuntu-latest
     name: Build, lint and test JS
     steps:

--- a/.github/workflows/mac.yml
+++ b/.github/workflows/mac.yml
@@ -29,6 +29,8 @@ on:
 
 jobs:
   mac_runner_matrix_builder:
+    # Check repository owner so that we don't run on a fork.
+    if: github.repository_owner == 'berty'
     name: macOS matrix builder
     runs-on: ubuntu-latest
     outputs:
@@ -50,6 +52,8 @@ jobs:
           node .github/workflows/utils/mac-runner-matrix-builder.js optimized
 
   build-macos-app:
+    # Check repository owner so that we don't run on a fork.
+    if: github.repository_owner == 'berty'
     name: Build Electron app (macOS)
     needs: mac_runner_matrix_builder
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/monitor-runners.yml
+++ b/.github/workflows/monitor-runners.yml
@@ -7,6 +7,8 @@ on:
 
 jobs:
   check:
+    # Check repository owner so that we don't run on a fork.
+    if: github.repository_owner == 'berty'
     name: Monitor and send alert
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   preview:
+    # Check repository owner so that we don't run on a fork.
+    if: github.repository_owner == 'berty'
     name: Release Note Preview
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/protobuf.yml
+++ b/.github/workflows/protobuf.yml
@@ -64,6 +64,8 @@ on:
       - "**/Podfile.lock"
 jobs:
   gen-go-and-docs:
+    # Check repository owner so that we don't run on a fork.
+    if: github.repository_owner == 'berty'
     name: Generate go protobuf and docs
     runs-on: ubuntu-latest
     container: bertytech/protoc:31
@@ -137,6 +139,8 @@ jobs:
           apiary publish --api-name=bertymessenger --path="docs/.tmp/openapi/bertymessenger.swagger.json" || true
 
   gen-js:
+    # Check repository owner so that we don't run on a fork.
+    if: github.repository_owner == 'berty'
     name: Generate js protobuf
     runs-on: ubuntu-latest
     container: bertytech/protoc:31


### PR DESCRIPTION
PR https://github.com/berty/weshnet/pull/61 was successful to prevent running the codeql workflow jobs when syncing a fork. This pull request does the same for the workflow jobs in this repository. Only run the job if github.repository_owner == 'berty' .
