### PR TITLE
fix: android ios ci

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -126,6 +126,11 @@ jobs:
         working-directory: berty-bridge-expo/mobile
         run: eas build -p ios --profile production --non-interactive --local --output=${{ github.workspace }}/berty-ios.ipa
 
+      - name: Upload the IPA
+        if: inputs.app-json-artifact != ''
+        working-directory: berty-bridge-expo/mobile
+        run: eas upload -p ios --profile production --non-interactive --local --build-path=${{ github.workspace }}/berty-ios.ipa
+
       - name: Prebuild iOS (PR)
         if: github.event_name == 'pull_request'
         working-directory: berty-bridge-expo/mobile

--- a/berty-bridge-expo/mobile/eas.json
+++ b/berty-bridge-expo/mobile/eas.json
@@ -1,6 +1,7 @@
 {
   "cli": {
-    "version": ">= 16.17.0"
+    "version": ">= 16.17.0",
+    "appVersionSource": "local"
   },
   "build": {
     "development": {


### PR DESCRIPTION
## Summary

- Fix Android production build crashing with `versionCode is set to 0`
- Fix iOS missing upload step to App Store

## Details

**`eas.json` — restore `appVersionSource: "local"`**

Removing this field caused EAS to default to `"remote"` version tracking. Since no remote version data exists (we previously used `"local"`), EAS fell back to `versionCode: 0`, which is rejected by the React Native Gradle plugin with:
```
android.defaultConfig.versionCode is set to 0, but it should be a positive integer.
```
With `"local"`, EAS reads `versionCode` and `buildNumber` directly from `app.json`, which is exactly what `semantic-release-expo` patches before the build runs.

**`ios.yml` — add Upload the IPA step**

The iOS workflow was building the IPA but never uploading it to the App Store. Added `eas upload -p ios --profile production` to match the Android workflow.

**`android.yml` / `ios.yml` — fix build step condition**

`github.event_name == 'workflow_call'` evaluated to `false` inside reusable workflows because GitHub passes the caller's event name (`push`) rather than `workflow_call`. Replaced with `inputs.app-json-artifact != ''` which directly reflects whether the workflow was invoked for a production build.