### PR TITLE
fix: new screen for Open Source license

### DIFF
--- a/js/packages/i18n/locale/af-ZA/messages.json
+++ b/js/packages/i18n/locale/af-ZA/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": ""
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "",
 			"header-left-button": "",

--- a/js/packages/i18n/locale/ar-SA/messages.json
+++ b/js/packages/i18n/locale/ar-SA/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": "سياسة الخصوصية"
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "أدوات التطوير",
 			"header-left-button": "معلومات الجهاز",

--- a/js/packages/i18n/locale/bg-BG/messages.json
+++ b/js/packages/i18n/locale/bg-BG/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": ""
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "Инструменти за програмисти",
 			"header-left-button": "Информация за устройства",

--- a/js/packages/i18n/locale/ca-ES/messages.json
+++ b/js/packages/i18n/locale/ca-ES/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": ""
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "",
 			"header-left-button": "",

--- a/js/packages/i18n/locale/cs-CZ/messages.json
+++ b/js/packages/i18n/locale/cs-CZ/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": "Zásady ochrany soukromí"
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "Nástroje pro vývojáře",
 			"header-left-button": "Informace o zařízení",

--- a/js/packages/i18n/locale/da-DK/messages.json
+++ b/js/packages/i18n/locale/da-DK/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": "Privatlivspolitik"
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "Udvikler værktøjer",
 			"header-left-button": "Enhedsinfo",

--- a/js/packages/i18n/locale/de-DE/messages.json
+++ b/js/packages/i18n/locale/de-DE/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": "Datenschutzerklärung"
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "Entwicklerwerkzeuge",
 			"header-left-button": "Geräteinformationen",

--- a/js/packages/i18n/locale/el-GR/messages.json
+++ b/js/packages/i18n/locale/el-GR/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": ""
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "",
 			"header-left-button": "",

--- a/js/packages/i18n/locale/en-US/messages.json
+++ b/js/packages/i18n/locale/en-US/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": "Privacy Policy"
 		},
