### PR TITLE
Fix/android ios ci

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -71,7 +71,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ hashFiles('go/**/go.sum') }}
+          key: ${{ runner.os }}-go-${{ env.GO_VERSION }}-${{ hashFiles('go.sum') }}
           restore-keys: ${{ runner.os }}-go-${{ env.GO_VERSION }}-
 
       - name: Cache expo module node modules
@@ -141,5 +141,5 @@ jobs:
             :app:compileDebugKotlin \
             :app:compileDebugJavaWithJavac \
             :app:processDebugResources \
-            --no-daemon --stacktrace --max-workers=2 \
+            --no-daemon --max-workers=2 \
             -PskipGomobile=${SKIP_GOMOBILE}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,17 +1,6 @@
 name: Android
 on:
-  push:
-    tags:
-      - v*
-    branches:
-      - master
-    paths:
-      - "go/**"
-      - "!go/**.md"
-      - "go.*"
-      - "**.go"
-      - "berty-bridge-expo/**"
-      - ".github/workflows/android.yml"
+  workflow_dispatch: {}
   pull_request:
     paths:
       - "go/**"
@@ -91,7 +80,7 @@ jobs:
       - name: Cache gobridge aar
         id: cache-gobridge-aar
         uses: n0izn0iz/mkache@5cedaeaf0b39a9220ae5a815cac8d2a924cee3ef
-        if: github.ref != 'refs/heads/master' # this makes sure the VCS_REF is correct on master
+        if: github.event_name == 'pull_request'
         with:
           rule: android/libs/gobridge.aar
           makefile: berty-bridge-expo/Makefile
@@ -107,21 +96,21 @@ jobs:
 
       - name: Setup Expo and EAS
         uses: expo/expo-github-action@v8
-        if: github.ref == 'refs/heads/master'
+        if: github.event_name == 'workflow_dispatch'
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
           packager: npm
 
       - name: Build the AAB
-        if: github.ref == 'refs/heads/master'
+        if: github.event_name == 'workflow_dispatch'
         working-directory: berty-bridge-expo/mobile
-        run: eas build -p android --non-interactive --local --output=${{ github.workspace }}/app-release.aab
+        run: eas build -p android --profile production --non-interactive --local --output=${{ github.workspace }}/app-release.aab
 
       - name: Upload the AAB
-        if: github.ref == 'refs/heads/master'
+        if: github.event_name == 'workflow_dispatch'
         working-directory: berty-bridge-expo/mobile
-        run: eas upload -p android --non-interactive --local --build-path=${{ github.workspace }}/app-release.aab
+        run: eas upload -p android --profile production --non-interactive --local --build-path=${{ github.workspace }}/app-release.aab
 
       - name: Prebuild Android (PR)
         if: github.event_name == 'pull_request'

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -116,12 +116,12 @@ jobs:
       - name: Build the AAB
         if: github.ref == 'refs/heads/master'
         working-directory: berty-bridge-expo/mobile
-        run: eas build -p android --non-interactive --local --output=${{ github.workspace }}
+        run: eas build -p android --non-interactive --local --output=${{ github.workspace }}/app-release.aab
 
       - name: Upload the AAB
         if: github.ref == 'refs/heads/master'
         working-directory: berty-bridge-expo/mobile
-        run: eas upload -p android --non-interactive --local --build-path=${{ github.workspace }}
+        run: eas upload -p android --non-interactive --local --build-path=${{ github.workspace }}/app-release.aab
 
       - name: Prebuild Android (PR)
         if: github.event_name == 'pull_request'

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,17 +1,6 @@
 name: iOS
 on:
-  push:
-    tags:
-      - v*
-    branches:
-      - master
-    paths:
-      - "go/**"
-      - "!go/**.md"
-      - "go.*"
-      - "**.go"
-      - "berty-bridge-expo/**"
-      - ".github/workflows/ios.yml"
+  workflow_dispatch: {}
   pull_request:
     paths:
       - "go/**"
