### PR TITLE
Fix broken snapshot tests in PR #4761

### DIFF
--- a/js/packages/screens/account/SelectNode/__snapshots__/SelectNode.test.tsx.snap
+++ b/js/packages/screens/account/SelectNode/__snapshots__/SelectNode.test.tsx.snap
@@ -105,7 +105,8 @@ exports[`Account.SelectNode renders correctly 1`] = `
         <View
           style={
             Object {
-              "width": "75%",
+              "flexShrink": 1,
+              "width": "90%",
             }
           }
         >
@@ -238,7 +239,8 @@ exports[`Account.SelectNode renders correctly 1`] = `
         <View
           style={
             Object {
-              "width": "75%",
+              "flexShrink": 1,
+              "width": "90%",
             }
           }
         >

--- a/js/packages/screens/chat/MultiMemberSettings/__snapshots__/MultiMemberSettings.test.tsx.snap
+++ b/js/packages/screens/chat/MultiMemberSettings/__snapshots__/MultiMemberSettings.test.tsx.snap
@@ -296,7 +296,8 @@ exports[`Chat.MultiMemberSettings renders correctly 1`] = `
                   <View
                     style={
                       Object {
-                        "width": "75%",
+                        "flexShrink": 1,
+                        "width": "90%",
                       }
                     }
                   >
@@ -672,7 +673,8 @@ exports[`Chat.MultiMemberSettings renders correctly 1`] = `
                   <View
                     style={
                       Object {
-                        "width": "75%",
+                        "flexShrink": 1,
+                        "width": "90%",
                       }
                     }
                   >
@@ -836,7 +838,8 @@ exports[`Chat.MultiMemberSettings renders correctly 1`] = `
                   <View
                     style={
                       Object {
-                        "width": "75%",
+                        "flexShrink": 1,
+                        "width": "90%",
                       }
                     }
                   >

--- a/js/packages/screens/chat/Share/__snapshots__/Share.test.tsx.snap
+++ b/js/packages/screens/chat/Share/__snapshots__/Share.test.tsx.snap
@@ -500,7 +500,8 @@ exports[`Chat.Share renders correctly 1`] = `
                 <View
                   style={
                     Object {
-                      "width": "75%",
+                      "flexShrink": 1,
+                      "width": "90%",
                     }
                   }
                 >

--- a/js/packages/screens/onboarding/CustomModeSettings/__snapshots__/CustomModeSettings.test.tsx.snap
+++ b/js/packages/screens/onboarding/CustomModeSettings/__snapshots__/CustomModeSettings.test.tsx.snap
@@ -224,7 +224,8 @@ exports[`Onboarding.CustomModeSettings renders correctly 1`] = `
                       <View
                         style={
                           Object {
-                            "width": "75%",
+                            "flexShrink": 1,
+                            "width": "90%",
                           }
                         }
                       >
@@ -388,7 +389,8 @@ exports[`Onboarding.CustomModeSettings renders correctly 1`] = `
                       <View
                         style={
                           Object {
-                            "width": "75%",
+                            "flexShrink": 1,
+                            "width": "90%",
                           }
                         }
                       >
@@ -552,7 +554,8 @@ exports[`Onboarding.CustomModeSettings renders correctly 1`] = `
                       <View
                         style={
                           Object {
-                            "width": "75%",
+                            "flexShrink": 1,
+                            "width": "90%",
                           }
                         }
                       >
@@ -833,7 +836,8 @@ exports[`Onboarding.CustomModeSettings renders correctly 1`] = `
                       <View
                         style={
                           Object {
-                            "width": "75%",
+                            "flexShrink": 1,
+                            "width": "90%",
                           }
                         }
                       >
@@ -1111,7 +1115,8 @@ exports[`Onboarding.CustomModeSettings renders correctly 1`] = `
                             <View
                               style={
                                 Object {
-                                  "width": "75%",
+                                  "flexShrink": 1,
+                                  "width": "90%",
                                 }
                               }
                             >
@@ -1881,7 +1886,8 @@ exports[`Onboarding.CustomModeSettings renders correctly 1`] = `
                           <View
                             style={
                               Object {
-                                "width": "75%",
+                                "flexShrink": 1,
+                                "width": "90%",
                               }
                             }
                           >
