### PR TITLE
fix: android and ios jobs when PR are merged

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -108,19 +108,19 @@ jobs:
 
       - name: Setup Expo and EAS
         uses: expo/expo-github-action@v8
-        if: github.event_name == 'workflow_call'
+        if: inputs.app-json-artifact != ''
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
           packager: npm
 
       - name: Build the AAB
-        if: github.event_name == 'workflow_call'
+        if: inputs.app-json-artifact != ''
         working-directory: berty-bridge-expo/mobile
         run: eas build -p android --profile production --non-interactive --local --output=${{ github.workspace }}/app-release.aab
 
       - name: Upload the AAB
-        if: github.event_name == 'workflow_call'
+        if: inputs.app-json-artifact != ''
         working-directory: berty-bridge-expo/mobile
         run: eas upload -p android --profile production --non-interactive --local --build-path=${{ github.workspace }}/app-release.aab
 

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -115,14 +115,14 @@ jobs:
 
       - name: Setup Expo and EAS
         uses: expo/expo-github-action@v8
-        if: github.event_name == 'workflow_call'
+        if: inputs.app-json-artifact != ''
         with:
           eas-version: latest
           token: ${{ secrets.EXPO_TOKEN }}
           packager: npm
 
       - name: Build the IPA
-        if: github.event_name == 'workflow_call'
+        if: inputs.app-json-artifact != ''
         working-directory: berty-bridge-expo/mobile
         run: eas build -p ios --profile production --non-interactive --local --output=${{ github.workspace }}/berty-ios.ipa
 


### PR DESCRIPTION
## Summary

- Fix Android and iOS production builds being silently skipped when triggered as reusable workflows from `release.yml`

## Details

The build steps (`Setup Expo and EAS`, `Build the AAB` / `Build the IPA`, `Upload`) were conditioned on `github.event_name == 'workflow_call'`, but GitHub passes the **caller's** event name (`push`) into reusable workflows — not `workflow_call`. As a result all production build steps were skipped while the job still reported success.

Replaced the condition with `inputs.app-json-artifact != ''`, which is already the correct signal: the artifact input is only set when the workflow is called from `release.yml` for a production build, and empty for PR compile checks.