### PR TITLE
Fix missing translation

### DIFF
--- a/js/packages/i18n/locale/en-US/messages.json
+++ b/js/packages/i18n/locale/en-US/messages.json
@@ -222,9 +222,9 @@
 		"delete-account": {
 			"title": "Delete account!",
 			"first-desc": "Are you sure you want to delete your account?",
-			"desc-please": "",
-			"desc-delete": "",
-			"desc-confirm": "",
+			"desc-please": "Please type ",
+			"desc-delete": "delete",
+			"desc-confirm": " to confirm",
 			"cancel-button": "Cancel",
 			"delete-button": "Delete"
 		},


### PR DESCRIPTION
This pull request fixes a missing translation in the `messages.json` file. The translation for the `delete-account` section was incomplete, and this PR adds the missing translation.
<img 
width="250"
src="https://github.com/berty/berty/assets/689440/96afba6d-a481-405e-bfe1-191b3f36a662" />
<img 
width="250"
src="https://github.com/berty/berty/assets/689440/c4283cc8-f206-4669-af5a-2ce1704896ac" />