### PR TITLE
fix: Long user names affect position of QR code

### DIFF
--- a/js/packages/screens/chat/Share/Share.tsx
+++ b/js/packages/screens/chat/Share/Share.tsx
@@ -112,24 +112,36 @@ const ScanBody: FC<{ visible: boolean }> = ({ visible = true }) => {
 }
 
 const ShareQr: FC = () => {
-	const { margin } = useStyles()
+	const { margin, flex } = useStyles()
 	const { windowWidth, windowHeight, scaleSize } = useAppDimensions()
 	const account = useAccount()
 	const qrCodeSize = Math.min(windowHeight, windowWidth) * 0.45
 
 	return (
-		<View>
+		<View
+			style={[
+				{
+					alignItems: 'center',
+					justifyContent: 'center',
+				},
+			]}
+		>
 			<View
 				style={[
+					flex.align.center,
+					flex.justify.center,
+					flex.direction.row,
 					margin.top.big,
 					margin.bottom.small,
-					{ alignItems: 'center', flexDirection: 'row', justifyContent: 'center' },
+					margin.horizontal.big,
 				]}
 			>
 				<View style={[margin.right.small]}>
 					<AccountAvatar size={24 * scaleSize} />
 				</View>
-				<UnifiedText>{account.displayName || ''}</UnifiedText>
+				<UnifiedText numberOfLines={2} ellipsizeMode='tail'>
+					{account.displayName || ''}
+				</UnifiedText>
 			</View>
 			<QrCode size={qrCodeSize} />
 		</View>

--- a/js/packages/screens/chat/Share/__snapshots__/Share.test.tsx.snap
+++ b/js/packages/screens/chat/Share/__snapshots__/Share.test.tsx.snap
@@ -89,10 +89,28 @@ exports[`Chat.Share renders correctly 1`] = `
                 ]
               }
             >
-              <View>
+              <View
+                style={
+                  Array [
+                    Object {
+                      "alignItems": "center",
+                      "justifyContent": "center",
+                    },
+                  ]
+                }
+              >
                 <View
                   style={
                     Array [
+                      Object {
+                        "alignItems": "center",
+                      },
+                      Object {
+                        "justifyContent": "center",
+                      },
+                      Object {
+                        "flexDirection": "row",
+                      },
                       Object {
                         "marginTop": 32,
                       },
@@ -100,9 +118,7 @@ exports[`Chat.Share renders correctly 1`] = `
                         "marginBottom": 9,
                       },
                       Object {
-                        "alignItems": "center",
-                        "flexDirection": "row",
-                        "justifyContent": "center",
+                        "marginHorizontal": 32,
                       },
                     ]
                   }
@@ -190,6 +206,8 @@ exports[`Chat.Share renders correctly 1`] = `
                     </View>
                   </View>
                   <Text
+                    ellipsizeMode="tail"
+                    numberOfLines={2}
                     style={
                       Array [
                         Object {


### PR DESCRIPTION
- Fix for long user names affect position of QR code
- Provides a better fit for long username on the share screen.


<img src="https://github.com/berty/berty/assets/689440/923a307e-0dfe-4901-9b7d-7ad768405fde" width="150" />

<img src="https://github.com/berty/berty/assets/689440/789f023b-a3e1-443d-927b-d559c183f011" width="150" />


fix #4391