@@ -2535,7 +2541,8 @@ exports[`Onboarding.CustomModeSettings renders correctly 1`] = `
                           <View
                             style={
                               Object {
-                                "width": "75%",
+                                "flexShrink": 1,
+                                "width": "90%",
                               }
                             }
                           >
@@ -3419,7 +3426,8 @@ exports[`Onboarding.CustomModeSettings renders correctly 2`] = `
                       <View
                         style={
                           Object {
-                            "width": "75%",
+                            "flexShrink": 1,
+                            "width": "90%",
                           }
                         }
                       >
@@ -3583,7 +3591,8 @@ exports[`Onboarding.CustomModeSettings renders correctly 2`] = `
                       <View
                         style={
                           Object {
-                            "width": "75%",
+                            "flexShrink": 1,
+                            "width": "90%",
                           }
                         }
                       >
@@ -3747,7 +3756,8 @@ exports[`Onboarding.CustomModeSettings renders correctly 2`] = `
                       <View
                         style={
                           Object {
-                            "width": "75%",
+                            "flexShrink": 1,
+                            "width": "90%",
                           }
                         }
                       >
@@ -4028,7 +4038,8 @@ exports[`Onboarding.CustomModeSettings renders correctly 2`] = `
                       <View
                         style={
                           Object {
-                            "width": "75%",
+                            "flexShrink": 1,
+                            "width": "90%",
                           }
                         }
                       >
@@ -4306,7 +4317,8 @@ exports[`Onboarding.CustomModeSettings renders correctly 2`] = `
                             <View
                               style={
                                 Object {
-                                  "width": "75%",
+                                  "flexShrink": 1,
+                                  "width": "90%",
                                 }
                               }
                             >
@@ -5076,7 +5088,8 @@ exports[`Onboarding.CustomModeSettings renders correctly 2`] = `
                           <View
                             style={
                               Object {
-                                "width": "75%",
+                                "flexShrink": 1,
+                                "width": "90%",
                               }
                             }
                           >
@@ -5730,7 +5743,8 @@ exports[`Onboarding.CustomModeSettings renders correctly 2`] = `
                           <View
                             style={
                               Object {
-                                "width": "75%",
+                                "flexShrink": 1,
+                                "width": "90%",
                               }
                             }
                           >
@@ -6614,7 +6628,8 @@ exports[`Onboarding.CustomModeSettings renders correctly 3`] = `
                       <View
                         style={
                           Object {
-                            "width": "75%",
+                            "flexShrink": 1,
+                            "width": "90%",
                           }
                         }
                       >
@@ -6778,7 +6793,8 @@ exports[`Onboarding.CustomModeSettings renders correctly 3`] = `
                       <View
                         style={
                           Object {
-                            "width": "75%",
+                            "flexShrink": 1,
+                            "width": "90%",
                           }
                         }
                       >
@@ -6942,7 +6958,8 @@ exports[`Onboarding.CustomModeSettings renders correctly 3`] = `
                       <View
                         style={
                           Object {
-                            "width": "75%",
+                            "flexShrink": 1,
+                            "width": "90%",
                           }
                         }
                       >
@@ -7223,7 +7240,8 @@ exports[`Onboarding.CustomModeSettings renders correctly 3`] = `
                       <View
                         style={
                           Object {
-                            "width": "75%",
+                            "flexShrink": 1,
+                            "width": "90%",
                           }
                         }
                       >
@@ -7501,7 +7519,8 @@ exports[`Onboarding.CustomModeSettings renders correctly 3`] = `
                             <View
                               style={
                                 Object {
-                                  "width": "75%",
+                                  "flexShrink": 1,
+                                  "width": "90%",
                                 }
                               }
                             >
@@ -8271,7 +8290,8 @@ exports[`Onboarding.CustomModeSettings renders correctly 3`] = `
                           <View
                             style={
                               Object {
-                                "width": "75%",
+                                "flexShrink": 1,
+                                "width": "90%",
                               }
                             }
                           >
@@ -8925,7 +8945,8 @@ exports[`Onboarding.CustomModeSettings renders correctly 3`] = `
                           <View
                             style={
                               Object {
-                                "width": "75%",
+                                "flexShrink": 1,
+                                "width": "90%",
                               }
                             }
                           >

--- a/js/packages/screens/settings/AboutBerty/__snapshots__/AboutBerty.test.tsx.snap
+++ b/js/packages/screens/settings/AboutBerty/__snapshots__/AboutBerty.test.tsx.snap
@@ -102,7 +102,8 @@ exports[`Settings.AboutBerty renders correctly 1`] = `
                 <View
                   style={
                     Object {
-                      "width": "75%",
+                      "flexShrink": 1,
+                      "width": "90%",
                     }
                   }
                 >
