### PR TITLE
Fix toggle button positioning on profile screen

### DIFF
--- a/js/ios/Podfile.lock
+++ b/js/ios/Podfile.lock
@@ -253,8 +253,8 @@ PODS:
     - React-jsi (= 0.64.4)
     - React-perflogger (= 0.64.4)
   - React-jsinspector (0.64.4)
-  - react-native-blur (0.8.0):
-    - React
+  - react-native-blur (4.4.1):
+    - React-Core
   - react-native-cameraroll (4.1.2):
     - React-Core
   - react-native-document-picker (8.2.2):
@@ -616,7 +616,7 @@ SPEC CHECKSUMS:
   React-jsi: 64f80675a66899bf0f4a58b8e3908966fa516234
   React-jsiexecutor: 8c077bef1c64430b6034f27df1000d194551e2eb
   React-jsinspector: d4f6973dd474357dbaaf6f52f31ffc713bf3e766
-  react-native-blur: cad4d93b364f91e7b7931b3fa935455487e5c33c
+  react-native-blur: 32db1a8e94964c17f3f85424dd822b2ffa1a83c4
   react-native-cameraroll: 2957f2bce63ae896a848fbe0d5352c1bd4d20866
   react-native-document-picker: cd4d6b36a5207ad7a9e599ebb9eb0c2e84fa0b87
   react-native-restart: 733a51ad137f15b0f8dc34c4082e55af7da00979

