### PR TITLE
fix: Blueetooth permissions for Android devices and above

### DIFF
--- a/js/android/app/src/main/AndroidManifest.xml
+++ b/js/android/app/src/main/AndroidManifest.xml
@@ -1,12 +1,21 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
   package="tech.berty.android">
 
-    <uses-permission android:name="android.permission.BLUETOOTH" />
-    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" />
+    <!-- Bluetooth permission API 30 or below -->
+    <uses-permission android:name="android.permission.BLUETOOTH" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" android:maxSdkVersion="30" />
+
+    <!-- Bluetooth permission API 31 or above -->
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation"
+        android:minSdkVersion="31" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" android:minSdkVersion="31" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" android:minSdkVersion="31" />
+
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
-    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.READ_PHONE_STATE" />

--- a/js/android/app/src/main/java/tech/berty/gobridge/bledriver/BleDriver.java
+++ b/js/android/app/src/main/java/tech/berty/gobridge/bledriver/BleDriver.java
@@ -9,6 +9,7 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.pm.PackageManager;
+import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 
@@ -114,9 +115,20 @@ public class BleDriver {
         }
 
         // Check BLE permissions
-        if (mAppContext.checkSelfPermission(Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
-            mLogger.e(TAG, "initSystemBle: BLE permissions not granted");
-            return false;
+        String[] permissions;
+        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S) {
+            permissions = new String[]{Manifest.permission.ACCESS_FINE_LOCATION};
+        } else {
+            permissions = new String[]{Manifest.permission.BLUETOOTH_SCAN,
+                Manifest.permission.BLUETOOTH_ADVERTISE,
+                Manifest.permission.BLUETOOTH_CONNECT
+            };
+        }
+        for (int i = 0; i < permissions.length; i++) {
+            if (mAppContext.checkSelfPermission(permissions[i]) != PackageManager.PERMISSION_GRANTED) {
+                mLogger.e(TAG, String.format("initSystemBle: %s permissions not granted", permissions[i]));
+                return false;
+            }
         }
 
         // Initializes Bluetooth adapter.

--- a/js/android/build.gradle
+++ b/js/android/build.gradle
@@ -8,14 +8,14 @@ buildscript {
         minSdkVersion = 23
         compileSdkVersion = 31
         targetSdkVersion = 31
-        ndkVersion = "22.1.7171670"
+        ndkVersion = "23.1.7779620"
     }
     repositories {
         google()
         mavenCentral()
     }
     dependencies {
-        classpath('com.android.tools.build:gradle:4.1.0')
+        classpath('com.android.tools.build:gradle:4.2.2')
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files
 
@@ -62,8 +62,8 @@ allprojects {
         project ->
             if (project.hasProperty("android")) {
                 android {
-                    compileSdkVersion = 29
-                    buildToolsVersion = "29.0.2"
+                    compileSdkVersion = 31
+                    buildToolsVersion = "29.0.3"
                 }
             }
     }

--- a/js/android/gradle/wrapper/gradle-wrapper.properties
+++ b/js/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip

--- a/js/ios/Podfile.lock
+++ b/js/ios/Podfile.lock
@@ -13,6 +13,8 @@ PODS:
     - ExpoModulesCore
   - EXConstants (13.0.2):
     - ExpoModulesCore
+  - EXErrorRecovery (3.0.5):
+    - ExpoModulesCore
   - EXFileSystem (13.1.4):
     - ExpoModulesCore
   - EXFont (10.0.5):
@@ -108,17 +110,17 @@ PODS:
     - lottie-ios (~> 3.2.3)
     - React-Core
   - OpenSSL-Universal (1.1.1100)
-  - Permission-BluetoothPeripheral (3.1.0):
+  - Permission-BluetoothPeripheral (3.8.4):
     - RNPermissions
-  - Permission-Camera (3.1.0):
+  - Permission-Camera (3.8.4):
     - RNPermissions
-  - Permission-Contacts (3.1.0):
+  - Permission-Contacts (3.8.4):
     - RNPermissions
-  - Permission-Microphone (3.1.0):
+  - Permission-Microphone (3.8.4):
     - RNPermissions
-  - Permission-Notifications (3.1.0):
+  - Permission-Notifications (3.8.4):
     - RNPermissions
-  - Permission-PhotoLibrary (3.1.0):
+  - Permission-PhotoLibrary (3.8.4):
     - RNPermissions
   - RCT-Folly (2020.01.13.00):
     - boost-for-react-native
@@ -403,7 +405,7 @@ PODS:
     - React-Core
   - RNFS (2.18.0):
     - React
-  - RNPermissions (3.1.0):
+  - RNPermissions (3.8.4):
     - React-Core
   - RNScreens (3.9.0):
     - React-Core
@@ -430,6 +432,7 @@ DEPENDENCIES:
   - EXBarCodeScanner (from `../node_modules/expo-barcode-scanner/ios`)
   - EXCamera (from `../node_modules/expo-camera/ios`)
   - EXConstants (from `../node_modules/expo-constants/ios`)
+  - EXErrorRecovery (from `../node_modules/expo-error-recovery/ios`)
   - EXFileSystem (from `../node_modules/expo-file-system/ios`)
   - EXFont (from `../node_modules/expo-font/ios`)
   - EXImageLoader (from `../node_modules/expo-image-loader/ios`)
@@ -543,6 +546,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/expo-camera/ios"
   EXConstants:
     :path: "../node_modules/expo-constants/ios"
+  EXErrorRecovery:
+    :path: "../node_modules/expo-error-recovery/ios"
   EXFileSystem:
     :path: "../node_modules/expo-file-system/ios"
   EXFont:
@@ -676,6 +681,7 @@ SPEC CHECKSUMS:
   EXBarCodeScanner: e5ca0062d8ad1c4c1d2e386d6a308d5a32213020
   EXCamera: 4a0d00d6d1e4703c31a75514d8bc804a2eab27bd
   EXConstants: d2594b4b1c48a2c6933622dbc2156543cfd5326b
+  EXErrorRecovery: b0d7582714a2cc896e94a2308a356f94dbf14ef7
   EXFileSystem: 08a3033ac372b6346becf07839e1ccef26fb1058
   EXFont: 2597c10ac85a69d348d44d7873eccf5a7576ef5e
   EXImageLoader: 347b72c2ec2df65120ccec40ea65a4c4f24317ff
@@ -694,19 +700,19 @@ SPEC CHECKSUMS:
   Flipper-Folly: 584845625005ff068a6ebf41f857f468decd26b3
   Flipper-Glog: ad8dd8dda19819daedb79db389c96a4f362e4d9c
   Flipper-PeerTalk: 116d8f857dc6ef55c7a5a75ea3ceaafe878aadc9
-  Flipper-RSocket: 127954abe8b162fcaf68d2134d34dc2bd7076154
-  FlipperKit: 651f50a42eb95c01b3e89a60996dd6aded529eeb
-  glog: 04b94705f318337d7ead9e6d17c019bd9b1f6b1b
+  Flipper-RSocket: d9d9ade67cbecf6ac10730304bf5607266dd2541
+  FlipperKit: 87dd306eef9927220672f98266e68bdab6c7cd69
+  glog: 73c2498ac6884b13ede40eda8228cb1eee9d9d62
   libevent: 4049cae6c81cdb3654a443be001fb9bdceff7913
   lottie-ios: c058aeafa76daa4cf64d773554bccc8385d0150e
   lottie-react-native: b561920bba7ec727ec94a473b683cffba00faece
   OpenSSL-Universal: ebc357f1e6bc71fa463ccb2fe676756aff50e88c
-  Permission-BluetoothPeripheral: e3bdcbf170bd1760881633941d4021b3d8e77f5a
-  Permission-Camera: 0db4fd6e1c556c1cf47f38b989a8084cea3ec3dd
-  Permission-Contacts: c9c3306280576546619fc9ae7489012ed9fe091f
-  Permission-Microphone: 7b75718196244a6e59dd60f82f12962562c2ea12
-  Permission-Notifications: e247d69c22ae72770d1c5314ad6ccd1256c57c83
-  Permission-PhotoLibrary: 9dcf80d1353d81b9f1e210c34291591236aaf2b6
+  Permission-BluetoothPeripheral: 2b88a131074edafd8a46a5cda4ba610ec986d2fb
+  Permission-Camera: 7ec9ee99704766ff9b90198183387a7f5d82b0c1
+  Permission-Contacts: 81a5fd864aa38af8edd201e9f5f8c4691b123e5c
+  Permission-Microphone: 3c985f25f8f89889c9e056622476deb291877194
+  Permission-Notifications: e06c4b115105e9aed6ed8d03c9894c23c1051731
+  Permission-PhotoLibrary: 6db9318df71ad74e9774cecedde95285f5a32d6a
   RCT-Folly: ec7a233ccc97cc556cf7237f0db1ff65b986f27c
   RCTRequired: f85fa00af016059cf88b90b8f8ff9a6af9e4b6c3
   RCTTypeSafety: 5279aaf0fb1ad715cbbbbee32d5c98c72598bc9c
@@ -743,7 +749,7 @@ SPEC CHECKSUMS:
   RNCClipboard: 99fc8ad669a376b756fbc8098ae2fd05c0ed0668
   RNFlashList: 399bf6a0db68f594ad2c86aaff3ea39564f39f8a
   RNFS: 3ab21fa6c56d65566d1fb26c2228e2b6132e5e32
-  RNPermissions: 4b54095940aea8c03fa3e6c92d4ac3647b31ed4e
+  RNPermissions: f1b49dd05fa9b83993cd05a9ee115247944d8f1a
   RNScreens: 4d79118be80f79fa1f4aa131909a1d6e86280af3
   RNShare: edd621a71124961e29a7ba43a84bd1c6f9980d88
   RNSVG: 551acb6562324b1d52a4e0758f7ca0ec234e278f

--- a/js/package.json
+++ b/js/package.json
@@ -64,7 +64,7 @@
     "react-native-fs": "^2.16.6",
     "react-native-hyperlink": "^0.0.19",
     "react-native-in-app-notification": "3.2.0",
-    "react-native-permissions": "^3.1.0",
+    "react-native-permissions": "3.8.4",
     "react-native-progress": "^5.0.0",
     "react-native-qrcode-svg": "6.1.1",
     "react-native-restart": "^0.0.22",

--- a/js/packages/utils/permissions/permissions.ts
+++ b/js/packages/utils/permissions/permissions.ts
@@ -2,11 +2,13 @@ import { Camera } from 'expo-camera'
 import { Platform } from 'react-native'
 import {
 	check,
+	checkMultiple,
 	checkNotifications,
 	Permission,
 	PERMISSIONS,
 	PermissionStatus,
 	request,
+	requestMultiple,
 	requestNotifications,
 	RESULTS,
 } from 'react-native-permissions'
@@ -21,14 +23,9 @@ export enum PermissionType {
 }
 
 const permissionsByDevice: Record<
-	Exclude<PermissionType, PermissionType.notification>,
+	Exclude<PermissionType, PermissionType.notification | PermissionType.proximity>,
 	Permission | undefined
 > = {
-	proximity: Platform.select({
-		ios: PERMISSIONS?.IOS?.BLUETOOTH_PERIPHERAL,
-		android: PERMISSIONS?.ANDROID?.ACCESS_FINE_LOCATION,
-		web: undefined,
-	}),
 	camera: Platform.select({
 		ios: PERMISSIONS?.IOS?.CAMERA,
 		android: PERMISSIONS?.ANDROID?.CAMERA,
@@ -51,6 +48,34 @@ const permissionsByDevice: Record<
 	}),
 }
 
+const checkProximity = async (): Promise<PermissionStatus> => {
+	if (Platform.OS === 'web') {
+		return 'denied'
+	}
+
+	if (Platform.OS === 'ios') {
+		return await check(PERMISSIONS?.IOS?.BLUETOOTH_PERIPHERAL)
+	}
+	// Android 11 or below
+	if (Platform.Version <= 30) {
+		return await check(PERMISSIONS?.ANDROID?.ACCESS_FINE_LOCATION)
+	}
+	// Android 12 or above
+	const statuses = await checkMultiple([
+		PERMISSIONS?.ANDROID?.BLUETOOTH_SCAN,
+		PERMISSIONS?.ANDROID?.BLUETOOTH_ADVERTISE,
+		PERMISSIONS?.ANDROID?.BLUETOOTH_CONNECT,
+	])
+	if (
+		statuses[PERMISSIONS?.ANDROID?.BLUETOOTH_SCAN] === 'granted' &&
+		statuses[PERMISSIONS?.ANDROID?.BLUETOOTH_ADVERTISE] === 'granted' &&
+		statuses[PERMISSIONS?.ANDROID?.BLUETOOTH_SCAN] === 'granted'
+	) {
+		return 'granted'
+	}
+	return 'denied'
+}
+
 export type Permissions = {
 	[Property in PermissionType]: PermissionStatus
 }
@@ -59,6 +84,7 @@ export const getPermissions = async (): Promise<Permissions> => {
 	const ret: Permissions = Object.assign({}, defaultPermissionStatus)
 
 	ret[PermissionType.notification] = (await checkNotifications()).status
+	ret[PermissionType.proximity] = await checkProximity()
 
 	await Promise.all(
 		Object.entries(permissionsByDevice).map(async ([key, perm]) => {
@@ -80,6 +106,36 @@ export const getPermissions = async (): Promise<Permissions> => {
 	return Object.freeze(ret)
 }
 
+const requestProximity = async (): Promise<PermissionStatus> => {
+	if (Platform.OS === 'web') {
+		return RESULTS.DENIED
+	}
+
+	if (Platform.OS === 'ios') {
+		return await request(PERMISSIONS?.IOS?.BLUETOOTH_PERIPHERAL)
+	}
+
+	if (Platform.Version <= 30) {
+		// Android 11 or below
+		return await request(PERMISSIONS?.ANDROID?.ACCESS_FINE_LOCATION)
+	}
+
+	// Android 12 or above
+	const statuses = await requestMultiple([
+		PERMISSIONS?.ANDROID?.BLUETOOTH_SCAN,
+		PERMISSIONS?.ANDROID?.BLUETOOTH_ADVERTISE,
+		PERMISSIONS?.ANDROID?.BLUETOOTH_CONNECT,
+	])
+	if (
+		statuses[PERMISSIONS?.ANDROID?.BLUETOOTH_SCAN] === 'granted' &&
+		statuses[PERMISSIONS?.ANDROID?.BLUETOOTH_ADVERTISE] === 'granted' &&
+		statuses[PERMISSIONS?.ANDROID?.BLUETOOTH_SCAN] === 'granted'
+	) {
+		return RESULTS.GRANTED
+	}
+	return RESULTS.DENIED
+}
+
 export const acquirePermission = async (
 	permissionType: PermissionType,
 ): Promise<PermissionStatus> => {
@@ -90,6 +146,9 @@ export const acquirePermission = async (
 		return (await Camera.requestCameraPermissionsAsync()).status === 'granted'
 			? RESULTS.GRANTED
 			: RESULTS.DENIED
+	}
+	if (permissionType === PermissionType.proximity) {
+		return await requestProximity()
 	}
 	const permission = permissionsByDevice[permissionType]
 	if (!permission) {

--- a/js/web/craco.config.js
+++ b/js/web/craco.config.js
@@ -98,6 +98,9 @@ module.exports = {
 			'lottie-react-native': path.resolve(
 				path.resolve(__dirname, './node_modules/react-native-web-lottie'),
 			),
+			'react-native-permissions': path.resolve(
+				path.resolve(__dirname, './node_modules/react-native-permissions'),
+			),
 		},
 	},
 }

--- a/js/web/package.json
+++ b/js/web/package.json
@@ -7,6 +7,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-native": "^0.67.1",
+    "react-native-permissions": "^3.8.4",
     "react-native-svg-web": "^1.0.9",
     "react-native-web": "^0.17.5",
     "react-native-web-lottie": "^1.4.4"

--- a/js/web/yarn.lock
+++ b/js/web/yarn.lock
@@ -6488,6 +6488,14 @@ find-up@^3.0.0:
   dependencies:
     locate-path "^3.0.0"
 
+find-up@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz#4c92819ecb7083561e4f4a240a86be5198f536fc"
+  integrity sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+  dependencies:
+    locate-path "^6.0.0"
+    path-exists "^4.0.0"
+
 flat-cache@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-3.0.4.tgz#61b0338302b2fe9f957dcc32fc2a87f1c3048b11"
@@ -9178,6 +9186,13 @@ locate-path@^5.0.0:
   dependencies:
     p-locate "^4.1.0"
 
+locate-path@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz#55321eb309febbc59c4801d931a72452a681d286"
+  integrity sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
+  dependencies:
+    p-locate "^5.0.0"
+
 lodash._reinterpolate@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/lodash._reinterpolate/-/lodash._reinterpolate-3.0.0.tgz#0ccf2d89166af03b3663c796538b75ac6e114d9d"
@@ -10503,6 +10518,13 @@ p-locate@^4.1.0:
   dependencies:
     p-limit "^2.2.0"
 
+p-locate@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz#83c8315c6785005e3bd021839411c9e110e6d834"
+  integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
+  dependencies:
+    p-limit "^3.0.2"
+
 p-map@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-map/-/p-map-2.1.0.tgz#310928feef9c9ecc65b68b17693018a665cea175"
@@ -10759,6 +10781,13 @@ pkg-dir@^4.1.0, pkg-dir@^4.2.0:
   integrity sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
   dependencies:
     find-up "^4.0.0"
+
+pkg-dir@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/pkg-dir/-/pkg-dir-5.0.0.tgz#a02d6aebe6ba133a928f74aec20bafdfe6b8e760"
+  integrity sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==
+  dependencies:
+    find-up "^5.0.0"
 
 pkg-up@3.1.0:
   version "3.1.0"
@@ -11827,6 +11856,14 @@ react-native-codegen@^0.0.8:
     flow-parser "^0.121.0"
     jscodeshift "^0.11.0"
     nullthrows "^1.1.1"
+
+react-native-permissions@^3.8.4:
+  version "3.8.4"
+  resolved "https://registry.npmjs.org/react-native-permissions/-/react-native-permissions-3.8.4.tgz#20f203f1dd659c28fb770fc26bbbf0126faa797e"
+  integrity sha512-tJq+5eNqu8Y1PpmuSVMjQtW8E7YJbQ0LSbZ1o9KjgF7etgYmBSZeCR138x715vyZUAtwuecV+ybEM9z8dDs76Q==
+  dependencies:
+    picocolors "^1.0.0"
+    pkg-dir "^5.0.0"
 
 react-native-svg-web@^1.0.9:
   version "1.0.9"

--- a/js/yarn.lock
+++ b/js/yarn.lock
@@ -13766,10 +13766,13 @@ react-native-iphone-x-helper@^1.2.0:
   resolved "https://registry.yarnpkg.com/react-native-iphone-x-helper/-/react-native-iphone-x-helper-1.3.1.tgz#20c603e9a0e765fd6f97396638bdeb0e5a60b010"
   integrity sha512-HOf0jzRnq2/aFUcdCJ9w9JGzN3gdEg0zFE4FyYlp4jtidqU03D5X7ZegGKfT1EWteR0gPBGp9ye5T5FvSWi9Yg==
 
-react-native-permissions@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/react-native-permissions/-/react-native-permissions-3.1.0.tgz#4cff584e0cc567aefe7c10b0d4f74f00950a68dd"
-  integrity sha512-Y/kAU8cUTNhX5CLxfAG96ItEjjmwvyqnVBie38Gj8HoomXQcKM+ToFmq/rPt+DOziCq7YFKinn9AIlnLBiV3AQ==
+react-native-permissions@3.8.4:
+  version "3.8.4"
+  resolved "https://registry.npmjs.org/react-native-permissions/-/react-native-permissions-3.8.4.tgz#20f203f1dd659c28fb770fc26bbbf0126faa797e"
+  integrity sha512-tJq+5eNqu8Y1PpmuSVMjQtW8E7YJbQ0LSbZ1o9KjgF7etgYmBSZeCR138x715vyZUAtwuecV+ybEM9z8dDs76Q==
+  dependencies:
+    picocolors "^1.0.0"
+    pkg-dir "^5.0.0"
 
 react-native-progress@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
Since Android 12, no more needs to ask for `ACCESS_FINE_LOCATION` to enable Bluetooth. Instead, we have to request 3 different Bluetooth permissions to the user: `BLUETOOTH_SCAN`, `BLUETOOTH_ADVERTISE`, and `BLUETOOTH_CONNECT`.
We have also to support Android API level 31 and above that introduces these new permissions.

fixes https://github.com/berty/berty/issues/4733

Tested on iPhone 7 and 8.
Tested on Android 13 and 10.