### PR TITLE
chore: .tool-versions: Update to ruby 3.2.2

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -33,7 +33,7 @@ yarn 1.22.19
 # This is simply the most recent ruby version available to date.
 # There is no contraindication for updating it.
 #-----
-ruby 3.1.3
+ruby 3.2.2
 
 #-----
 # This is simply the most recent golangci-lint version available to date.


### PR DESCRIPTION
Update to ruby 3.2.2 (same version as gnonative, etc.) Hopefully, this will fix the CI build on macOS 15. On my local macOS, `make tests` passes and Berty Messenger builds and runs on iOS simulator.