@@ -85,7 +74,7 @@ jobs:
       - name: Cache bertybridge framework
         id: cache-bertybridge-framework
         uses: n0izn0iz/mkache@5cedaeaf0b39a9220ae5a815cac8d2a924cee3ef
-        if: github.ref != 'refs/heads/master' # this makes sure the VCS_REF is correct on master
+        if: github.event_name == 'pull_request'
         env:
           GOMOBILE_IOS_TARGET: iossimulator
         with:
@@ -96,7 +85,7 @@ jobs:
       - name: Cache bertypush framework
         id: cache-bertypush-framework
         uses: n0izn0iz/mkache@5cedaeaf0b39a9220ae5a815cac8d2a924cee3ef
-        if: github.ref != 'refs/heads/master' # this makes sure the VCS_REF is correct on master
+        if: github.event_name == 'pull_request'
         env:
           GOMOBILE_IOS_TARGET: iossimulator
         with:
@@ -114,16 +103,16 @@ jobs:
 
       - name: Setup Expo and EAS
         uses: expo/expo-github-action@v8
-        if: github.ref == 'refs/heads/master'
+        if: github.event_name == 'workflow_dispatch'
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
           packager: npm
 
       - name: Build the IPA
-        if: github.ref == 'refs/heads/master'
+        if: github.event_name == 'workflow_dispatch'
         working-directory: berty-bridge-expo/mobile
-        run: eas build -p ios --non-interactive --local --output=${{ github.workspace }}/berty-ios.ipa
+        run: eas build -p ios --profile production --non-interactive --local --output=${{ github.workspace }}/berty-ios.ipa
 
       - name: Prebuild iOS (PR)
         if: github.event_name == 'pull_request'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,35 +22,74 @@ jobs:
     name: Semantic release
     runs-on: ubuntu-latest
     outputs:
