### PR TITLE
chore: update berty app to Android API 31

### DIFF
--- a/js/android/app/src/main/AndroidManifest.xml
+++ b/js/android/app/src/main/AndroidManifest.xml
@@ -86,7 +86,8 @@
       <activity
         android:name="com.zoontek.rnbootsplash.RNBootSplashActivity"
         android:theme="@style/BootTheme"
-        android:launchMode="singleTask">
+        android:launchMode="singleTask"
+        android:exported="true">
         <intent-filter>
           <action android:name="android.intent.action.MAIN" />
           <category android:name="android.intent.category.LAUNCHER" />

--- a/js/android/build.gradle
+++ b/js/android/build.gradle
@@ -6,8 +6,8 @@ buildscript {
         androidXAnnotation = "1.2.0"
         buildToolsVersion = "29.0.3"
         minSdkVersion = 23
-        compileSdkVersion = 30
-        targetSdkVersion = 30
+        compileSdkVersion = 31
+        targetSdkVersion = 31
         ndkVersion = "22.1.7171670"
     }
     repositories {


### PR DESCRIPTION
To be allowed to upload Berty to the Play Store, we need to use at least the Android API 31.

With API 31, each Activity which has intent-filter must set android:exported="true" in the AndroidManifest.xml (see https://stackoverflow.com/questions/70333565/targeting-s-version-31-and-above-requires-that-an-explicit-value-for-android)