### PR TITLE
fix: wire semantic-release-expo to local Android and iOS builds

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,6 +1,11 @@
 name: Android
 on:
-  workflow_dispatch: {}
+  workflow_call:
+    inputs:
+      app-json-artifact:
+        type: string
+        required: false
+        default: ''
   pull_request:
     paths:
       - "go/**"
@@ -21,6 +26,13 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Download patched app.json
+        if: inputs.app-json-artifact != ''
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.app-json-artifact }}
+          path: berty-bridge-expo/mobile
 
       - name: Setup asdf
         uses: asdf-vm/actions/setup@9cd779f40fe38688dd19505ccbc4eaaf018b44e7
@@ -96,19 +108,19 @@ jobs:
 
       - name: Setup Expo and EAS
         uses: expo/expo-github-action@v8
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_call'
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
           packager: npm
 
       - name: Build the AAB
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_call'
         working-directory: berty-bridge-expo/mobile
         run: eas build -p android --profile production --non-interactive --local --output=${{ github.workspace }}/app-release.aab
 
       - name: Upload the AAB
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_call'
         working-directory: berty-bridge-expo/mobile
         run: eas upload -p android --profile production --non-interactive --local --build-path=${{ github.workspace }}/app-release.aab
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,6 +1,11 @@
 name: iOS
 on:
-  workflow_dispatch: {}
+  workflow_call:
+    inputs:
+      app-json-artifact:
+        type: string
+        required: false
+        default: ''
   pull_request:
     paths:
       - "go/**"
@@ -21,6 +26,13 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      - name: Download patched app.json
+        if: inputs.app-json-artifact != ''
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ inputs.app-json-artifact }}
+          path: berty-bridge-expo/mobile
 
       - name: Setup asdf
         uses: asdf-vm/actions/setup@9cd779f40fe38688dd19505ccbc4eaaf018b44e7
@@ -103,14 +115,14 @@ jobs:
 
       - name: Setup Expo and EAS
         uses: expo/expo-github-action@v8
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_call'
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
           packager: npm
 
       - name: Build the IPA
-        if: github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_call'
         working-directory: berty-bridge-expo/mobile
         run: eas build -p ios --profile production --non-interactive --local --output=${{ github.workspace }}/berty-ios.ipa
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
     outputs:
       new-release-published: ${{ steps.semantic.outputs.new_release_published }}
       release-version: ${{ steps.semantic.outputs.new_release_version }}
+      android-changed: ${{ steps.changes.outputs.android }}
+      ios-changed: ${{ steps.changes.outputs.ios }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -52,7 +54,6 @@ jobs:
           working_directory: ./berty-bridge-expo/mobile
           extra_plugins: |
             semantic-release-expo
-            @semantic-release/git
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
@@ -79,17 +80,30 @@ jobs:
               - ".github/workflows/ios.yml"
               - ".github/workflows/release.yml"
 
-      - name: Trigger Android build
-        if: steps.semantic.outputs.new_release_published == 'true' && steps.changes.outputs.android == 'true'
-        run: gh workflow run android.yml --ref master
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Upload patched app.json
+        if: steps.semantic.outputs.new_release_published == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: app-json
+          path: berty-bridge-expo/mobile/app.json
 
-      - name: Trigger iOS build
-        if: steps.semantic.outputs.new_release_published == 'true' && steps.changes.outputs.ios == 'true'
-        run: gh workflow run ios.yml --ref master
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  build-android:
+    name: Build for Android
+    needs: semantic-release
+    if: needs.semantic-release.outputs.new-release-published == 'true' && needs.semantic-release.outputs.android-changed == 'true'
+    uses: ./.github/workflows/android.yml
+    with:
+      app-json-artifact: app-json
+    secrets: inherit
+
+  build-ios:
+    name: Build for iOS
+    needs: semantic-release
+    if: needs.semantic-release.outputs.new-release-published == 'true' && needs.semantic-release.outputs.ios-changed == 'true'
+    uses: ./.github/workflows/ios.yml
+    with:
+      app-json-artifact: app-json
+    secrets: inherit
 
   release-on-stores:
     name: Release on stores

--- a/berty-bridge-expo/mobile/.releaserc
+++ b/berty-bridge-expo/mobile/.releaserc
@@ -4,10 +4,6 @@
     "semantic-release-expo",
     "@semantic-release/commit-analyzer",
     "@semantic-release/release-notes-generator",
-    ["@semantic-release/git", {
-      "assets": ["app.json"],
-      "message": "chore(release): ${nextRelease.version} [skip ci]"
-    }],
     "@semantic-release/github"
   ]
 }


### PR DESCRIPTION
## Summary

- **Fix Android CI**: `eas build --output` was pointing to the workspace directory instead of a file path, causing EAS to fail when trying to overwrite the checkout directory with the `.aab`
- **Fix iOS CI**: EAS local build failed during cleanup because gomobile's internal Go module cache creates read-only files; fixed by adding `chmod -R u+w` to the iOS gomobile Makefile targets
- **Integrate semantic-release-expo**: replace the old docker-based semantic-release action with `cycjimmy/semantic-release-action@v4` + `semantic-release-expo`, which automatically bumps `version`, `ios.buildNumber` and `android.versionCode` in `app.json` on each release
- **Wire versioned builds**: `app.json` is patched in the `semantic-release` job then shared via GitHub artifact to `build-android` and `build-ios` jobs (reusable `workflow_call`), so local EAS builds pick up the correct version without committing back to master
- **Remove debug logs** in `notification.context.tsx` and `messenger.hooks.ts`

## Details

**Version management** (`eas.json`, `app.config.ts`, `app.json`, `.releaserc`):
- `semantic-release-expo` owns versioning — on each release it writes `version`, `buildNumber` and `versionCode` to `app.json`; the patched file is uploaded as a CI artifact and consumed by the build jobs
- `app.config.ts` no longer imports version from `package.json`; it forwards `buildNumber` and `versionCode` from the Expo config context (which merges `app.json`)
- `APP_ENV` env var added to `eas.json` profiles so `app.config.ts` selects the right bundle identifier per environment

**CI flow** (`android.yml`, `ios.yml`, `release.yml`):
- `android.yml` and `ios.yml` now expose a `workflow_call` trigger with an optional `app-json-artifact` input; when called from `release.yml` they download the patched `app.json` before building; for PRs the input is empty and the step is skipped — compile checks work unchanged
- `release.yml` uploads the patched `app.json` as an artifact after semantic release, then calls `android.yml` / `ios.yml` as reusable workflows (`needs: semantic-release`), gated by both a new release being published and path filters (`go/**`, `berty-bridge-expo/**`, workflow files)
- `--profile production` made explicit on all `eas build` / `eas upload` commands