--- a/js/packages/components/items/Text.priv.tsx
+++ b/js/packages/components/items/Text.priv.tsx
@@ -18,7 +18,6 @@ export const TextPriv: React.FC<{}> = props => {
 
 const styles = StyleSheet.create({
 	container: {
-		width: '90%',
 		flexShrink: 1,
 	},
 })

--- a/js/packages/screens/account/SelectNode/__snapshots__/SelectNode.test.tsx.snap
+++ b/js/packages/screens/account/SelectNode/__snapshots__/SelectNode.test.tsx.snap
@@ -106,7 +106,6 @@ exports[`Account.SelectNode renders correctly 1`] = `
           style={
             Object {
               "flexShrink": 1,
-              "width": "90%",
             }
           }
         >
@@ -240,7 +239,6 @@ exports[`Account.SelectNode renders correctly 1`] = `
           style={
             Object {
               "flexShrink": 1,
-              "width": "90%",
             }
           }
         >

--- a/js/packages/screens/chat/MultiMemberSettings/__snapshots__/MultiMemberSettings.test.tsx.snap
+++ b/js/packages/screens/chat/MultiMemberSettings/__snapshots__/MultiMemberSettings.test.tsx.snap
@@ -297,7 +297,6 @@ exports[`Chat.MultiMemberSettings renders correctly 1`] = `
                     style={
                       Object {
                         "flexShrink": 1,
-                        "width": "90%",
                       }
                     }
                   >
@@ -674,7 +673,6 @@ exports[`Chat.MultiMemberSettings renders correctly 1`] = `
                     style={
                       Object {
                         "flexShrink": 1,
-                        "width": "90%",
                       }
                     }
                   >
@@ -839,7 +837,6 @@ exports[`Chat.MultiMemberSettings renders correctly 1`] = `
                     style={
                       Object {
                         "flexShrink": 1,
-                        "width": "90%",
                       }
                     }
                   >

--- a/js/packages/screens/chat/Share/__snapshots__/Share.test.tsx.snap
+++ b/js/packages/screens/chat/Share/__snapshots__/Share.test.tsx.snap
@@ -501,7 +501,6 @@ exports[`Chat.Share renders correctly 1`] = `
                   style={
                     Object {
                       "flexShrink": 1,
-                      "width": "90%",
                     }
                   }
                 >

--- a/js/packages/screens/onboarding/CustomModeSettings/__snapshots__/CustomModeSettings.test.tsx.snap
+++ b/js/packages/screens/onboarding/CustomModeSettings/__snapshots__/CustomModeSettings.test.tsx.snap
@@ -225,7 +225,6 @@ exports[`Onboarding.CustomModeSettings renders correctly 1`] = `
                         style={
                           Object {
                             "flexShrink": 1,
-                            "width": "90%",
                           }
                         }
                       >
@@ -390,7 +389,6 @@ exports[`Onboarding.CustomModeSettings renders correctly 1`] = `
                         style={
                           Object {
                             "flexShrink": 1,
-                            "width": "90%",
                           }
                         }
                       >
@@ -555,7 +553,6 @@ exports[`Onboarding.CustomModeSettings renders correctly 1`] = `
                         style={
                           Object {
                             "flexShrink": 1,
-                            "width": "90%",
                           }
                         }
                       >
@@ -837,7 +834,6 @@ exports[`Onboarding.CustomModeSettings renders correctly 1`] = `
                         style={
                           Object {
                             "flexShrink": 1,
-                            "width": "90%",
                           }
                         }
                       >
@@ -1116,7 +1112,6 @@ exports[`Onboarding.CustomModeSettings renders correctly 1`] = `
                               style={
                                 Object {
                                   "flexShrink": 1,
-                                  "width": "90%",
                                 }
                               }
                             >
@@ -1887,7 +1882,6 @@ exports[`Onboarding.CustomModeSettings renders correctly 1`] = `
                             style={
                               Object {
                                 "flexShrink": 1,
-                                "width": "90%",
                               }
                             }
                           >
@@ -2542,7 +2536,6 @@ exports[`Onboarding.CustomModeSettings renders correctly 1`] = `
                             style={
                               Object {
                                 "flexShrink": 1,
-                                "width": "90%",
                               }
                             }
                           >
@@ -3427,7 +3420,6 @@ exports[`Onboarding.CustomModeSettings renders correctly 2`] = `
                         style={
                           Object {
                             "flexShrink": 1,
-                            "width": "90%",
                           }
                         }
                       >
@@ -3592,7 +3584,6 @@ exports[`Onboarding.CustomModeSettings renders correctly 2`] = `
                         style={
                           Object {
                             "flexShrink": 1,
-                            "width": "90%",
                           }
                         }
                       >
@@ -3757,7 +3748,6 @@ exports[`Onboarding.CustomModeSettings renders correctly 2`] = `
                         style={
                           Object {
                             "flexShrink": 1,
-                            "width": "90%",
                           }
                         }
                       >
@@ -4039,7 +4029,6 @@ exports[`Onboarding.CustomModeSettings renders correctly 2`] = `
                         style={
                           Object {
                             "flexShrink": 1,
-                            "width": "90%",
                           }
                         }
                       >
@@ -4318,7 +4307,6 @@ exports[`Onboarding.CustomModeSettings renders correctly 2`] = `
                               style={
                                 Object {
                                   "flexShrink": 1,
-                                  "width": "90%",
                                 }
                               }
                             >
@@ -5089,7 +5077,6 @@ exports[`Onboarding.CustomModeSettings renders correctly 2`] = `
                             style={
                               Object {
                                 "flexShrink": 1,
-                                "width": "90%",
                               }
                             }
                           >
@@ -5744,7 +5731,6 @@ exports[`Onboarding.CustomModeSettings renders correctly 2`] = `
                             style={
                               Object {
                                 "flexShrink": 1,
-                                "width": "90%",
                               }
                             }
                           >
@@ -6629,7 +6615,6 @@ exports[`Onboarding.CustomModeSettings renders correctly 3`] = `
                         style={
                           Object {
                             "flexShrink": 1,
-                            "width": "90%",
                           }
                         }
                       >
@@ -6794,7 +6779,6 @@ exports[`Onboarding.CustomModeSettings renders correctly 3`] = `
                         style={
                           Object {
                             "flexShrink": 1,
-                            "width": "90%",
                           }
                         }
                       >
@@ -6959,7 +6943,6 @@ exports[`Onboarding.CustomModeSettings renders correctly 3`] = `
                         style={
                           Object {
                             "flexShrink": 1,
-                            "width": "90%",
                           }
                         }
                       >
@@ -7241,7 +7224,6 @@ exports[`Onboarding.CustomModeSettings renders correctly 3`] = `
                         style={
                           Object {
                             "flexShrink": 1,
-                            "width": "90%",
                           }
                         }
                       >
@@ -7520,7 +7502,6 @@ exports[`Onboarding.CustomModeSettings renders correctly 3`] = `
                               style={
                                 Object {
                                   "flexShrink": 1,
-                                  "width": "90%",
                                 }
                               }
                             >
@@ -8291,7 +8272,6 @@ exports[`Onboarding.CustomModeSettings renders correctly 3`] = `
                             style={
                               Object {
                                 "flexShrink": 1,
-                                "width": "90%",
                               }
                             }
                           >
@@ -8946,7 +8926,6 @@ exports[`Onboarding.CustomModeSettings renders correctly 3`] = `
                             style={
                               Object {
                                 "flexShrink": 1,
-                                "width": "90%",
                               }
                             }
                           >

--- a/js/packages/screens/settings/AboutBerty/__snapshots__/AboutBerty.test.tsx.snap
+++ b/js/packages/screens/settings/AboutBerty/__snapshots__/AboutBerty.test.tsx.snap
@@ -103,7 +103,6 @@ exports[`Settings.AboutBerty renders correctly 1`] = `
                   style={
                     Object {
                       "flexShrink": 1,
-                      "width": "90%",
                     }
                   }
                 >
@@ -207,7 +206,6 @@ exports[`Settings.AboutBerty renders correctly 1`] = `
                   style={
                     Object {
                       "flexShrink": 1,
-                      "width": "90%",
                     }
                   }
                 >
@@ -311,7 +309,6 @@ exports[`Settings.AboutBerty renders correctly 1`] = `
                   style={
                     Object {
                       "flexShrink": 1,
-                      "width": "90%",
                     }
                   }
                 >
@@ -415,7 +412,6 @@ exports[`Settings.AboutBerty renders correctly 1`] = `
                   style={
                     Object {
                       "flexShrink": 1,
-                      "width": "90%",
                     }
                   }
                 >

--- a/js/packages/screens/settings/Accounts/__snapshots__/Accounts.test.tsx.snap
+++ b/js/packages/screens/settings/Accounts/__snapshots__/Accounts.test.tsx.snap
@@ -78,7 +78,6 @@ exports[`Settings.Accounts renders correctly 1`] = `
                 style={
                   Object {
                     "flexShrink": 1,
-                    "width": "90%",
                   }
                 }
               >
@@ -165,7 +164,6 @@ exports[`Settings.Accounts renders correctly 1`] = `
                 style={
                   Object {
                     "flexShrink": 1,
-                    "width": "90%",
                   }
                 }
               >

--- a/js/packages/screens/settings/Appearance/__snapshots__/Appearance.test.tsx.snap
+++ b/js/packages/screens/settings/Appearance/__snapshots__/Appearance.test.tsx.snap
@@ -78,7 +78,6 @@ exports[`Settings.Appearance renders correctly 1`] = `
                 style={
                   Object {
                     "flexShrink": 1,
-                    "width": "90%",
                   }
                 }
               >

--- a/js/packages/screens/settings/DevTools/__snapshots__/DevTools.test.tsx.snap
+++ b/js/packages/screens/settings/DevTools/__snapshots__/DevTools.test.tsx.snap
@@ -508,7 +508,6 @@ exports[`Settings.DevTools renders correctly 1`] = `
                   style={
                     Object {
                       "flexShrink": 1,
-                      "width": "90%",
                     }
                   }
                 >
@@ -586,7 +585,6 @@ exports[`Settings.DevTools renders correctly 1`] = `
                   style={
                     Object {
                       "flexShrink": 1,
-                      "width": "90%",
                     }
                   }
                 >
@@ -706,7 +704,6 @@ exports[`Settings.DevTools renders correctly 1`] = `
                     style={
                       Object {
                         "flexShrink": 1,
-                        "width": "90%",
                       }
                     }
                   >
@@ -802,7 +799,6 @@ exports[`Settings.DevTools renders correctly 1`] = `
                     style={
                       Object {
                         "flexShrink": 1,
-                        "width": "90%",
                       }
                     }
                   >
@@ -915,7 +911,6 @@ exports[`Settings.DevTools renders correctly 1`] = `
                     style={
                       Object {
                         "flexShrink": 1,
-                        "width": "90%",
                       }
                     }
                   >

--- a/js/packages/screens/settings/Network/__snapshots__/Network.test.tsx.snap
+++ b/js/packages/screens/settings/Network/__snapshots__/Network.test.tsx.snap
@@ -94,7 +94,6 @@ exports[`Settings.Network + button onPress works 1`] = `
                   style={
                     Object {
                       "flexShrink": 1,
-                      "width": "90%",
                     }
                   }
                 >
@@ -219,7 +218,6 @@ exports[`Settings.Network + button onPress works 1`] = `
                   style={
                     Object {
                       "flexShrink": 1,
-                      "width": "90%",
                     }
                   }
                 >
@@ -344,7 +342,6 @@ exports[`Settings.Network + button onPress works 1`] = `
                   style={
                     Object {
                       "flexShrink": 1,
-                      "width": "90%",
                     }
                   }
                 >
@@ -477,7 +474,6 @@ exports[`Settings.Network + button onPress works 1`] = `
                   style={
                     Object {
                       "flexShrink": 1,
-                      "width": "90%",
                     }
                   }
                 >
@@ -728,7 +724,6 @@ exports[`Settings.Network + button onPress works 1`] = `
                             style={
                               Object {
                                 "flexShrink": 1,
-                                "width": "90%",
                               }
                             }
                           >
@@ -1366,7 +1361,6 @@ exports[`Settings.Network + button onPress works 1`] = `
                             style={
                               Object {
                                 "flexShrink": 1,
-                                "width": "90%",
                               }
                             }
                           >
@@ -1995,7 +1989,6 @@ exports[`Settings.Network + button onPress works 1`] = `
                             style={
                               Object {
                                 "flexShrink": 1,
-                                "width": "90%",
                               }
                             }
                           >
@@ -2567,7 +2560,6 @@ exports[`Settings.Network renders correctly 1`] = `
                   style={
                     Object {
                       "flexShrink": 1,
-                      "width": "90%",
                     }
                   }
                 >
@@ -2692,7 +2684,6 @@ exports[`Settings.Network renders correctly 1`] = `
                   style={
                     Object {
                       "flexShrink": 1,
-                      "width": "90%",
                     }
                   }
                 >
@@ -2817,7 +2808,6 @@ exports[`Settings.Network renders correctly 1`] = `
                   style={
                     Object {
                       "flexShrink": 1,
-                      "width": "90%",
                     }
                   }
                 >
@@ -2950,7 +2940,6 @@ exports[`Settings.Network renders correctly 1`] = `
                   style={
                     Object {
                       "flexShrink": 1,
-                      "width": "90%",
                     }
                   }
                 >
@@ -3201,7 +3190,6 @@ exports[`Settings.Network renders correctly 1`] = `
                             style={
                               Object {
                                 "flexShrink": 1,
-                                "width": "90%",
                               }
                             }
                           >
@@ -3839,7 +3827,6 @@ exports[`Settings.Network renders correctly 1`] = `
                             style={
                               Object {
                                 "flexShrink": 1,
-                                "width": "90%",
                               }
                             }
                           >
@@ -4468,7 +4455,6 @@ exports[`Settings.Network renders correctly 1`] = `
                             style={
                               Object {
                                 "flexShrink": 1,
-                                "width": "90%",
                               }
                             }
                           >
@@ -5040,7 +5026,6 @@ exports[`Settings.Network toggle onPress works 1`] = `
                   style={
                     Object {
                       "flexShrink": 1,
-                      "width": "90%",
                     }
                   }
                 >
@@ -5165,7 +5150,6 @@ exports[`Settings.Network toggle onPress works 1`] = `
                   style={
                     Object {
                       "flexShrink": 1,
-                      "width": "90%",
                     }
                   }
                 >
@@ -5290,7 +5274,6 @@ exports[`Settings.Network toggle onPress works 1`] = `
                   style={
                     Object {
                       "flexShrink": 1,
-                      "width": "90%",
                     }
                   }
                 >
@@ -5423,7 +5406,6 @@ exports[`Settings.Network toggle onPress works 1`] = `
                   style={
                     Object {
                       "flexShrink": 1,
-                      "width": "90%",
                     }
                   }
                 >
@@ -5674,7 +5656,6 @@ exports[`Settings.Network toggle onPress works 1`] = `
                             style={
                               Object {
                                 "flexShrink": 1,
-                                "width": "90%",
                               }
                             }
                           >
@@ -6312,7 +6293,6 @@ exports[`Settings.Network toggle onPress works 1`] = `
                             style={
                               Object {
                                 "flexShrink": 1,
-                                "width": "90%",
                               }
                             }
                           >
@@ -6941,7 +6921,6 @@ exports[`Settings.Network toggle onPress works 1`] = `
                             style={
                               Object {
                                 "flexShrink": 1,
-                                "width": "90%",
                               }
                             }
                           >

--- a/js/packages/screens/settings/Notifications/__snapshots__/Notifications.test.tsx.snap
+++ b/js/packages/screens/settings/Notifications/__snapshots__/Notifications.test.tsx.snap
@@ -78,7 +78,6 @@ exports[`Settings.Notifications renders correctly 1`] = `
                 style={
                   Object {
                     "flexShrink": 1,
-                    "width": "90%",
                   }
                 }
               >
@@ -211,7 +210,6 @@ exports[`Settings.Notifications renders correctly 1`] = `
                 style={
                   Object {
                     "flexShrink": 1,
-                    "width": "90%",
                   }
                 }
               >

--- a/js/packages/screens/settings/SettingsHome/__snapshots__/SettingsHome.test.tsx.snap
+++ b/js/packages/screens/settings/SettingsHome/__snapshots__/SettingsHome.test.tsx.snap
@@ -286,7 +286,6 @@ exports[`Settings.Home renders correctly 1`] = `
                   style={
                     Object {
                       "flexShrink": 1,
-                      "width": "90%",
                     }
                   }
                 >
@@ -436,7 +435,6 @@ exports[`Settings.Home renders correctly 1`] = `
                   style={
                     Object {
                       "flexShrink": 1,
-                      "width": "90%",
                     }
                   }
                 >
@@ -557,7 +555,6 @@ exports[`Settings.Home renders correctly 1`] = `
                   style={
                     Object {
                       "flexShrink": 1,
-                      "width": "90%",
                     }
                   }
                 >
@@ -661,7 +658,6 @@ exports[`Settings.Home renders correctly 1`] = `
                   style={
                     Object {
                       "flexShrink": 1,
-                      "width": "90%",
                     }
                   }
                 >
@@ -782,7 +778,6 @@ exports[`Settings.Home renders correctly 1`] = `
                   style={
                     Object {
                       "flexShrink": 1,
-                      "width": "90%",
                     }
                   }
                 >

--- a/js/packages/screens/settings/ThemeEditor/__snapshots__/ThemeEditor.test.tsx.snap
+++ b/js/packages/screens/settings/ThemeEditor/__snapshots__/ThemeEditor.test.tsx.snap
@@ -122,7 +122,6 @@ exports[`Settings.ThemeEditor renders correctly 1`] = `
                     style={
                       Object {
                         "flexShrink": 1,
-                        "width": "90%",
                       }
                     }
                   >
@@ -241,7 +240,6 @@ exports[`Settings.ThemeEditor renders correctly 1`] = `
                     style={
                       Object {
                         "flexShrink": 1,
-                        "width": "90%",
                       }
                     }
                   >
@@ -690,7 +688,6 @@ exports[`Settings.ThemeEditor renders correctly 1`] = `
                       style={
                         Object {
                           "flexShrink": 1,
-                          "width": "90%",
                         }
                       }
                     >
@@ -809,7 +806,6 @@ exports[`Settings.ThemeEditor renders correctly 1`] = `
                       style={
                         Object {
                           "flexShrink": 1,
-                          "width": "90%",
                         }
                       }
                     >
@@ -928,7 +924,6 @@ exports[`Settings.ThemeEditor renders correctly 1`] = `
                       style={
                         Object {
                           "flexShrink": 1,
-                          "width": "90%",
                         }
                       }
                     >


### PR DESCRIPTION
Adjust the width of the container to prevent the toggle button from going out of the screen.

Fixes #4823

![Simulator Screenshot - iPhone 16 - 2024-11-12 at 14 35 19](https://github.com/user-attachments/assets/214c3f23-7f88-408c-a9c4-b0b839dbdd08)
![Simulator Screenshot - iPhone 16 - 2024-11-12 at 14 34 06](https://github.com/user-attachments/assets/34a5cd16-5884-427a-8e4e-796ddc09c92a)