@@ -205,7 +206,8 @@ exports[`Settings.AboutBerty renders correctly 1`] = `
                 <View
                   style={
                     Object {
-                      "width": "75%",
+                      "flexShrink": 1,
+                      "width": "90%",
                     }
                   }
                 >
@@ -308,7 +310,8 @@ exports[`Settings.AboutBerty renders correctly 1`] = `
                 <View
                   style={
                     Object {
-                      "width": "75%",
+                      "flexShrink": 1,
+                      "width": "90%",
                     }
                   }
                 >
@@ -411,7 +414,8 @@ exports[`Settings.AboutBerty renders correctly 1`] = `
                 <View
                   style={
                     Object {
-                      "width": "75%",
+                      "flexShrink": 1,
+                      "width": "90%",
                     }
                   }
                 >

--- a/js/packages/screens/settings/Accounts/__snapshots__/Accounts.test.tsx.snap
+++ b/js/packages/screens/settings/Accounts/__snapshots__/Accounts.test.tsx.snap
@@ -77,7 +77,8 @@ exports[`Settings.Accounts renders correctly 1`] = `
               <View
                 style={
                   Object {
-                    "width": "75%",
+                    "flexShrink": 1,
+                    "width": "90%",
                   }
                 }
               >
@@ -163,7 +164,8 @@ exports[`Settings.Accounts renders correctly 1`] = `
               <View
                 style={
                   Object {
-                    "width": "75%",
+                    "flexShrink": 1,
+                    "width": "90%",
                   }
                 }
               >

--- a/js/packages/screens/settings/Appearance/__snapshots__/Appearance.test.tsx.snap
+++ b/js/packages/screens/settings/Appearance/__snapshots__/Appearance.test.tsx.snap
@@ -77,7 +77,8 @@ exports[`Settings.Appearance renders correctly 1`] = `
               <View
                 style={
                   Object {
-                    "width": "75%",
+                    "flexShrink": 1,
+                    "width": "90%",
                   }
                 }
               >

--- a/js/packages/screens/settings/DevTools/__snapshots__/DevTools.test.tsx.snap
+++ b/js/packages/screens/settings/DevTools/__snapshots__/DevTools.test.tsx.snap
@@ -507,7 +507,8 @@ exports[`Settings.DevTools renders correctly 1`] = `
                 <View
                   style={
                     Object {
-                      "width": "75%",
+                      "flexShrink": 1,
+                      "width": "90%",
                     }
                   }
                 >
@@ -584,7 +585,8 @@ exports[`Settings.DevTools renders correctly 1`] = `
                 <View
                   style={
                     Object {
-                      "width": "75%",
+                      "flexShrink": 1,
+                      "width": "90%",
                     }
                   }
                 >
@@ -703,7 +705,8 @@ exports[`Settings.DevTools renders correctly 1`] = `
                   <View
                     style={
                       Object {
-                        "width": "75%",
+                        "flexShrink": 1,
+                        "width": "90%",
                       }
                     }
                   >
@@ -798,7 +801,8 @@ exports[`Settings.DevTools renders correctly 1`] = `
                   <View
                     style={
                       Object {
-                        "width": "75%",
+                        "flexShrink": 1,
+                        "width": "90%",
                       }
                     }
                   >
@@ -910,7 +914,8 @@ exports[`Settings.DevTools renders correctly 1`] = `
                   <View
                     style={
                       Object {
-                        "width": "75%",
+                        "flexShrink": 1,
+                        "width": "90%",
                       }
                     }
                   >

--- a/js/packages/screens/settings/Network/__snapshots__/Network.test.tsx.snap
+++ b/js/packages/screens/settings/Network/__snapshots__/Network.test.tsx.snap
@@ -93,7 +93,8 @@ exports[`Settings.Network + button onPress works 1`] = `
                 <View
                   style={
                     Object {
-                      "width": "75%",
+                      "flexShrink": 1,
+                      "width": "90%",
                     }
                   }
                 >
@@ -217,7 +218,8 @@ exports[`Settings.Network + button onPress works 1`] = `
                 <View
                   style={
                     Object {
-                      "width": "75%",
+                      "flexShrink": 1,
+                      "width": "90%",
                     }
                   }
                 >
@@ -341,7 +343,8 @@ exports[`Settings.Network + button onPress works 1`] = `
                 <View
                   style={
                     Object {
-                      "width": "75%",
+                      "flexShrink": 1,
+                      "width": "90%",
                     }
                   }
                 >
