### PR TITLE
fix: android/ios ci build

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Upload the AAB
         if: inputs.app-json-artifact != ''
         working-directory: berty-bridge-expo/mobile
-        run: eas upload -p android --profile production --non-interactive --local --build-path=${{ github.workspace }}/app-release.aab
+        run: eas upload -p android --non-interactive --build-path=${{ github.workspace }}/app-release.aab
 
       - name: Prebuild Android (PR)
         if: github.event_name == 'pull_request'

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Upload the IPA
         if: inputs.app-json-artifact != ''
         working-directory: berty-bridge-expo/mobile
-        run: eas upload -p ios --profile production --non-interactive --local --build-path=${{ github.workspace }}/berty-ios.ipa
+        run: eas upload -p ios --non-interactive --build-path=${{ github.workspace }}/berty-ios.ipa
 
       - name: Prebuild iOS (PR)
         if: github.event_name == 'pull_request'

--- a/berty-bridge-expo/mobile/app.json
+++ b/berty-bridge-expo/mobile/app.json
@@ -1,6 +1,7 @@
 {
   "expo": {
     "version": "1.0.0",
+    "sdkVersion": "54.0.0",
     "ios": {
       "buildNumber": "1"
     },


### PR DESCRIPTION
## fix: android and iOS CI upload steps

### Android

**Root cause:** `semantic-release-expo` computes the Android `versionCode` using the formula:

```
expo.major × 10,000,000 + next.major × 10,000 + next.minor × 100 + next.patch
```

where `expo` is parsed from `sdkVersion` in `app.json`. Without that field, `expo` is `null`, the package falls back to the string `'000000000'`, and `parseInt('000000000', 10) = 0` — a value Gradle rejects with `android.defaultConfig.versionCode is set to 0, but it should be a positive integer`.

**Fix:** add `"sdkVersion": "54.0.0"` to `app.json`. For version `2.471.5` this produces `versionCode = 540,067,105`.

### Android & iOS

**Root cause:** both upload steps used `eas upload` with `--profile` and `--local`, which are not valid flags for that command, causing `Nonexistent flags: --profile, --local`.

**Fix:** remove the two unsupported flags; `--build-path` and `--non-interactive` are sufficient.