-      new-release-published: ${{ steps.semantic-echo.outputs.new-release-published }}
-      release-version: ${{ steps.semantic-echo.outputs.release-version }}
+      new-release-published: ${{ steps.semantic.outputs.new_release_published }}
+      release-version: ${{ steps.semantic.outputs.new_release_version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
-      - name: Unshallow
-        run: git fetch --prune --unshallow
-
-      - name: Run Semantic Release
-        id: semantic
-        uses: docker://ghcr.io/codfish/semantic-release-action:v1
         with:
-          branches: |
-            ['master']
-          plugins: |
-            [
-              '@semantic-release/commit-analyzer',
-              '@semantic-release/release-notes-generator',
-              '@semantic-release/github'
-            ]
+          fetch-depth: 0
+
+      - name: Setup asdf
+        uses: asdf-vm/actions/setup@9cd779f40fe38688dd19505ccbc4eaaf018b44e7
+        with:
+          asdf_version: 0.16.7
+
+      - name: Setup node
+        working-directory: berty-bridge-expo
+        run: |
+          asdf plugin add nodejs
+          asdf install nodejs
+          echo "NODE_VERSION=$(asdf current nodejs | xargs | cut -d ' ' -f 6)" >> $GITHUB_ENV
+
+      - name: Set nodejs as global exec
+        run: asdf set -u nodejs ${{ env.NODE_VERSION }}
+
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v4
+        id: semantic
+        with:
+          working_directory: ./berty-bridge-expo/mobile
+          extra_plugins: |
+            semantic-release-expo
+            @semantic-release/git
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Export Semantic Release
-        id: semantic-echo
-        run: |
-          echo "::set-output name=new-release-published::${{steps.semantic.outputs.new-release-published}}"
-          echo "::set-output name=release-version::${{steps.semantic.outputs.release-version}}"
+      - name: Check changed paths
+        if: steps.semantic.outputs.new_release_published == 'true'
+        uses: dorny/paths-filter@v3
+        id: changes
+        with:
+          filters: |
+            android:
+              - "go/**"
+              - "!go/**.md"
+              - "go.*"
+              - "**.go"
+              - "berty-bridge-expo/**"
+              - ".github/workflows/android.yml"
+              - ".github/workflows/release.yml"
+            ios:
+              - "go/**"
+              - "!go/**.md"
+              - "go.*"
+              - "**.go"
+              - "berty-bridge-expo/**"
+              - ".github/workflows/ios.yml"
+              - ".github/workflows/release.yml"
+
+      - name: Trigger Android build
+        if: steps.semantic.outputs.new_release_published == 'true' && steps.changes.outputs.android == 'true'
+        run: gh workflow run android.yml --ref master
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Trigger iOS build
+        if: steps.semantic.outputs.new_release_published == 'true' && steps.changes.outputs.ios == 'true'
+        run: gh workflow run ios.yml --ref master
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   release-on-stores:
     name: Release on stores

--- a/berty-bridge-expo/Makefile
+++ b/berty-bridge-expo/Makefile
@@ -50,6 +50,7 @@ $(IOS_OUTPUT_BERTYBRIDGE_FRAMEWORK): $(bridge_src)
 
 	touch $(abspath $@)
 	cd .. && $(GO) mod tidy
+	chmod -R u+w $(gomobile_cache_abs) 2>/dev/null || true
 
 $(IOS_OUTPUT_BERTYPUSH_FRAMEWORK): $(bridge_src)
 	cd .. && $(GO) mod download
@@ -73,6 +74,7 @@ $(IOS_OUTPUT_BERTYPUSH_FRAMEWORK): $(bridge_src)
 
 	touch $(abspath $@)
 	cd .. && $(GO) mod tidy
+	chmod -R u+w $(gomobile_cache_abs) 2>/dev/null || true
 
 #### Android
 

--- a/berty-bridge-expo/mobile/.releaserc
+++ b/berty-bridge-expo/mobile/.releaserc
@@ -1,0 +1,13 @@
+{
+  "branches": ["master"],
+  "plugins": [
+    "semantic-release-expo",
+    "@semantic-release/commit-analyzer",
+    "@semantic-release/release-notes-generator",
+    ["@semantic-release/git", {
+      "assets": ["app.json"],
+      "message": "chore(release): ${nextRelease.version} [skip ci]"
+    }],
+    "@semantic-release/github"
+  ]
+}

--- a/berty-bridge-expo/mobile/app.config.ts
+++ b/berty-bridge-expo/mobile/app.config.ts
@@ -1,5 +1,4 @@
 import { ExpoConfig, ConfigContext } from "expo/config";
-import { version } from "./package.json";
 
 // App production config
 const APP_NAME = "Berty";
@@ -21,7 +20,6 @@ export default ({ config }: ConfigContext): ExpoConfig => {
 	return {
 		...config,
 		name: name,
-		version, // Automatically bump your project version with `npm version patch`, `npm version minor` or `npm version major`.
 		slug: "berty",
 		platforms: ["ios", "android"],
 		orientation: "portrait",
@@ -38,6 +36,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
 		ios: {
 			supportsTablet: true,
 			bundleIdentifier: bundleIdentifier,
+			buildNumber: config.ios?.buildNumber,
 			config: {
 				usesNonExemptEncryption: false,
 			},
@@ -48,6 +47,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
 				backgroundColor: "#ffffff",
 			},
 			package: packageName,
+			versionCode: config.android?.versionCode,
 			googleServicesFile: "./google-services.json",
 		},
 		updates: {

--- a/berty-bridge-expo/mobile/app.config.ts
+++ b/berty-bridge-expo/mobile/app.config.ts
@@ -38,6 +38,9 @@ export default ({ config }: ConfigContext): ExpoConfig => {
 		ios: {
 			supportsTablet: true,
 			bundleIdentifier: bundleIdentifier,
+			config: {
+				usesNonExemptEncryption: false,
+			},
 		},
 		android: {
 			adaptiveIcon: {

--- a/berty-bridge-expo/mobile/app.json
+++ b/berty-bridge-expo/mobile/app.json
@@ -1,0 +1,11 @@
+{
+  "expo": {
+    "version": "1.0.0",
+    "ios": {
+      "buildNumber": "1"
+    },
+    "android": {
+      "versionCode": 1
+    }
+  }
+}

--- a/berty-bridge-expo/mobile/eas.json
+++ b/berty-bridge-expo/mobile/eas.json
@@ -1,12 +1,15 @@
 {
   "cli": {
     "version": ">= 16.17.0",
-    "appVersionSource": "remote"
+    "appVersionSource": "local"
   },
   "build": {
     "development": {
       "developmentClient": true,
-      "distribution": "internal"
+      "distribution": "internal",
+      "env": {
+        "APP_ENV": "development"
+      }
     },
     "ios-simulator": {
       "extends": "development",
@@ -15,10 +18,15 @@
       }
     },
     "preview": {
-      "distribution": "internal"
+      "distribution": "internal",
+      "env": {
+        "APP_ENV": "preview"
+      }
     },
     "production": {
-      "autoIncrement": true
+      "env": {
+        "APP_ENV": "production"
+      }
     }
   },
   "submit": {

--- a/berty-bridge-expo/mobile/eas.json
+++ b/berty-bridge-expo/mobile/eas.json
@@ -1,7 +1,6 @@
 {
   "cli": {
-    "version": ">= 16.17.0",
-    "appVersionSource": "local"
+    "version": ">= 16.17.0"
   },
   "build": {
     "development": {

--- a/berty-bridge-expo/mobile/src/contexts/notification.context.tsx
+++ b/berty-bridge-expo/mobile/src/contexts/notification.context.tsx
@@ -88,7 +88,6 @@ const PushNotificationBridge = () => {
 						}
 						payload =
 							data.payload === undefined ? {} : pbobj.decode(data.payload)
-				console.log("remi: notification interacted with", data)
 				}
 			});
 

--- a/berty-bridge-expo/mobile/src/hooks/messenger.hooks.ts
+++ b/berty-bridge-expo/mobile/src/hooks/messenger.hooks.ts
@@ -69,7 +69,6 @@ export const useMember = (
 const State = beapi.messenger.Contact.State;
 
 export const useIncomingContactRequests = () => {
-	console.log('remi: calling useIncomingContactRequests')
 	const contacts = useAllContacts()
 	return useMemo(
 		() => contacts.filter(c => toStateNumber(c.state) === State.IncomingRequest),


### PR DESCRIPTION
## Summary

- **Fix Android CI**: `eas build --output` was pointing to the workspace directory instead of a file path, causing the build to fail when trying to overwrite the checkout directory with the `.aab` file
- **Fix iOS CI**: EAS local build failed during cleanup because gomobile's internal Go module cache creates read-only files (`0444`); fixed by adding `chmod -R u+w` to the iOS gomobile Makefile targets so files are writable before EAS cleans up its temp directory
- **Wire semantic-release to mobile builds**: replace the old docker-based semantic-release action with `cycjimmy/semantic-release-action@v4` and integrate `semantic-release-expo` so each release automatically bumps `version`, `ios.buildNumber`, and `android.versionCode` in `app.json`; android/ios production builds are then dispatched via `gh workflow run` only when a new release is published and relevant files changed
- **Remove debug logs** in `notification.context.tsx` and `messenger.hooks.ts`

## Details

**Version management** (`eas.json`, `app.config.ts`, `app.json`, `.releaserc`):
- `semantic-release-expo` now owns versioning — it writes `version`, `buildNumber`, and `versionCode` to `app.json` on each release, committed back by `@semantic-release/git`
- `app.config.ts` no longer imports version from `package.json`; it forwards `buildNumber` and `versionCode` from the Expo config context (which merges `app.json`)
- `APP_ENV` env var added to `eas.json` profiles so `app.config.ts` can select the right bundle identifier per environment

**CI flow** (`android.yml`, `ios.yml`, `release.yml`):
- Android and iOS workflows no longer trigger on master push; they now only run via `workflow_dispatch` (dispatched by `release.yml` after a successful semantic release)
- Path filtering is preserved: `dorny/paths-filter` in `release.yml` checks that Go or `berty-bridge-expo` files actually changed before dispatching each platform's build
- `--profile production` made explicit on all `eas build` / `eas upload` commands