@@ -473,7 +476,8 @@ exports[`Settings.Network + button onPress works 1`] = `
                 <View
                   style={
                     Object {
-                      "width": "75%",
+                      "flexShrink": 1,
+                      "width": "90%",
                     }
                   }
                 >
@@ -723,7 +727,8 @@ exports[`Settings.Network + button onPress works 1`] = `
                           <View
                             style={
                               Object {
-                                "width": "75%",
+                                "flexShrink": 1,
+                                "width": "90%",
                               }
                             }
                           >
@@ -1360,7 +1365,8 @@ exports[`Settings.Network + button onPress works 1`] = `
                           <View
                             style={
                               Object {
-                                "width": "75%",
+                                "flexShrink": 1,
+                                "width": "90%",
                               }
                             }
                           >
@@ -1988,7 +1994,8 @@ exports[`Settings.Network + button onPress works 1`] = `
                           <View
                             style={
                               Object {
-                                "width": "75%",
+                                "flexShrink": 1,
+                                "width": "90%",
                               }
                             }
                           >
@@ -2559,7 +2566,8 @@ exports[`Settings.Network renders correctly 1`] = `
                 <View
                   style={
                     Object {
-                      "width": "75%",
+                      "flexShrink": 1,
+                      "width": "90%",
                     }
                   }
                 >
@@ -2683,7 +2691,8 @@ exports[`Settings.Network renders correctly 1`] = `
                 <View
                   style={
                     Object {
-                      "width": "75%",
+                      "flexShrink": 1,
+                      "width": "90%",
                     }
                   }
                 >
@@ -2807,7 +2816,8 @@ exports[`Settings.Network renders correctly 1`] = `
                 <View
                   style={
                     Object {
-                      "width": "75%",
+                      "flexShrink": 1,
+                      "width": "90%",
                     }
                   }
                 >
@@ -2939,7 +2949,8 @@ exports[`Settings.Network renders correctly 1`] = `
                 <View
                   style={
                     Object {
-                      "width": "75%",
+                      "flexShrink": 1,
+                      "width": "90%",
                     }
                   }
                 >
@@ -3189,7 +3200,8 @@ exports[`Settings.Network renders correctly 1`] = `
                           <View
                             style={
                               Object {
-                                "width": "75%",
+                                "flexShrink": 1,
+                                "width": "90%",
                               }
                             }
                           >
@@ -3826,7 +3838,8 @@ exports[`Settings.Network renders correctly 1`] = `
                           <View
                             style={
                               Object {
-                                "width": "75%",
+                                "flexShrink": 1,
+                                "width": "90%",
                               }
                             }
                           >
@@ -4454,7 +4467,8 @@ exports[`Settings.Network renders correctly 1`] = `
                           <View
                             style={
                               Object {
-                                "width": "75%",
+                                "flexShrink": 1,
+                                "width": "90%",
                               }
                             }
                           >
@@ -5025,7 +5039,8 @@ exports[`Settings.Network toggle onPress works 1`] = `
                 <View
                   style={
                     Object {
-                      "width": "75%",
+                      "flexShrink": 1,
+                      "width": "90%",
                     }
                   }
                 >
@@ -5149,7 +5164,8 @@ exports[`Settings.Network toggle onPress works 1`] = `
                 <View
                   style={
                     Object {
-                      "width": "75%",
+                      "flexShrink": 1,
+                      "width": "90%",
                     }
                   }
                 >
@@ -5273,7 +5289,8 @@ exports[`Settings.Network toggle onPress works 1`] = `
                 <View
                   style={
                     Object {
-                      "width": "75%",
+                      "flexShrink": 1,
+                      "width": "90%",
                     }
                   }
                 >
@@ -5405,7 +5422,8 @@ exports[`Settings.Network toggle onPress works 1`] = `
                 <View
                   style={
                     Object {
-                      "width": "75%",
+                      "flexShrink": 1,
+                      "width": "90%",
                     }
                   }
                 >
@@ -5655,7 +5673,8 @@ exports[`Settings.Network toggle onPress works 1`] = `
                           <View
                             style={
                               Object {
-                                "width": "75%",
+                                "flexShrink": 1,
+                                "width": "90%",
                               }
                             }
                           >
