### PR TITLE
chore: adding missing library to web project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ all: generate test
 test:
 	cd go; $(MAKE) test
 	cd js; $(MAKE) test
+# install dependencies for lint process
+	cd js/web; yarn
 	cd js; $(MAKE) lint
 .PHONY: test
 


### PR DESCRIPTION
Fix the `make` default command on root folder that generates the following issue:

<img width="795" alt="Screenshot 2024-07-29 at 11 28 29" src="https://github.com/user-attachments/assets/34826c16-c0d3-4d6c-9cb6-54b247b2e2db">
