### PR TITLE
fix: android ios ci

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -117,6 +117,8 @@ jobs:
       - name: Build the AAB
         if: inputs.app-json-artifact != ''
         working-directory: berty-bridge-expo/mobile
+        env:
+          APP_ENV: production
         run: eas build -p android --profile production --non-interactive --local --output=${{ github.workspace }}/app-release.aab
 
       - name: Upload the AAB

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -122,7 +122,7 @@ jobs:
       - name: Upload the AAB
         if: inputs.app-json-artifact != ''
         working-directory: berty-bridge-expo/mobile
-        run: eas upload -p android --profile production --non-interactive --local --build-path=${{ github.workspace }}/app-release.aab
+        run: eas upload -p android --non-interactive --build-path=${{ github.workspace }}/app-release.aab
 
       - name: Prebuild Android (PR)
         if: github.event_name == 'pull_request'

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -34,6 +34,9 @@ jobs:
           name: ${{ inputs.app-json-artifact }}
           path: berty-bridge-expo/mobile
 
+      - name: Select Xcode 26
+        run: sudo xcode-select -s /Applications/Xcode_26.app/Contents/Developer
+
       - name: Setup asdf
         uses: asdf-vm/actions/setup@9cd779f40fe38688dd19505ccbc4eaaf018b44e7
         with:
@@ -124,6 +127,8 @@ jobs:
       - name: Build the IPA
         if: inputs.app-json-artifact != ''
         working-directory: berty-bridge-expo/mobile
+        env:
+          APP_ENV: production
         run: eas build -p ios --profile production --non-interactive --local --output=${{ github.workspace }}/berty-ios.ipa
 
       - name: Upload the IPA

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -129,7 +129,7 @@ jobs:
       - name: Upload the IPA
         if: inputs.app-json-artifact != ''
         working-directory: berty-bridge-expo/mobile
-        run: eas upload -p ios --profile production --non-interactive --local --build-path=${{ github.workspace }}/berty-ios.ipa
+        run: eas upload -p ios --non-interactive --build-path=${{ github.workspace }}/berty-ios.ipa
 
       - name: Prebuild iOS (PR)
         if: github.event_name == 'pull_request'

--- a/berty-bridge-expo/mobile/app.json
+++ b/berty-bridge-expo/mobile/app.json
@@ -1,6 +1,7 @@
 {
   "expo": {
     "version": "1.0.0",
+    "sdkVersion": "54.0.0",
     "ios": {
       "buildNumber": "1"
     },


### PR DESCRIPTION
## fix: bundle ID and Xcode version for iOS and Android production builds

### Wrong bundle ID (`tech.berty.ios.debug` instead of `tech.berty.ios`)

`app.config.ts` reads `process.env.APP_ENV` to pick the bundle identifier, defaulting to `"development"` → `tech.berty.ios.debug` / `tech.berty.android.debug` when unset. While `eas build --profile production` should inject `APP_ENV=production` from `eas.json`, it may not be propagated to the subprocess that evaluates the config during `expo prebuild`.

**Fix:** explicitly set `APP_ENV: production` as an env var on both build steps.

### iOS built with iOS 18.5 SDK (rejected by App Store Connect)

The `macos-latest` runner defaults to Xcode 16.4 (iOS 18.5 SDK), but App Store Connect now requires iOS 26 SDK. Xcode 26 is available on the runner but not selected.

**Fix:** add a `xcode-select` step before the build to switch to Xcode 26.