@@ -6292,7 +6311,8 @@ exports[`Settings.Network toggle onPress works 1`] = `
                           <View
                             style={
                               Object {
-                                "width": "75%",
+                                "flexShrink": 1,
+                                "width": "90%",
                               }
                             }
                           >
@@ -6920,7 +6940,8 @@ exports[`Settings.Network toggle onPress works 1`] = `
                           <View
                             style={
                               Object {
-                                "width": "75%",
+                                "flexShrink": 1,
+                                "width": "90%",
                               }
                             }
                           >

--- a/js/packages/screens/settings/Notifications/__snapshots__/Notifications.test.tsx.snap
+++ b/js/packages/screens/settings/Notifications/__snapshots__/Notifications.test.tsx.snap
@@ -77,7 +77,8 @@ exports[`Settings.Notifications renders correctly 1`] = `
               <View
                 style={
                   Object {
-                    "width": "75%",
+                    "flexShrink": 1,
+                    "width": "90%",
                   }
                 }
               >
@@ -209,7 +210,8 @@ exports[`Settings.Notifications renders correctly 1`] = `
               <View
                 style={
                   Object {
-                    "width": "75%",
+                    "flexShrink": 1,
+                    "width": "90%",
                   }
                 }
               >

--- a/js/packages/screens/settings/SettingsHome/__snapshots__/SettingsHome.test.tsx.snap
+++ b/js/packages/screens/settings/SettingsHome/__snapshots__/SettingsHome.test.tsx.snap
@@ -285,7 +285,8 @@ exports[`Settings.Home renders correctly 1`] = `
                 <View
                   style={
                     Object {
-                      "width": "75%",
+                      "flexShrink": 1,
+                      "width": "90%",
                     }
                   }
                 >
@@ -434,7 +435,8 @@ exports[`Settings.Home renders correctly 1`] = `
                 <View
                   style={
                     Object {
-                      "width": "75%",
+                      "flexShrink": 1,
+                      "width": "90%",
                     }
                   }
                 >
@@ -554,7 +556,8 @@ exports[`Settings.Home renders correctly 1`] = `
                 <View
                   style={
                     Object {
-                      "width": "75%",
+                      "flexShrink": 1,
+                      "width": "90%",
                     }
                   }
                 >
@@ -657,7 +660,8 @@ exports[`Settings.Home renders correctly 1`] = `
                 <View
                   style={
                     Object {
-                      "width": "75%",
+                      "flexShrink": 1,
+                      "width": "90%",
                     }
                   }
                 >
@@ -777,7 +781,8 @@ exports[`Settings.Home renders correctly 1`] = `
                 <View
                   style={
                     Object {
-                      "width": "75%",
+                      "flexShrink": 1,
+                      "width": "90%",
                     }
                   }
                 >

--- a/js/packages/screens/settings/ThemeEditor/__snapshots__/ThemeEditor.test.tsx.snap
+++ b/js/packages/screens/settings/ThemeEditor/__snapshots__/ThemeEditor.test.tsx.snap
@@ -121,7 +121,8 @@ exports[`Settings.ThemeEditor renders correctly 1`] = `
                   <View
                     style={
                       Object {
-                        "width": "75%",
+                        "flexShrink": 1,
+                        "width": "90%",
                       }
                     }
                   >
@@ -239,7 +240,8 @@ exports[`Settings.ThemeEditor renders correctly 1`] = `
                   <View
                     style={
                       Object {
-                        "width": "75%",
+                        "flexShrink": 1,
+                        "width": "90%",
                       }
                     }
                   >
@@ -687,7 +689,8 @@ exports[`Settings.ThemeEditor renders correctly 1`] = `
                     <View
                       style={
                         Object {
-                          "width": "75%",
+                          "flexShrink": 1,
+                          "width": "90%",
                         }
                       }
                     >
@@ -805,7 +808,8 @@ exports[`Settings.ThemeEditor renders correctly 1`] = `
                     <View
                       style={
                         Object {
-                          "width": "75%",
+                          "flexShrink": 1,
+                          "width": "90%",
                         }
                       }
                     >
@@ -923,7 +927,8 @@ exports[`Settings.ThemeEditor renders correctly 1`] = `
                     <View
                       style={
                         Object {
-                          "width": "75%",
+                          "flexShrink": 1,
+                          "width": "90%",
                         }
                       }
                     >


### PR DESCRIPTION
This pull request fixes the width style in multiple components to use flexShrink: 1 and width: "90%" instead of width: "75%". This ensures that the components are displayed correctly on different screen sizes.