### PR TITLE
chore: Fix text input background color and add additional help command

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -7,6 +7,7 @@
     "ios": "react-native run-ios",
     "start": "react-native start",
     "test": "jest --silent",
+    "test-snapshot-update": "jest -u",
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx",
     "postinstall": "patch-package && node ./fix-types.js && npx jetify",
     "storybook-prestart": "sb-rn-get-stories",

--- a/js/packages/components/inputs/medium/MediumInput.tsx
+++ b/js/packages/components/inputs/medium/MediumInput.tsx
@@ -24,7 +24,7 @@ export const MediumInput: React.FC<InputWithIconProps> = props => {
 
 const styles = StyleSheet.create({
 	button: {
-		backgroundColor: '#F2F2F2',
+		backgroundColor: '#F7F8FE',
 		borderRadius: 14,
 		height: 42,
 		paddingHorizontal: 12,

--- a/js/packages/screens/chat/CreateGroupAddMembers/__snapshots__/CreateGroupAddMembers.test.tsx.snap
+++ b/js/packages/screens/chat/CreateGroupAddMembers/__snapshots__/CreateGroupAddMembers.test.tsx.snap
@@ -235,7 +235,7 @@ exports[`Chat.CreateGroupAddMembers renders correctly 1`] = `
               style={
                 Object {
                   "alignItems": "center",
-                  "backgroundColor": "#F2F2F2",
+                  "backgroundColor": "#F7F8FE",
                   "borderRadius": 14,
                   "flexDirection": "row",
                   "height": 42,

--- a/js/packages/screens/chat/MultiMemberSettingsAddMembers/__snapshots__/MultiMemberSettingsAddMembers.test.tsx.snap
+++ b/js/packages/screens/chat/MultiMemberSettingsAddMembers/__snapshots__/MultiMemberSettingsAddMembers.test.tsx.snap
@@ -235,7 +235,7 @@ exports[`Chat.MultiMemberSettingsAddMembers renders correctly 1`] = `
               style={
                 Object {
                   "alignItems": "center",
-                  "backgroundColor": "#F2F2F2",
+                  "backgroundColor": "#F7F8FE",
                   "borderRadius": 14,
                   "flexDirection": "row",
                   "height": 42,


### PR DESCRIPTION
This pull request fixes the background color of the text input to match the Figma design. 
The screen background has already been fixed in another PR.

It also adds an additional yarn command for regenerating the snapshot files.

Fix #4390 