### PR TITLE
Fix translation escaping unicode chars

### DIFF
--- a/js/packages/screens/chat/Home/components/conversation/ConversationItem.tsx
+++ b/js/packages/screens/chat/Home/components/conversation/ConversationItem.tsx
@@ -72,6 +72,7 @@ export const ConversationItem: React.FC<
 	} else if (chatInputText) {
 		description = t('main.home.conversations.draft', {
 			message: chatInputText,
+			interpolation: { escapeValue: false },
 		})
 	}
 


### PR DESCRIPTION
This pull request fixes an issue with translation escaping unicode characters. I've added the "interpolation: { escapeValue: false }" to avoid escaping the unicode.

fix #4371