### PR TITLE
chore: In berty-bridge-expo/example instructions for Xcode, need npm …

### DIFF
--- a/berty-bridge-expo/example/README.md
+++ b/berty-bridge-expo/example/README.md
@@ -35,6 +35,7 @@ If you prefer to compile with Xcode, open a new terminal in this folder and run:
 ```
 npm install
 npx expo prebuild --clean
+npm start
 ```
 
 Then open `ios/bertybridgeexpoexample.xcworkspace` with Xcode and compile the project.


### PR DESCRIPTION
Small fix to berty-bridge-expo/example instructions