+		"license": {
+			"title": "Open source licence"
+		},
 		"devtools": {
 			"title": "Dev tools",
 			"header-left-button": "Device infos",

--- a/js/packages/i18n/locale/es-ES/messages.json
+++ b/js/packages/i18n/locale/es-ES/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": ""
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "Herramientas de desarrollo",
 			"header-left-button": "Información del dispositivo",

--- a/js/packages/i18n/locale/et-EE/messages.json
+++ b/js/packages/i18n/locale/et-EE/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": ""
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "",
 			"header-left-button": "",

--- a/js/packages/i18n/locale/fa-IR/messages.json
+++ b/js/packages/i18n/locale/fa-IR/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": ""
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "",
 			"header-left-button": "",

--- a/js/packages/i18n/locale/fi-FI/messages.json
+++ b/js/packages/i18n/locale/fi-FI/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": ""
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "",
 			"header-left-button": "",

--- a/js/packages/i18n/locale/fr-FR/messages.json
+++ b/js/packages/i18n/locale/fr-FR/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": "Politique de confidentialité"
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "Outils Dev",
 			"header-left-button": "Infos sur l'appareil",

--- a/js/packages/i18n/locale/he-IL/messages.json
+++ b/js/packages/i18n/locale/he-IL/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": ""
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "",
 			"header-left-button": "",

--- a/js/packages/i18n/locale/hi-IN/messages.json
+++ b/js/packages/i18n/locale/hi-IN/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": ""
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "",
 			"header-left-button": "",

--- a/js/packages/i18n/locale/hu-HU/messages.json
+++ b/js/packages/i18n/locale/hu-HU/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": "Adatvédelmi irányelvek"
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "Fejlesztői eszközök",
 			"header-left-button": "Eszköz információk",

--- a/js/packages/i18n/locale/id-ID/messages.json
+++ b/js/packages/i18n/locale/id-ID/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": ""
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "",
 			"header-left-button": "",

--- a/js/packages/i18n/locale/it-IT/messages.json
+++ b/js/packages/i18n/locale/it-IT/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": ""
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "Strumenti di sviluppo",
 			"header-left-button": "Informazioni sul dispositivo",

--- a/js/packages/i18n/locale/ja-JP/messages.json
+++ b/js/packages/i18n/locale/ja-JP/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": "プライバシーポリシー"
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "開発用ツール",
 			"header-left-button": "端末情報",

--- a/js/packages/i18n/locale/ka-GE/messages.json
+++ b/js/packages/i18n/locale/ka-GE/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": ""
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "",
 			"header-left-button": "",

--- a/js/packages/i18n/locale/ko-KR/messages.json
+++ b/js/packages/i18n/locale/ko-KR/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": ""
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "개발 도구",
 			"header-left-button": "장치 정보",

--- a/js/packages/i18n/locale/my-MM/messages.json
+++ b/js/packages/i18n/locale/my-MM/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": ""
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "",
 			"header-left-button": "",

--- a/js/packages/i18n/locale/nl-NL/messages.json
+++ b/js/packages/i18n/locale/nl-NL/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": ""
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "Ontwikkeling tools",
 			"header-left-button": "Apparaat informatie",

--- a/js/packages/i18n/locale/no-NO/messages.json
+++ b/js/packages/i18n/locale/no-NO/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": ""
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "Verktøy for utviklere",
 			"header-left-button": "Infoer om enheten",

--- a/js/packages/i18n/locale/pl-PL/messages.json
+++ b/js/packages/i18n/locale/pl-PL/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": "Polityka prywatności"
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "Narzędzia deweloperskie",
 			"header-left-button": "Informacje o urządzeniu",

--- a/js/packages/i18n/locale/pt-BR/messages.json
+++ b/js/packages/i18n/locale/pt-BR/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": "Política de privacidade"
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "Ferramentas de desenvolvedor",
 			"header-left-button": "Informações do dispositivo",

--- a/js/packages/i18n/locale/pt-PT/messages.json
+++ b/js/packages/i18n/locale/pt-PT/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": ""
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "",
 			"header-left-button": "",

--- a/js/packages/i18n/locale/ro-RO/messages.json
+++ b/js/packages/i18n/locale/ro-RO/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": ""
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "",
 			"header-left-button": "Informații dispozitiv",

--- a/js/packages/i18n/locale/ru-RU/messages.json
+++ b/js/packages/i18n/locale/ru-RU/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": "Политика Конфиденциальности"
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "Инструменты для разработчиков",
 			"header-left-button": "Информация об устройстве",

--- a/js/packages/i18n/locale/sl-SI/messages.json
+++ b/js/packages/i18n/locale/sl-SI/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": ""
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "",
 			"header-left-button": "",

--- a/js/packages/i18n/locale/sr-Cyrl/messages.json
+++ b/js/packages/i18n/locale/sr-Cyrl/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": ""
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "",
 			"header-left-button": "",

--- a/js/packages/i18n/locale/sv-SE/messages.json
+++ b/js/packages/i18n/locale/sv-SE/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": ""
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "Utvecklingsverktyg",
 			"header-left-button": "Enhetsinformation",

--- a/js/packages/i18n/locale/te-IN/messages.json
+++ b/js/packages/i18n/locale/te-IN/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": ""
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "",
 			"header-left-button": "",

--- a/js/packages/i18n/locale/tr-TR/messages.json
+++ b/js/packages/i18n/locale/tr-TR/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": "Gizlilik Politikası"
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "Geliştirici araçları",
 			"header-left-button": "Aygıt bilgileri",

--- a/js/packages/i18n/locale/uk-UA/messages.json
+++ b/js/packages/i18n/locale/uk-UA/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": ""
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "",
 			"header-left-button": "",

--- a/js/packages/i18n/locale/vi-VN/messages.json
+++ b/js/packages/i18n/locale/vi-VN/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": ""
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "",
 			"header-left-button": "",

--- a/js/packages/i18n/locale/zh-CN/messages.json
+++ b/js/packages/i18n/locale/zh-CN/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": "隐私政策"
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "开发工具",
 			"header-left-button": "设备信息",

--- a/js/packages/i18n/locale/zh-TW/messages.json
+++ b/js/packages/i18n/locale/zh-TW/messages.json
@@ -239,6 +239,9 @@
 		"privacy-policy": {
 			"title": ""
 		},
+		"license": {
+			"title": ""
+		},
 		"devtools": {
 			"title": "開發工具",
 			"header-left-button": "設備信息",

--- a/js/packages/navigation/stacks.tsx
+++ b/js/packages/navigation/stacks.tsx
@@ -647,6 +647,15 @@ export const Navigation: React.FC = React.memo(() => {
 				})}
 			/>
 			<NavigationStack.Screen
+				name='Settings.CodeLicense'
+				component={Components.Settings.CodeLicense}
+				options={BackgroundHeaderScreenOptions({
+					title: t('settings.license.title'),
+					...CustomTitleStyle(),
+					presentation: 'formSheet',
+				})}
+			/>
+			<NavigationStack.Screen
 				name='Settings.Permissions'
 				component={Components.Settings.Permissions}
 				options={{

--- a/js/packages/navigation/types.ts
+++ b/js/packages/navigation/types.ts
@@ -46,6 +46,7 @@ export type ScreensParams = {
 	'Settings.Roadmap': undefined
 	'Settings.Faq': undefined
 	'Settings.PrivacyPolicy': undefined
+	'Settings.CodeLicense': undefined
 
 	'Settings.Home': undefined
 	'Settings.MyBertyId': undefined

--- a/js/packages/screens/settings/AboutBerty/AboutBerty.tsx
+++ b/js/packages/screens/settings/AboutBerty/AboutBerty.tsx
@@ -39,7 +39,10 @@ export const AboutBerty: ScreenFC<'Settings.AboutBerty'> = () => {
 						{t('settings.about.policy-button')}
 					</MenuItemWithIcon>
 					<DividerItem />
-					<MenuItemWithIcon iconName='info-outline'>
+					<MenuItemWithIcon
+						iconName='info-outline'
+						onPress={() => navigate('Settings.CodeLicense')}
+					>
 						{t('settings.about.license-button')}
 					</MenuItemWithIcon>
 				</ItemSection>

--- a/js/packages/screens/settings/AboutBerty/__snapshots__/AboutBerty.test.tsx.snap
+++ b/js/packages/screens/settings/AboutBerty/__snapshots__/AboutBerty.test.tsx.snap
@@ -364,7 +364,7 @@ exports[`Settings.AboutBerty renders correctly 1`] = `
             />
             <View
               accessible={true}
-              focusable={false}
+              focusable={true}
               onClick={[Function]}
               onResponderGrant={[Function]}
               onResponderMove={[Function]}

--- a/js/packages/screens/settings/CodeLicense/CodeLicense.test.tsx
+++ b/js/packages/screens/settings/CodeLicense/CodeLicense.test.tsx
@@ -1,0 +1,8 @@
+import { renderScreen } from '@berty/utils/testing/renderScreen.test'
+
+import { CodeLicense } from './CodeLicense'
+
+test('Settings.CodeLicense renders correctly', async () => {
+	const { toJSON } = renderScreen('Settings.CodeLicense', CodeLicense)
+	expect(toJSON()).toMatchSnapshot()
+})

--- a/js/packages/screens/settings/CodeLicense/CodeLicense.tsx
+++ b/js/packages/screens/settings/CodeLicense/CodeLicense.tsx
@@ -1,0 +1,20 @@
+import { Layout } from '@ui-kitten/components'
+import React from 'react'
+import { StatusBar } from 'react-native'
+
+import { WebViews } from '@berty/components/shared-components'
+import { useThemeColor } from '@berty/hooks'
+import { ScreenFC } from '@berty/navigation'
+
+const CodeLicenseURL = 'https://raw.githubusercontent.com/berty/berty/master/LICENSE-APACHE'
+
+export const CodeLicense: ScreenFC<'Settings.CodeLicense'> = () => {
+	const colors = useThemeColor()
+
+	return (
+		<Layout style={{ flex: 1, backgroundColor: colors['main-background'] }}>
+			<StatusBar barStyle='dark-content' />
+			<WebViews url={CodeLicenseURL} />
+		</Layout>
+	)
+}

--- a/js/packages/screens/settings/CodeLicense/__snapshots__/CodeLicense.test.tsx.snap
+++ b/js/packages/screens/settings/CodeLicense/__snapshots__/CodeLicense.test.tsx.snap
@@ -1,0 +1,390 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Settings.CodeLicense renders correctly 1`] = `
+<RNCSafeAreaProvider
+  onInsetsChange={[Function]}
+  style={
+    Array [
+      Object {
+        "flex": 1,
+      },
+      undefined,
+    ]
+  }
+>
+  <View
+    style={
+      Object {
+        "flex": 1,
+      }
+    }
+  >
+    <View
+      appearance="default"
+      level="1"
+      style={
+        Array [
+          Object {
+            "backgroundColor": "#FFFFFF",
+          },
+          Object {
+            "backgroundColor": "#FFFFFF",
+            "flex": 1,
+          },
+        ]
+      }
+    >
+      <View
+        style={
+          Array [
+            Object {
+              "alignItems": "center",
+              "height": 250,
+              "justifyContent": "center",
+              "top": "25%",
+            },
+            Object {
+              "margin": 32,
+            },
+          ]
+        }
+      >
+        <View
+          style={
+            Array [
+              Object {
+                "paddingHorizontal": 24,
+              },
+              Object {
+                "paddingBottom": 16,
+              },
+              Object {
+                "backgroundColor": "white",
+                "borderRadius": 20,
+                "elevation": 7,
+                "shadowColor": "black",
+                "shadowOffset": Object {
+                  "height": 10,
+                  "width": 0,
+                },
+                "shadowOpacity": 0.1,
+                "shadowRadius": 40,
+              },
+            ]
+          }
+        >
+          <View
+            style={
+              Object {
+                "transform": Array [
+                  Object {
+                    "scale": 1,
+                  },
+                ],
+              }
+            }
+          >
+            <RNSVGMock
+              fill="#535AE4"
+              height={60}
+              style={
+                Array [
+                  Object {
+                    "alignSelf": "center",
+                  },
+                  Object {
+                    "marginTop": 40,
+                  },
+                  Object {
+                    "marginBottom": 9,
+                  },
+                ]
+              }
+              viewBox="0 0 24 24"
+              width={60}
+            />
+          </View>
+          <View
+            style={Array []}
+          >
+            <Text
+              style={
+                Array [
+                  Object {
+                    "fontSize": 30,
+                  },
+                  Object {
+                    "color": "#383B62",
+                    "fontFamily": "Open Sans",
+                  },
+                  Array [
+                    Object {
+                      "textAlign": "center",
+                    },
+                    Object {
+                      "paddingTop": 9,
+                    },
+                    Object {
+                      "fontSize": 44,
+                      "lineHeight": 44,
+                    },
+                    Object {
+                      "fontFamily": "Bold Open Sans",
+                    },
+                  ],
+                ]
+              }
+            >
+              onboarding.web-views.title
+            </Text>
+            <View
+              style={
+                Array [
+                  Object {
+                    "paddingTop": 20,
+                  },
+                  Object {
+                    "flexDirection": "column",
+                  },
+                ]
+              }
+            >
+              <Text
+                style={
+                  Array [
+                    Object {
+                      "fontSize": 30,
+                    },
+                    Object {
+                      "color": "#383B62",
+                      "fontFamily": "Open Sans",
+                    },
+                    Array [
+                      Object {
+                        "textAlign": "center",
+                      },
+                    ],
+                  ]
+                }
+              >
+                onboarding.web-views.desc
+              </Text>
+            </View>
+            <View
+              style={
+                Array [
+                  Object {
+                    "marginTop": 16,
+                  },
+                ]
+              }
+            />
+          </View>
+          <View
+            style={
+              Array [
+                Object {
+                  "marginTop": 16,
+                },
+                Object {
+                  "marginBottom": 9,
+                },
+              ]
+            }
+          >
+            <View
+              style={
+                Object {
+                  "alignItems": "stretch",
+                  "flexDirection": "row",
+                  "justifyContent": "space-evenly",
+                }
+              }
+            >
+              <View
+                style={
+                  Array [
+                    Object {
+                      "flex": 1,
+                    },
+                    Object {
+                      "marginRight": 9,
+                    },
+                  ]
+                }
+              >
+                <View
+                  accessible={true}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "borderColor": "#D2D3E1",
+                      "borderRadius": 8,
+                      "borderWidth": 1,
+                      "flexDirection": "row",
+                      "height": 44,
+                      "justifyContent": "center",
+                      "opacity": 1,
+                    }
+                  }
+                  testID="onboarding.web-views.first-button"
+                >
+                  <View
+                    style={
+                      Object {
+                        "marginRight": 9,
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        Object {
+                          "transform": Array [
+                            Object {
+                              "scale": 1,
+                            },
+                          ],
+                        }
+                      }
+                    >
+                      <RNSVGMock
+                        fill="#D2D3E1"
+                        height={25}
+                        viewBox="0 0 24 24"
+                        width={25}
+                      />
+                    </View>
+                  </View>
+                  <Text
+                    style={
+                      Array [
+                        Object {
+                          "fontSize": 30,
+                        },
+                        Object {
+                          "color": "#383B62",
+                          "fontFamily": "Open Sans",
+                        },
+                        Array [
+                          Object {
+                            "textTransform": "uppercase",
+                          },
+                          Object {
+                            "color": "#D2D3E1",
+                          },
+                          Object {
+                            "fontFamily": "Bold Open Sans",
+                          },
+                        ],
+                      ]
+                    }
+                  >
+                    onboarding.web-views.first-button
+                  </Text>
+                </View>
+              </View>
+              <View
+                style={
+                  Array [
+                    Object {
+                      "flex": 1,
+                    },
+                    Object {
+                      "marginLeft": 9,
+                    },
+                  ]
+                }
+              >
+                <View
+                  accessible={true}
+                  focusable={true}
+                  onClick={[Function]}
+                  onResponderGrant={[Function]}
+                  onResponderMove={[Function]}
+                  onResponderRelease={[Function]}
+                  onResponderTerminate={[Function]}
+                  onResponderTerminationRequest={[Function]}
+                  onStartShouldSetResponder={[Function]}
+                  style={
+                    Object {
+                      "alignItems": "center",
+                      "backgroundColor": "#EAEAFB",
+                      "borderRadius": 8,
+                      "flexDirection": "row",
+                      "height": 44,
+                      "justifyContent": "center",
+                      "opacity": 1,
+                    }
+                  }
+                  testID="onboarding.web-views.second-button"
+                >
+                  <View
+                    style={
+                      Object {
+                        "marginRight": 9,
+                      }
+                    }
+                  >
+                    <View
+                      style={
+                        Object {
+                          "transform": Array [
+                            Object {
+                              "scale": 1,
+                            },
+                          ],
+                        }
+                      }
+                    >
+                      <RNSVGMock
+                        fill="#535AE4"
+                        height={25}
+                        viewBox="0 0 24 24"
+                        width={25}
+                      />
+                    </View>
+                  </View>
+                  <Text
+                    style={
+                      Array [
+                        Object {
+                          "fontSize": 30,
+                        },
+                        Object {
+                          "color": "#383B62",
+                          "fontFamily": "Open Sans",
+                        },
+                        Array [
+                          Object {
+                            "textTransform": "uppercase",
+                          },
+                          Object {
+                            "color": "#535AE4",
+                          },
+                          Object {
+                            "fontFamily": "Bold Open Sans",
+                          },
+                        ],
+                      ]
+                    }
+                  >
+                    onboarding.web-views.second-button
+                  </Text>
+                </View>
+              </View>
+            </View>
+          </View>
+        </View>
+      </View>
+    </View>
+  </View>
+</RNCSafeAreaProvider>
+`;

--- a/js/packages/screens/settings/index.ts
+++ b/js/packages/screens/settings/index.ts
@@ -3,6 +3,7 @@ export { TermsOfUse } from './TermsOfUse/TermsOfUse'
 export { Roadmap } from './Roadmap/Roadmap'
 export { Faq } from './Faq/Faq'
 export { PrivacyPolicy } from './PrivacyPolicy/PrivacyPolicy'
+export { CodeLicense } from './CodeLicense/CodeLicense'
 
 export { SettingsHome } from './SettingsHome/SettingsHome'
 export { MyBertyId } from './MyBertyId/MyBertyId'


### PR DESCRIPTION
Adds a new screen to render the Open Source license disclaimer directly from GitHub raw page.

fix #4257

<img height="400" src="https://github.com/berty/berty/assets/689440/4732bf72-f08f-4520-bc0a-75d3c659b078"/>
<img height="400" src="https://github.com/berty/berty/assets/689440/5570a4fa-ab23-4e9d-8552-2069af00bee4"/>

<!-- Thank you for your contribution! ❤️ -->
