### PR TITLE
chore: bump-golang-1.23.2

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -6,7 +6,7 @@
 # major version of Go which is allowed by kubo.
 # There is no contraindication for updating it.
 #-----
-golang 1.22.5
+golang 1.23.2
 
 #-----
 # This is the most recent LTS version available to date.


### PR DESCRIPTION
This PR updates golang to version 1.23.2 that fixes an issue where running the binary `berty` fails (either by doing `go build` or `go install`).