### PR TITLE
Port BLE fixes and improvements

### DIFF
--- a/berty-bridge-expo/ios/Sources/Bridge/ConnectivityDriver.swift
+++ b/berty-bridge-expo/ios/Sources/Bridge/ConnectivityDriver.swift
@@ -5,135 +5,281 @@
 //  Created by u on 01/02/2023.
 //
 
-import SystemConfiguration
-import CoreBluetooth
-import CoreTelephony
 import Foundation
-import Bertybridge
+import UIKit
 import Network
+import SystemConfiguration
+import CoreTelephony
+import CoreBluetooth
+import Bertybridge
 
-class ConnectivityDriver: NSObject, BertybridgeIConnectivityDriverProtocol, CBCentralManagerDelegate {
-    let logger: BertyLogger = BertyLogger("tech.berty.ConnectivityDriver")
-    let queue = DispatchQueue.global(qos: .background)
-    let pathMonitor = NWPathMonitor()
-    var centralManager: CBCentralManager!
+// Bridges iOS network and Bluetooth state to Go's netmanager.
+//
+// Network reachability comes from NWPathMonitor, with an SCNetworkReachability
+// fallback for iOS < 12. Bluetooth state is observed through a CBCentralManager we
+// own (the expo bridge has no shared BLE driver to borrow one from); we keep a
+// strong reference so it is not deallocated and suppress the system power alert
+// since we only observe state.
+//
+// The connectivity constants (state/net/cellular) are exported by the Bertybridge
+// framework from Go's netmanager/connectivity.go — never redefine them locally.
+class ConnectivityDriver: NSObject, BertybridgeIConnectivityDriverProtocol {
+    let logger = BertyLogger("tech.berty.connectivity")
 
-    var state: BertybridgeConnectivityInfo
-    var handlers: [BertybridgeIConnectivityHandlerProtocol] = []
+    private var pathMonitor: NWPathMonitor?
+    private let monitorQueue = DispatchQueue(label: "tech.berty.connectivity.monitor")
+
+    // Owned manager: kept as a strong reference so it is not deallocated.
+    private var centralManager: CBCentralManager?
+
+    private let networkInfo = CTTelephonyNetworkInfo()
+
+    private var isMonitoring = false
+    private var currentPath: NWPath?
+    private var bluetoothState: CBManagerState = .unknown
+
+    // Thread-safe handler storage. Go callbacks run on a dedicated serial queue
+    // (not DispatchQueue.global(), which causes stack-alignment issues in the Go
+    // runtime) when the app is backgrounded.
+    private let handlerQueue = DispatchQueue(label: "tech.berty.connectivity.handlers", attributes: .concurrent)
+    private let goCallbackQueue = DispatchQueue(label: "tech.berty.connectivity.go-callbacks")
+    private var handlers: [BertybridgeIConnectivityHandlerProtocol] = []
 
     override init() {
-        self.logger.debug("Init")
-      
-        self.state = BertybridgeConnectivityInfo()!
-
         super.init()
-      
-        self.centralManager = CBCentralManager(delegate: self, queue: nil)
-
-        self.pathMonitor.pathUpdateHandler = { [weak self] path in
-            self!.logger.debug("Network state changed")
-          
-            self!.updateNetworkState(path)
-
-            for handler in self!.handlers {
-                handler.handleConnectivityUpdate(self!.state)
-            }
-        }
-        self.pathMonitor.start(queue: self.queue)
+        self.startMonitoring()
     }
 
-    func updateNetworkState(_ info: NWPath) {
-        self.state.setState(info.status == .satisfied ? BertybridgeConnectivityStateOn : BertybridgeConnectivityStateOff)
-        self.state.setMetering(BertybridgeConnectivityStateUnknown)
-        self.state.setNetType(BertybridgeConnectivityNetUnknown)
-        self.state.setCellularType(BertybridgeConnectivityCellularUnknown)
+    // MARK: - Monitoring lifecycle
 
-        if info.status != .satisfied {
-            return
+    func startMonitoring() {
+        guard !self.isMonitoring else { return }
+        self.isMonitoring = true
+
+        if #available(iOS 12.0, *) {
+            self.setupPathMonitor()
         }
+        self.setupBluetoothMonitoring()
 
-        if #available(iOS 13.0, *) {
-            self.state.setMetering(info.isConstrained ? BertybridgeConnectivityStateOn : BertybridgeConnectivityStateOff)
-        }
-
-        if let interface = self.pathMonitor.currentPath.availableInterfaces.first {
-            switch interface.type {
-                case .wifi:
-                    self.state.setNetType(BertybridgeConnectivityNetWifi)
-                case .cellular:
-                    self.state.setNetType(BertybridgeConnectivityNetCellular)
-                    self.state.setCellularType(ConnectivityDriver.getCellularType())
-                case .wiredEthernet:
-                    self.state.setNetType(BertybridgeConnectivityNetEthernet)
-                default:
-                    self.state.setNetType(BertybridgeConnectivityNetUnknown)
-            }
-        }
-    }
-  
-    static func getCellularType() -> Int {
-        let networkInfo = CTTelephonyNetworkInfo()
-
-        guard let carrierType = networkInfo.serviceCurrentRadioAccessTechnology?.first?.value else {
-            return BertybridgeConnectivityCellularNone
-        }
-
-        switch carrierType {
-            case CTRadioAccessTechnologyGPRS,
-                 CTRadioAccessTechnologyEdge,
-                 CTRadioAccessTechnologyCDMA1x:
-                return BertybridgeConnectivityCellular2G
-            case CTRadioAccessTechnologyWCDMA,
-                 CTRadioAccessTechnologyHSDPA,
-                 CTRadioAccessTechnologyHSUPA,
-                 CTRadioAccessTechnologyCDMAEVDORev0,
-                 CTRadioAccessTechnologyCDMAEVDORevA,
-                 CTRadioAccessTechnologyCDMAEVDORevB,
-                 CTRadioAccessTechnologyeHRPD:
-                return BertybridgeConnectivityCellular3G
-            case CTRadioAccessTechnologyLTE:
-                return BertybridgeConnectivityCellular4G
-            default:
-                if #available(iOS 14.1, *) {
-                    if carrierType == CTRadioAccessTechnologyNRNSA
-                    || carrierType == CTRadioAccessTechnologyNR {
-                        return BertybridgeConnectivityCellular5G
-                    }
-                }
-
-                return BertybridgeConnectivityCellularUnknown
-        }
+        self.logger.info("Started connectivity monitoring")
     }
 
-    func centralManagerDidUpdateState(_ central: CBCentralManager) {
-        self.logger.debug("Bluetooth state changed")
+    func stopMonitoring() {
+        guard self.isMonitoring else { return }
+        self.isMonitoring = false
 
-        switch central.state {
-            case .poweredOn:
-                self.state.setBluetooth(BertybridgeConnectivityStateOn)
-            case .poweredOff,
-                 .unsupported,
-                 .unauthorized,
-                 .resetting:
-                self.state.setBluetooth(BertybridgeConnectivityStateOff)
-            case .unknown:
-                self.state.setBluetooth(BertybridgeConnectivityStateUnknown)
-            @unknown default:
-                self.state.setBluetooth(BertybridgeConnectivityStateUnknown)
+        if #available(iOS 12.0, *) {
+            self.pathMonitor?.cancel()
+            self.pathMonitor = nil
         }
+        self.centralManager = nil
 
-        for handler in self.handlers {
-            handler.handleConnectivityUpdate(self.state)
-        }
+        self.logger.info("Stopped connectivity monitoring")
     }
+
+    // MARK: - BertybridgeIConnectivityDriverProtocol
 
     public func getCurrentState() -> BertybridgeConnectivityInfo? {
-        return self.state
+        return self.buildCurrentState()
     }
 
     public func register(_ handler: BertybridgeIConnectivityHandlerProtocol?) {
-        if (handler != nil) {
-            self.handlers.append(handler!)
+        guard let handler = handler else { return }
+
+        self.handlerQueue.async(flags: .barrier) { [weak self] in
+            self?.handlers.append(handler)
         }
+
+        // Notify the new handler of the current state immediately.
+        handler.handleConnectivityUpdate(self.buildCurrentState())
+    }
+
+    // MARK: - State
+
+    private func buildCurrentState() -> BertybridgeConnectivityInfo {
+        let info = BertybridgeConnectivityInfo()!
+
+        if #available(iOS 12.0, *), let path = self.currentPath {
+            info.setState(path.status == .satisfied ? BertybridgeConnectivityStateOn : BertybridgeConnectivityStateOff)
+
+            if #available(iOS 13.0, *) {
+                info.setMetering(path.isConstrained ? BertybridgeConnectivityStateOn : BertybridgeConnectivityStateOff)
+            } else {
+                info.setMetering(BertybridgeConnectivityStateUnknown)
+            }
+
+            if path.usesInterfaceType(.wifi) {
+                info.setNetType(BertybridgeConnectivityNetWifi)
+            } else if path.usesInterfaceType(.cellular) {
+                info.setNetType(BertybridgeConnectivityNetCellular)
+                info.setCellularType(self.getCellularGeneration())
+            } else if path.usesInterfaceType(.wiredEthernet) {
+                info.setNetType(BertybridgeConnectivityNetEthernet)
+            } else {
+                info.setNetType(BertybridgeConnectivityNetUnknown)
+            }
+        } else {
+            // Fallback for iOS < 12
+            info.setState(self.isConnectedLegacy() ? BertybridgeConnectivityStateOn : BertybridgeConnectivityStateOff)
+            info.setMetering(BertybridgeConnectivityStateUnknown)
+            info.setNetType(self.getNetworkTypeLegacy())
+            info.setCellularType(BertybridgeConnectivityCellularUnknown)
+        }
+
+        // Read Bluetooth state directly from the live manager for the freshest value.
+        let state = self.centralManager?.state ?? self.bluetoothState
+        switch state {
+        case .poweredOn:
+            info.setBluetooth(BertybridgeConnectivityStateOn)
+        case .poweredOff:
+            info.setBluetooth(BertybridgeConnectivityStateOff)
+        default:
+            info.setBluetooth(BertybridgeConnectivityStateUnknown)
+        }
+
+        return info
+    }
+
+    private func notifyHandlers() {
+        // Read applicationState on the main thread before entering handlerQueue, to
+        // avoid a sync hop to main from within the queue (deadlock risk).
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            let isBackground = UIApplication.shared.applicationState == .background
+
+            self.handlerQueue.async { [weak self] in
+                guard let self = self else { return }
+                let state = self.buildCurrentState()
+                let handlers = self.handlers
+
+                if isBackground {
+                    // Background: hand off to Go on the dedicated serial queue.
+                    self.goCallbackQueue.async {
+                        handlers.forEach { $0.handleConnectivityUpdate(state) }
+                    }
+                } else {
+                    DispatchQueue.main.async {
+                        handlers.forEach { $0.handleConnectivityUpdate(state) }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Network monitoring
+
+    @available(iOS 12.0, *)
+    private func setupPathMonitor() {
+        let monitor = NWPathMonitor()
+        monitor.pathUpdateHandler = { [weak self] path in
+            self?.handlePathUpdate(path)
+        }
+        monitor.start(queue: self.monitorQueue)
+        self.pathMonitor = monitor
+    }
+
+    @available(iOS 12.0, *)
+    private func handlePathUpdate(_ path: NWPath) {
+        self.logger.info("Network path updated: status=\(path.status), wifi=\(path.usesInterfaceType(.wifi)), cellular=\(path.usesInterfaceType(.cellular))")
+        self.currentPath = path
+        self.notifyHandlers()
+    }
+
+    // MARK: - Bluetooth monitoring
+
+    private func setupBluetoothMonitoring() {
+        guard self.centralManager == nil else { return }
+
+        // Suppress the system power alert since we only observe state.
+        self.centralManager = CBCentralManager(delegate: self, queue: nil, options: [CBCentralManagerOptionShowPowerAlertKey: false])
+    }
+
+    // MARK: - Cellular
+
+    private func getCellularGeneration() -> Int {
+        let technology: String?
+        if #available(iOS 12.0, *) {
+            technology = self.networkInfo.serviceCurrentRadioAccessTechnology?.values.first
+        } else {
+            technology = self.networkInfo.currentRadioAccessTechnology
+        }
+        guard let technology = technology else {
+            return BertybridgeConnectivityCellularNone
+        }
+        return self.mapRadioAccessTechnology(technology)
+    }
+
+    private func mapRadioAccessTechnology(_ technology: String) -> Int {
+        switch technology {
+        case CTRadioAccessTechnologyGPRS,
+             CTRadioAccessTechnologyEdge,
+             CTRadioAccessTechnologyCDMA1x:
+            return BertybridgeConnectivityCellular2G
+
+        case CTRadioAccessTechnologyWCDMA,
+             CTRadioAccessTechnologyHSDPA,
+             CTRadioAccessTechnologyHSUPA,
+             CTRadioAccessTechnologyCDMAEVDORev0,
+             CTRadioAccessTechnologyCDMAEVDORevA,
+             CTRadioAccessTechnologyCDMAEVDORevB,
+             CTRadioAccessTechnologyeHRPD:
+            return BertybridgeConnectivityCellular3G
+
+        case CTRadioAccessTechnologyLTE:
+            return BertybridgeConnectivityCellular4G
+
+        default:
+            if #available(iOS 14.1, *),
+               technology == CTRadioAccessTechnologyNRNSA || technology == CTRadioAccessTechnologyNR {
+                return BertybridgeConnectivityCellular5G
+            }
+            return BertybridgeConnectivityCellularUnknown
+        }
+    }
+
+    // MARK: - Legacy support (iOS < 12)
+
+    private func isConnectedLegacy() -> Bool {
+        guard let flags = self.legacyReachabilityFlags() else { return false }
+        return flags.contains(.reachable) && !flags.contains(.connectionRequired)
+    }
+
+    private func getNetworkTypeLegacy() -> Int {
+        guard let flags = self.legacyReachabilityFlags() else {
+            return BertybridgeConnectivityNetUnknown
+        }
+        if flags.contains(.isWWAN) {
+            return BertybridgeConnectivityNetCellular
+        } else if flags.contains(.reachable) {
+            return BertybridgeConnectivityNetWifi
+        }
+        return BertybridgeConnectivityNetUnknown
+    }
+
+    private func legacyReachabilityFlags() -> SCNetworkReachabilityFlags? {
+        var zeroAddress = sockaddr_in()
+        zeroAddress.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        zeroAddress.sin_family = sa_family_t(AF_INET)
+
+        let reachability = withUnsafePointer(to: &zeroAddress) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { zeroSockAddress in
+                SCNetworkReachabilityCreateWithAddress(nil, zeroSockAddress)
+            }
+        }
+        guard let reachability = reachability else { return nil }
+
+        var flags = SCNetworkReachabilityFlags()
+        guard SCNetworkReachabilityGetFlags(reachability, &flags) else { return nil }
+        return flags
+    }
+}
+
+// MARK: - CBCentralManagerDelegate
+
+extension ConnectivityDriver: CBCentralManagerDelegate {
+    func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        self.logger.info("Bluetooth state changed: \(central.state.rawValue)")
+        self.bluetoothState = central.state
+        self.notifyHandlers()
     }
 }

--- a/js/android/app/src/main/java/tech/berty/gobridge/bledriver/BleInterface.java
+++ b/js/android/app/src/main/java/tech/berty/gobridge/bledriver/BleInterface.java
@@ -13,8 +13,11 @@ public class BleInterface implements ProximityDriver {
     public static final int ProtocolCode = 0x0042;
     public static final String ProtocolName = "ble";
     private static final String TAG = "bty.ble.BleInterface";
-    private static ProximityTransport mTransport;
+    private static volatile ProximityTransport mTransport;
+    private static final Object mTransportLock = new Object();
     private final Context mContext;
+    // Lock object for synchronized access to mBleDriver
+    private final Object mDriverLock = new Object();
     private BleDriver mBleDriver;
     private Logger mLogger;
 
@@ -24,67 +27,97 @@ public class BleInterface implements ProximityDriver {
     }
 
     public static boolean BLEHandleFoundPeer(String remotePID) {
-        if (mTransport != null) {
-            return mTransport.handleFoundPeer(remotePID);
+        synchronized (mTransportLock) {
+            if (mTransport != null) {
+                return mTransport.handleFoundPeer(remotePID);
+            }
         }
         return false;
     }
 
     public static void BLEHandleLostPeer(String remotePID) {
-        if (mTransport != null) {
-            mTransport.handleLostPeer(remotePID);
+        synchronized (mTransportLock) {
+            if (mTransport != null) {
+                mTransport.handleLostPeer(remotePID);
+            }
         }
     }
 
     public static void BLEReceiveFromPeer(String remotePID, byte[] payload) {
-        if (mTransport != null) {
-            mTransport.receiveFromPeer(remotePID, payload);
+        synchronized (mTransportLock) {
+            if (mTransport != null) {
+                mTransport.receiveFromPeer(remotePID, payload);
+            }
         }
     }
 
     public static void BLELog(Logger.Level level, String message) {
-        if (mTransport != null) {
-            mTransport.log(level.getValue(), message);
+        synchronized (mTransportLock) {
+            if (mTransport != null) {
+                mTransport.log(level.getValue(), message);
+            }
         }
     }
 
     public void start(String localPID) {
         mLogger.d(TAG, "start driver");
 
-        mTransport = Bertybridge.getProximityTransport(ProtocolName);
-        if (mTransport == null) {
-            mLogger.e(TAG, "proximityTransporter not found");
-            return;
+            synchronized (mTransportLock) {
+            mTransport = Bertybridge.getProximityTransport(ProtocolName);
+            if (mTransport == null) {
+                mLogger.e(TAG, "proximityTransporter not found");
+                return;
+            }
         }
 
-        if ((this.mBleDriver = BleDriver.getInstance(mContext, mLogger)) == null) {
-            mLogger.e(TAG, "can't get BleDriver instance");
-            return;
+        synchronized (mDriverLock) {
+            if ((this.mBleDriver = BleDriver.getInstance(mContext, mLogger)) == null) {
+                mLogger.e(TAG, "can't get BleDriver instance");
+                synchronized (mTransportLock) {
+                    mTransport = null;
+                }
+                return;
+            }
+            this.mBleDriver.StartBleDriver(localPID);
         }
-        this.mBleDriver.StartBleDriver(localPID);
     }
 
     public void stop() {
-        if (this.mBleDriver != null) {
-            this.mBleDriver.StopBleDriver();
-            this.mBleDriver = null;
+        synchronized (mDriverLock) {
+            if (this.mBleDriver != null) {
+                this.mBleDriver.StopBleDriver();
+                this.mBleDriver = null;
+            }
         }
-        mTransport = null;
+            synchronized (mTransportLock) {
+            mTransport = null;
+        }
     }
 
     public boolean dialPeer(String remotePID) {
-        return mBleDriver.peerManager().get(remotePID) != null;
+        synchronized (mDriverLock) {
+            if (mBleDriver == null || mBleDriver.peerManager() == null) {
+                return false;
+            }
+            return mBleDriver.peerManager().get(remotePID) != null;
+        }
     }
 
     public boolean sendToPeer(String remotePID, byte[] payload) {
-        if (this.mBleDriver != null) {
-            return this.mBleDriver.SendToPeer(remotePID, payload);
+        synchronized (mDriverLock) {
+            if (this.mBleDriver != null) {
+                return this.mBleDriver.SendToPeer(remotePID, payload);
+            }
         }
         return false;
     }
 
     public void closeConnWithPeer(String remotePID) {
-        mBleDriver.deviceManager().closeDeviceConnection(remotePID);
+        synchronized (mDriverLock) {
+            if (mBleDriver != null && mBleDriver.deviceManager() != null) {
+                mBleDriver.deviceManager().closeDeviceConnection(remotePID);
+            }
+        }
     }
 
     public long protocolCode() {

--- a/js/android/app/src/main/java/tech/berty/gobridge/bledriver/BleQueue.java
+++ b/js/android/app/src/main/java/tech/berty/gobridge/bledriver/BleQueue.java
@@ -4,6 +4,7 @@ import android.os.Handler;
 
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.atomic.AtomicLong;
 
 // Vastly inspired from https://medium.com/@martijn.van.welie/making-android-ble-work-part-1-a736dcd53b02
 // Github repo: https://github.com/weliem/blessed-android
@@ -25,7 +26,7 @@ public class BleQueue {
     private boolean mIsRetrying = false;
     private int mNrTries = 0;
 
-    private int mIndex = 0;
+    private final AtomicLong mIndex = new AtomicLong(0);
 
     public BleQueue(Logger logger, Handler handler) {
         mLogger = logger;
@@ -179,14 +180,14 @@ public class BleQueue {
         private final Callback callback;
         private final long delay;
         private final Runnable cancel;
-        private final int index;
+        private final long index;
 
         public TaskDelay(Runnable t, Callback cb, long d, Runnable c) {
             task = t;
             callback = cb;
             delay = d;
             cancel = c;
-            index = mIndex++;
+            index = mIndex.getAndIncrement();
         }
     }
 

--- a/js/android/app/src/main/java/tech/berty/gobridge/bledriver/DeviceManager.java
+++ b/js/android/app/src/main/java/tech/berty/gobridge/bledriver/DeviceManager.java
@@ -15,7 +15,7 @@ public class DeviceManager {
     public DeviceManager(Logger logger) {
         mLogger = logger;
     }
-    
+
     public synchronized PeerDevice put(String macAddress, PeerDevice value) {
         mLogger.d(TAG, "put() called");
         PeerDevice peerDevice = mPeerDevices.get(macAddress);

--- a/js/android/app/src/main/java/tech/berty/gobridge/bledriver/GattServer.java
+++ b/js/android/app/src/main/java/tech/berty/gobridge/bledriver/GattServer.java
@@ -32,7 +32,8 @@ import java.util.concurrent.locks.ReentrantLock;
 public class GattServer {
     // BLE protocol reserves 3 bytes out of MTU_SIZE for metadata
     public static final int ATT_HEADER_SIZE = 3;
-    private static final long OP_TIMEOUT = 10000;
+    private static final long OP_TIMEOUT_MS = 10000;
+    private static final long SERVICE_START_TIMEOUT_MS = 30000;
     // GATT service UUID
     static final UUID SERVICE_UUID = UUID.fromString("00004240-0000-1000-8000-00805F9B34FB");
     // GATT characteristic used for peer ID exchange
@@ -60,6 +61,8 @@ public class GattServer {
     private volatile boolean mStarted = false;
     private final Lock mLock = new ReentrantLock();
     private BluetoothGattCharacteristic mWriterCharacteristic;
+    private volatile Thread mL2capThread = null;
+    private volatile boolean mL2capRunning = false;
 
     public GattServer(Context context, BleDriver bleDriver, Logger logger, BluetoothManager bluetoothManager) {
         mContext = context;
@@ -133,56 +136,71 @@ public class GattServer {
                 mBluetoothServerSocket = null;
             }
 
-            // loop to accept multiple incoming connections
             if (mBluetoothServerSocket != null) {
-                Thread l2capThread = new Thread(() -> {
-                    while (true) {
-                        if (mBluetoothServerSocket != null) {
-                            BluetoothSocket bluetoothSocket;
-                            try {
-                                bluetoothSocket = mBluetoothServerSocket.accept();
-                            } catch (IOException e) {
+                mL2capRunning = true;
+                mL2capThread = new Thread(() -> {
+                    mLogger.d(TAG, "L2CAP accept thread started");
+                    while (mL2capRunning && mBluetoothServerSocket != null) {
+                        BluetoothSocket bluetoothSocket;
+                        try {
+                            bluetoothSocket = mBluetoothServerSocket.accept();
+                        } catch (IOException e) {
+                            if (mL2capRunning) {
                                 mLogger.e(TAG, "L2CAP accept(): exception catch: ", e);
-                                return;
-                            }
-
-                            PeerDevice peerDevice;
-                            if ((peerDevice = mBleDriver.deviceManager().get(bluetoothSocket.getRemoteDevice().getAddress())) == null) {
-                                mLogger.e(TAG, String.format("L2CAP accept(): device=%s not found", mLogger.sensitiveObject(bluetoothSocket.getRemoteDevice().getAddress())));
-                                continue;
                             } else {
-                                mLogger.d(TAG, String.format("L2CAP accept(): accepted incoming connection from known device=%s", mLogger.sensitiveObject(bluetoothSocket.getRemoteDevice().getAddress())));
+                                mLogger.d(TAG, "L2CAP accept(): socket closed during shutdown");
                             }
-
-                            peerDevice.setBluetoothSocket(bluetoothSocket);
-                            peerDevice.setL2capServerHandshakeStarted(true);
-                            try {
-                                peerDevice.setInputStream(bluetoothSocket.getInputStream());
-                                peerDevice.setOutputStream(bluetoothSocket.getOutputStream());
-
-                                Thread readThread = new Thread(() -> {
-                                    peerDevice.l2capRead();
-                                });
-                                readThread.start();
-                            } catch (IOException e) {
-                                mLogger.e(TAG, String.format("L2CAP accept() error: l2cap cannot get stream: device=%s", mLogger.sensitiveObject(peerDevice.getMACAddress())), e);
-                                try {
-                                    bluetoothSocket.close();
-                                } catch (IOException ioException) {
-                                    // ignore
-                                } finally {
-                                    peerDevice.setBluetoothSocket(null);
-                                    peerDevice.setInputStream(null);
-                                    peerDevice.setOutputStream(null);
-                                }
-                            }
-                        } else {
-                            mLogger.e(TAG, "L2CAP accept(): BluetoothServerSocket is null");
                             return;
                         }
+
+                        if (!mL2capRunning) {
+                            try {
+                                bluetoothSocket.close();
+                            } catch (IOException e) {
+                                // ignore
+                            }
+                            return;
+                        }
+
+                        PeerDevice peerDevice;
+                        if ((peerDevice = mBleDriver.deviceManager().get(bluetoothSocket.getRemoteDevice().getAddress())) == null) {
+                            mLogger.e(TAG, String.format("L2CAP accept(): device=%s not found", mLogger.sensitiveObject(bluetoothSocket.getRemoteDevice().getAddress())));
+                            try {
+                                bluetoothSocket.close();
+                            } catch (IOException e) {
+                                // ignore
+                            }
+                            continue;
+                        } else {
+                            mLogger.d(TAG, String.format("L2CAP accept(): accepted incoming connection from known device=%s", mLogger.sensitiveObject(bluetoothSocket.getRemoteDevice().getAddress())));
+                        }
+
+                        peerDevice.setBluetoothSocket(bluetoothSocket);
+                        peerDevice.setL2capServerHandshakeStarted(true);
+                        try {
+                            peerDevice.setInputStream(bluetoothSocket.getInputStream());
+                            peerDevice.setOutputStream(bluetoothSocket.getOutputStream());
+
+                            Thread readThread = new Thread(() -> {
+                                peerDevice.l2capRead();
+                            });
+                            readThread.start();
+                        } catch (IOException e) {
+                            mLogger.e(TAG, String.format("L2CAP accept() error: l2cap cannot get stream: device=%s", mLogger.sensitiveObject(peerDevice.getMACAddress())), e);
+                            try {
+                                bluetoothSocket.close();
+                            } catch (IOException ioException) {
+                                // ignore
+                            } finally {
+                                peerDevice.setBluetoothSocket(null);
+                                peerDevice.setInputStream(null);
+                                peerDevice.setOutputStream(null);
+                            }
+                        }
                     }
+                    mLogger.d(TAG, "L2CAP accept thread stopped");
                 });
-                l2capThread.start();
+                mL2capThread.start();
             }
         }
 
@@ -193,11 +211,16 @@ public class GattServer {
             return false;
         }
 
-        // wait that service starts
         try {
-            mDoneSignal.await();
+            if (!mDoneSignal.await(SERVICE_START_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                mLogger.e(TAG, "start: service registration timed out");
+                mBluetoothGattServer.close();
+                mBluetoothGattServer = null;
+                return false;
+            }
         } catch (InterruptedException e) {
             mLogger.e(TAG, "start: interrupted exception:", e);
+            return false;
         }
 
         // mStarted is updated by GattServerCallback
@@ -243,6 +266,9 @@ public class GattServer {
         mLogger.i(TAG, "stop() called");
         if (isStarted()) {
             setStarted(false);
+
+            mL2capRunning = false;
+
             if (mBluetoothServerSocket != null) {
                 try {
                     mLogger.d(TAG, "stop BluetoothServerSocket (L2cap)");
@@ -253,6 +279,16 @@ public class GattServer {
                     mBluetoothServerSocket = null;
                 }
             }
+
+            if (mL2capThread != null) {
+                try {
+                    mL2capThread.join(1000); // 1 second timeout
+                } catch (InterruptedException e) {
+                    mLogger.e(TAG, "stop: L2CAP thread join interrupted");
+                }
+                mL2capThread = null;
+            }
+
             mBluetoothGattServer.close();
             mLock.lock();
             try {
@@ -311,7 +347,10 @@ public class GattServer {
         }
 
         try {
-            countDownLatch.await(OP_TIMEOUT, TimeUnit.SECONDS);
+            if (!countDownLatch.await(OP_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                mLogger.e(TAG, String.format("_writeAndNotify: device=%s: operation timed out", mLogger.sensitiveObject(device.getMACAddress())));
+                return false;
+            }
         } catch (InterruptedException e) {
             mLogger.e(TAG, String.format("_writeAndNotify: device=%s: await failed", mLogger.sensitiveObject(device.getMACAddress())));
             return false;

--- a/js/android/app/src/main/java/tech/berty/gobridge/bledriver/Logger.java
+++ b/js/android/app/src/main/java/tech/berty/gobridge/bledriver/Logger.java
@@ -1,9 +1,25 @@
 package tech.berty.gobridge.bledriver;
 
-import tech.berty.android.BuildConfig;
 import android.util.Log;
 
 public class Logger {
+    private static final String TAG = "BertyBleLogger";
+
+    // Debug mode - defaults to false (production-safe)
+    private static boolean sDebugMode = false;
+
+    // Minimum log level for production (only warnings and errors)
+    private static final int MIN_PRODUCTION_LEVEL = Log.WARN;
+
+    /**
+     * Initialize debug mode based on application debuggable flag.
+     * Call this during app initialization before any Berty code runs.
+     */
+    public static void initializeDebugMode(boolean isDebuggable) {
+        sDebugMode = isDebuggable;
+        Log.i(TAG, "BLE Logger initialized: debugMode=" + sDebugMode);
+    }
+
     public enum Level {
         Verbose(0),
         Debug(1),
@@ -30,30 +46,33 @@ public class Logger {
     }
 
     public void log(Level level, String tag, String message) {
-        if (!BuildConfig.DEBUG) {
+        // Get the Android log priority for this level
+        int priority;
+        switch (level) {
+            case Verbose:
+                priority = Log.VERBOSE;
+                break;
+            case Debug:
+                priority = Log.DEBUG;
+                break;
+            case Warn:
+                priority = Log.WARN;
+                break;
+            case Error:
+                priority = Log.ERROR;
+                break;
+            default:
+                priority = Log.INFO;
+        }
+
+        // In production builds, only log warnings and errors to prevent log flooding
+        if (!sDebugMode && priority < MIN_PRODUCTION_LEVEL) {
             return;
         }
 
         if (mUseExternalLogger) {
             BleInterface.BLELog(level, tag + ": " + message);
         } else {
-            int priority;
-            switch (level) {
-                case Verbose:
-                    priority = Log.VERBOSE;
-                    break;
-                case Debug:
-                    priority = Log.DEBUG;
-                    break;
-                case Warn:
-                    priority = Log.WARN;
-                    break;
-                case Error:
-                    priority = Log.ERROR;
-                    break;
-                default:
-                    priority = Log.INFO;
-            }
             Log.println(priority, tag, message);
         }
     }

--- a/js/android/app/src/main/java/tech/berty/gobridge/bledriver/PeerDevice.java
+++ b/js/android/app/src/main/java/tech/berty/gobridge/bledriver/PeerDevice.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 public class PeerDevice {
     // Mark used to tell all data is transferred
@@ -47,6 +48,9 @@ public class PeerDevice {
     private final BleDriver mBleDriver;
     // Connection timeout
     private static final int CONNECTION_TIMEOUT = 15000;
+    private static final int OPERATION_TIMEOUT_MS = 30000;
+    // Max buffer size to prevent OOM from malicious/malfunctioning peer (64KB)
+    private static final int MAX_IN_DATA_BUFFER_SIZE = 64 * 1024;
     // Minimal and default MTU
     private static final int DEFAULT_MTU = 23;
     // Client Characteristic Configuration (CCC) descriptor of the characteristic
@@ -83,7 +87,7 @@ public class PeerDevice {
     private InputStream mInputStream;
     private OutputStream mOutputStream;
     private byte[] mInDataBuffer;
-    private CircularBuffer<byte[]> mDataCache = new CircularBuffer<>(10);
+    private CircularBuffer<byte[]> mDataCache = new CircularBuffer<>(100);
     private int mMtu = DEFAULT_MTU;
     private boolean mL2capClientHandshakeStarted;
     private boolean mL2capServerHandshakeStarted;
@@ -93,6 +97,9 @@ public class PeerDevice {
     private boolean mL2capHandshakeStepStatus;
     private CountDownLatch mL2capHandshakeLatch;
     private boolean mUseL2cap = false;
+    // L2CAP read thread control
+    private volatile boolean mL2capRunning = false;
+    private volatile Thread mL2capReadThread;
 
     private final BluetoothGattCallback mGattCallback =
         new BluetoothGattCallback() {
@@ -444,6 +451,9 @@ public class PeerDevice {
     }
 
     private void closeL2cap() {
+        // Signal read thread to stop
+        mL2capRunning = false;
+
         if (mBluetoothSocket != null) {
             mLogger.d(TAG, String.format("closeL2cap called: device=%s", mLogger.sensitiveObject(getMACAddress())));
             try {
@@ -460,6 +470,16 @@ public class PeerDevice {
             } catch (IOException e) {
                 mLogger.e(TAG, String.format("disconnect: device=%s: error when closing l2cap channel", mLogger.sensitiveObject(getMACAddress())));
             }
+        }
+
+        // Wait briefly for read thread to exit
+        if (mL2capReadThread != null && mL2capReadThread.isAlive()) {
+            try {
+                mL2capReadThread.join(500);
+            } catch (InterruptedException e) {
+                mLogger.w(TAG, "closeL2cap: interrupted while waiting for read thread");
+            }
+            mL2capReadThread = null;
         }
     }
 
@@ -627,8 +647,10 @@ public class PeerDevice {
         // read loop
         byte[] buffer = new byte[L2CAP_BUFFER];
         int size;
+        mL2capRunning = true;
+        mL2capReadThread = Thread.currentThread();
 
-        while (true) {
+        while (mL2capRunning) {
             try {
                 if (!mBluetoothSocket.isConnected()) {
                     mLogger.w(TAG, "l2capRead: socket not connected");
@@ -821,9 +843,13 @@ public class PeerDevice {
         }
 
         try {
-            countDownLatch.await();
+            if (!countDownLatch.await(OPERATION_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                mLogger.e(TAG, String.format("setNotify error: device=%s: operation timed out", mLogger.sensitiveObject(getMACAddress())));
+                return false;
+            }
         } catch (InterruptedException e) {
             mLogger.e(TAG, "setNotify: interrupted exception:", e);
+            return false;
         }
 
         return success[0];
@@ -959,9 +985,14 @@ public class PeerDevice {
         }
 
         try {
-            countDownLatch.await();
+            if (!countDownLatch.await(OPERATION_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                mLogger.e(TAG, String.format("read error: device=%s: operation timed out, cleaning up stale connection", mLogger.sensitiveObject(getMACAddress())));
+                disconnect();
+                return false;
+            }
         } catch (InterruptedException e) {
             mLogger.e(TAG, "read: interrupted exception:", e);
+            return false;
         }
 
         return success[0];
@@ -1023,9 +1054,13 @@ public class PeerDevice {
             }
 
             try {
-                countDownLatch.await();
+                if (!countDownLatch.await(OPERATION_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                    mLogger.e(TAG, String.format("l2capWrite error: device=%s: operation timed out", mLogger.sensitiveObject(getMACAddress())));
+                    return false;
+                }
             } catch (InterruptedException e) {
                 mLogger.e(TAG, "l2capWrite: interrupted exception:", e);
+                return false;
             }
         }
 
@@ -1070,9 +1105,14 @@ public class PeerDevice {
         }
 
         try {
-            countDownLatch.await();
+            if (!countDownLatch.await(OPERATION_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                mLogger.e(TAG, String.format("internalWrite error: device=%s: operation timed out, cleaning up stale connection", mLogger.sensitiveObject(getMACAddress())));
+                disconnect();
+                return false;
+            }
         } catch (InterruptedException e) {
             mLogger.e(TAG, "internalWrite: interrupted exception:", e);
+            return false;
         }
 
         return success[0];
@@ -1127,9 +1167,12 @@ public class PeerDevice {
         mL2capHandshakeLatch = new CountDownLatch(1);
 
         // step 1
+        final CountDownLatch timerLatch = mL2capHandshakeLatch;
         startTimer(() -> {
             mLogger.i(TAG, "testL2capConnection: timer fired, L2CAP will be not used");
-            mL2capHandshakeLatch.countDown();
+            if (timerLatch != null) {
+                timerLatch.countDown();
+            }
         }, 10000);
 
         mL2capHandshakeData = createRandomBytes(L2CAP_HANDSHAKE_DATA_LEN);
@@ -1141,8 +1184,16 @@ public class PeerDevice {
         }
 
         // wait that l2capRead receives the remote PID
+        // Store local reference to avoid race condition with timer callback
+        CountDownLatch latch = mL2capHandshakeLatch;
         try {
-            mL2capHandshakeLatch.await();
+            if (latch != null && !latch.await(OPERATION_TIMEOUT_MS, TimeUnit.MILLISECONDS)) {
+                mLogger.e(TAG, "testL2capConnection: timed out waiting for L2CAP handshake");
+                cancelTimer();
+                mL2capHandshakeLatch = null;
+                mL2capHandshakeData = null;
+                return false;
+            }
         } catch (InterruptedException e) {
             mLogger.e(TAG, "testL2capConnection: interrupted exception:", e);
             cancelTimer();
@@ -1348,6 +1399,12 @@ public class PeerDevice {
     public void putInDataBuffer(byte[] value) {
         if (mInDataBuffer == null) {
             mInDataBuffer = new byte[0];
+        }
+
+        // Prevent unbounded buffer growth (OOM protection)
+        if (mInDataBuffer.length + value.length > MAX_IN_DATA_BUFFER_SIZE) {
+            mLogger.e(TAG, "putInDataBuffer: buffer overflow, rejecting data");
+            return;
         }
 
         byte[] tmp = new byte[mInDataBuffer.length + value.length];

--- a/js/android/app/src/main/java/tech/berty/gobridge/bledriver/PeerManager.java
+++ b/js/android/app/src/main/java/tech/berty/gobridge/bledriver/PeerManager.java
@@ -7,7 +7,7 @@ public class PeerManager {
     private final Logger mLogger;
 
     private final HashMap<String, Peer> mPeers = new HashMap<>();
-    
+
     public PeerManager(Logger logger) {
         mLogger = logger;
     }

--- a/js/android/app/src/main/java/tech/berty/gobridge/bledriver/Scanner.java
+++ b/js/android/app/src/main/java/tech/berty/gobridge/bledriver/Scanner.java
@@ -11,11 +11,11 @@ import android.content.Context;
 import android.os.ParcelUuid;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Timer;
 import java.util.TimerTask;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -29,7 +29,7 @@ public class Scanner extends ScanCallback {
     private static final int SCANNER_STATE_ENABLED = 1;
     private static final int SCANNER_STATE_PAUSED = 2;
     // key is MAC address
-    private static final HashMap<String, ScanResult> foundMap = new HashMap<>();
+    private static final Map<String, ScanResult> foundMap = new ConcurrentHashMap<>();
     private final Context mContext;
     private final BluetoothAdapter mBluetoothAdapter;
     private String mLocalPID;
@@ -98,6 +98,7 @@ public class Scanner extends ScanCallback {
         CountDownLatch countDown;
 
         setProcessingResult(true);
+        mLogger.d(TAG, "processResult: found " + foundMap.size() + " devices to process");
         countDown = new CountDownLatch(foundMap.size());
         for (Map.Entry<String, ScanResult> keySet : foundMap.entrySet()) {
             result = keySet.getValue();
@@ -188,9 +189,16 @@ public class Scanner extends ScanCallback {
         } else {
             mLogger.e(TAG, "stop scanner error: BT adapter not running");
         }
-        mTask.cancel();
-        mTimer.purge();
-        mTimer = null;
+
+        if (mTask != null) {
+            mTask.cancel();
+            mTask = null;
+        }
+        if (mTimer != null) {
+            mTimer.purge();
+            mTimer.cancel();
+            mTimer = null;
+        }
     }
 
     // Return the status of the scanner

--- a/js/ios/Berty/Sources/Bridge/ActivityBackgroundState.swift
+++ b/js/ios/Berty/Sources/Bridge/ActivityBackgroundState.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Singleton class to manage activity background state for iOS
+/// Coordinates with the app's background persistence needs
+class ActivityBackgroundState {
+    static let shared = ActivityBackgroundState()
+
+    // State tracking
+    private(set) var isActivityActive = false
+    private var activityId: String?
+    private var activityName: String?
+
+    private init() {
+        // Private initializer for singleton
+    }
+
+    /// Start activity background mode
+    /// Called when an active activity is detected that requires background persistence
+    func startActivityBackgroundMode(activityId: String, activityName: String) {
+        self.isActivityActive = true
+        self.activityId = activityId
+        self.activityName = activityName
+
+        print("ActivityBackgroundState: Started background mode for activity \(activityId)")
+    }
+
+    /// Stop activity background mode
+    /// Called when activity becomes inactive
+    func stopActivityBackgroundMode() {
+        self.isActivityActive = false
+        self.activityId = nil
+        self.activityName = nil
+
+        print("ActivityBackgroundState: Stopped background mode")
+    }
+
+    /// Get current activity ID if active
+    func getCurrentActivityId() -> String? {
+        return activityId
+    }
+
+    /// Get current activity name if active
+    func getCurrentActivityName() -> String? {
+        return activityName
+    }
+}
+
+/// Bridge class for native communication
+@objc class ActivityBackgroundStateBridge: NSObject {
+    private let activityState = ActivityBackgroundState.shared
+
+    @objc func startActivityBackgroundMode(activityId: String, activityName: String) {
+        activityState.startActivityBackgroundMode(activityId: activityId, activityName: activityName)
+    }
+
+    @objc func stopActivityBackgroundMode() {
+        activityState.stopActivityBackgroundMode()
+    }
+
+    @objc func isActivityActive() -> Bool {
+        return activityState.isActivityActive
+    }
+}

--- a/js/ios/Berty/Sources/Bridge/BertyBLEDriver.swift
+++ b/js/ios/Berty/Sources/Bridge/BertyBLEDriver.swift
@@ -1,0 +1,1522 @@
+import Foundation
+import CoreBluetooth
+import UIKit
+
+// MARK: - BLE Driver Protocol
+protocol BertyBLEDriverProtocol {
+    func startAdvertising() throws
+    func stopAdvertising()
+    func startScanning() throws
+    func stopScanning()
+    func connectToPeer(_ peerId: String) throws
+    func disconnectFromPeer(_ peerId: String)
+    func sendData(_ data: Data, toPeer peerId: String) throws
+    func isBluetoothAvailable() -> Bool
+    func isBluetoothEnabled() -> Bool
+}
+
+// MARK: - BLE Peer Model
+struct BertyBLEPeer {
+    let id: String
+    let name: String?
+    let rssi: Int
+    let lastSeen: Date
+    let isConnected: Bool
+    let peripheral: CBPeripheral?
+    let services: [String]
+}
+
+// MARK: - BLE Service Constants
+struct BertyBLEConstants {
+    static let serviceUUID = CBUUID(string: BertyConfiguration.bleServiceUUID)
+    static let pidCharacteristicUUID = CBUUID(string: BertyConfiguration.blePIDCharacteristicUUID)
+    static let writerCharacteristicUUID = CBUUID(string: BertyConfiguration.bleWriterCharacteristicUUID)
+    static let cccDescriptorUUID = CBUUID(string: BertyConfiguration.bleCCCDescriptorUUID)
+
+    // Legacy alias
+    static let characteristicUUID = pidCharacteristicUUID
+
+    static let eodMarker = BertyConfiguration.bleEODMarker
+    // Safe conversion with fallback - avoid force unwrap crash
+    static let eodMarkerData: Data = {
+        guard let data = BertyConfiguration.bleEODMarker.data(using: .utf8) else {
+            // Fallback to ASCII "EOD" if configuration is invalid
+            return "EOD".data(using: .utf8) ?? Data()
+        }
+        return data
+    }()
+    static let maxDataLength = BertyConfiguration.bleMaxDataLength
+    static let attHeaderSize = BertyConfiguration.bleATTHeaderSize
+    static let connectionTimeout = BertyConfiguration.bleConnectionTimeout
+    static let scanTimeout = BertyConfiguration.bleScanTimeout
+    static let reconnectDelay = BertyConfiguration.bleReconnectDelay
+    static let scanRestartInterval = BertyConfiguration.bleScanRestartInterval
+}
+
+// MARK: - BLE Driver Delegate
+protocol BertyBLEDriverDelegate: AnyObject {
+    func bleDriver(_ driver: BertyBLEDriver, didDiscoverPeer peer: BertyBLEPeer)
+    func bleDriver(_ driver: BertyBLEDriver, didConnectToPeer peerId: String)
+    func bleDriver(_ driver: BertyBLEDriver, didDisconnectFromPeer peerId: String, error: Error?)
+    func bleDriver(_ driver: BertyBLEDriver, didReceiveData data: Data, fromPeer peerId: String)
+    func bleDriver(_ driver: BertyBLEDriver, didFailWithError error: BertyError)
+}
+
+// MARK: - BLE Driver Implementation
+class BertyBLEDriver: NSObject, BertyBLEDriverProtocol {
+    static let shared = BertyBLEDriver()
+
+    weak var delegate: BertyBLEDriverDelegate?
+
+    private let logger = BertyLogger("tech.berty.ble")
+
+    private var centralManager: CBCentralManager?
+    private var peripheralManager: CBPeripheralManager?
+
+    private var discoveredPeers: [String: BertyBLEPeer] = [:]
+    private var connectedPeers: [String: CBPeripheral] = [:]
+    private var peerCharacteristics: [String: CBCharacteristic] = [:]
+
+    private var isAdvertising = false
+    private var isScanning = false
+    private var bluetoothState: CBManagerState = .unknown
+    private var isBluetoothInitialized = false
+
+    private let bluetoothStateCondition = NSCondition()
+    private var bluetoothStateReady = false
+
+    private let peripheralStateCondition = NSCondition()
+    private var peripheralStateReady = false
+
+    private let bleQueue = BertyQueueManager.shared.bleQueue
+
+    private var connectionTimeoutWork: [String: DispatchWorkItem] = [:]
+    private var handshakeTimeoutWork: [String: DispatchWorkItem] = [:]
+
+    private var scanCycleWork: DispatchWorkItem?
+    private let scanCycleInterval: TimeInterval = 12.0
+
+    // Local peer ID for handshake
+    private var localPID: String = ""
+
+    // Service and characteristics for peripheral (server) mode
+    private var bertyService: CBMutableService?
+    private var pidCharacteristic: CBMutableCharacteristic?
+    private var writerCharacteristic: CBMutableCharacteristic?
+
+    // Track whether service has been added to avoid re-adding
+    private var serviceAdded = false
+
+    // Centrals subscribed to WRITER notifications (server mode)
+    private var subscribedCentrals: [String: CBCentral] = [:]
+
+    // Incoming PID buffer for server-side handshake (accumulates until EOD)
+    private var incomingPIDBuffers: [String: Data] = [:]
+
+    // Track handshake completion for server-side connections
+    private var serverHandshakeComplete: [String: Bool] = [:]
+    private var serverRemotePIDs: [String: String] = [:]
+
+    // Data cache for messages received before handshake completion
+    private var pendingDataCache: [String: [Data]] = [:]
+
+    // Client-side: track WRITER characteristics for each connected peripheral
+    private var peerWriterCharacteristics: [String: CBCharacteristic] = [:]
+
+    // Client-side handshake state
+    private var clientHandshakeComplete: [String: Bool] = [:]
+    private var clientRemotePIDs: [String: String] = [:]
+
+    // Client handshake state machine (instance variable, not static)
+    private enum ClientHandshakeState {
+        case idle, writingPID, writingEOD, readingPID, subscribing, complete
+    }
+    private var clientHandshakeStates: [String: ClientHandshakeState] = [:]
+
+    // Notification queue management for server-side sends
+    private let maxPendingNotifications = 100
+    private var pendingNotifications: [(data: Data, central: CBCentral)] = []
+    // Max pending data cache size per peer (64KB)
+    private let maxPendingDataCacheSize = 64 * 1024
+    private var isProcessingNotifications = false
+
+    private let handshakeTimeout: TimeInterval = 30.0
+
+    private let maxPIDBufferSize = 1024
+
+    override init() {
+        super.init()
+        // Defer Bluetooth setup until actually needed to prevent early permission prompt
+        // setupBluetooth() will be called lazily when needed
+    }
+
+    deinit {
+        stopAdvertising()
+        stopScanning()
+        disconnectAllPeers()
+    }
+
+    // MARK: - Setup
+
+    private func setupBluetooth() {
+        guard !isBluetoothInitialized else { return }
+
+        logger.info("Initializing Bluetooth managers")
+
+        centralManager = CBCentralManager(
+            delegate: self,
+            queue: bleQueue,
+            options: [
+                CBCentralManagerOptionRestoreIdentifierKey: "tech.berty.central",
+                CBCentralManagerOptionShowPowerAlertKey: true
+            ]
+        )
+        peripheralManager = CBPeripheralManager(
+            delegate: self,
+            queue: bleQueue,
+            options: [
+                CBPeripheralManagerOptionRestoreIdentifierKey: "tech.berty.peripheral",
+                CBPeripheralManagerOptionShowPowerAlertKey: true
+            ]
+        )
+        isBluetoothInitialized = true
+        logger.info("Bluetooth managers initialized")
+    }
+
+    private func ensureBluetoothInitialized() {
+        if !isBluetoothInitialized {
+            setupBluetooth()
+        }
+    }
+
+    // MARK: - Public Interface
+
+    func startAdvertising() throws {
+        ensureBluetoothInitialized()
+
+        bluetoothStateCondition.lock()
+        if !bluetoothStateReady {
+            logger.info("Waiting for Bluetooth state")
+            let timedOut = !bluetoothStateCondition.wait(until: Date().addingTimeInterval(5.0))
+            if timedOut {
+                logger.info("Timed out waiting for Bluetooth state")
+            } else {
+                logger.info("Bluetooth state received: \(bluetoothState.rawValue)")
+            }
+        }
+        bluetoothStateCondition.unlock()
+
+        guard isBluetoothAvailable() && isBluetoothEnabled() else {
+            throw BertyError.bluetoothError(
+                .bluetoothUnavailable,
+                message: "Bluetooth is not available or enabled (state: \(bluetoothState.rawValue))"
+            )
+        }
+
+        guard !isAdvertising else { return }
+
+        // Wait for peripheral manager to be powered on BEFORE dispatching to bleQueue
+        // (because peripheralManagerDidUpdateState callback also runs on bleQueue)
+        peripheralStateCondition.lock()
+        if !peripheralStateReady {
+                let timedOut = !peripheralStateCondition.wait(until: Date().addingTimeInterval(5.0))
+            if timedOut {
+                logger.info("Timed out waiting for peripheral manager")
+            }
+        }
+        peripheralStateCondition.unlock()
+
+        // Verify peripheral manager is actually powered on
+        guard peripheralManager?.state == .poweredOn else {
+            logger.info("Peripheral manager not powered on, cannot add service")
+            return
+        }
+
+        bleQueue.async { [weak self] in
+            guard let self = self else { return }
+            self.setupPeripheralService()
+        }
+    }
+
+    func stopAdvertising() {
+        guard isAdvertising else { return }
+
+        bleQueue.async { [weak self] in
+            guard let self = self else { return }
+            self.peripheralManager?.stopAdvertising()
+            // Remove service so it can be re-added on next start
+            if let service = self.bertyService {
+                self.peripheralManager?.remove(service)
+                self.serviceAdded = false
+            }
+            self.isAdvertising = false
+            self.logger.info("Stopped advertising")
+        }
+    }
+
+    func startScanning() throws {
+        ensureBluetoothInitialized()
+
+        bluetoothStateCondition.lock()
+        if !bluetoothStateReady {
+            logger.info("Waiting for Bluetooth state (scanning)")
+            let timedOut = !bluetoothStateCondition.wait(until: Date().addingTimeInterval(5.0))
+            if timedOut {
+                logger.info("Timed out waiting for Bluetooth state (scanning)")
+            }
+        }
+        bluetoothStateCondition.unlock()
+
+        guard isBluetoothAvailable() && isBluetoothEnabled() else {
+            throw BertyError.bluetoothError(
+                .bluetoothUnavailable,
+                message: "Bluetooth is not available or enabled (state: \(bluetoothState.rawValue))"
+            )
+        }
+        guard !isScanning else { return }
+
+        bleQueue.async { [weak self] in
+            self?.startCentralScanning()
+        }
+    }
+
+    func stopScanning() {
+        guard isScanning else { return }
+
+        bleQueue.async { [weak self] in
+            self?.scanCycleWork?.cancel()
+            self?.scanCycleWork = nil
+
+            self?.centralManager?.stopScan()
+            self?.isScanning = false
+            self?.logger.info("Stopped scanning")
+        }
+    }
+
+    func connectToPeer(_ peerId: String) throws {
+        guard let peer = discoveredPeers[peerId] else {
+            throw BertyError.bluetoothError(
+                .bleConnectionFailed,
+                message: "Peer not found: \(peerId)"
+            )
+        }
+
+        guard let peripheral = peer.peripheral else {
+            throw BertyError.bluetoothError(
+                .bleConnectionFailed,
+                message: "Peripheral not available for peer: \(peerId)"
+            )
+        }
+
+        bleQueue.async { [weak self] in
+            self?.connectToPeripheral(peripheral, peerId: peerId)
+        }
+    }
+
+    func disconnectFromPeer(_ peerId: String) {
+        bleQueue.async { [weak self] in
+            guard let peripheral = self?.connectedPeers[peerId] else { return }
+            self?.centralManager?.cancelPeripheralConnection(peripheral)
+        }
+    }
+
+    /// Disconnect from a peer by their Berty PID (handles both client and server connections)
+    func disconnectByRemotePID(_ remotePID: String) {
+        bleQueue.async { [weak self] in
+            guard let self = self else { return }
+
+            // Check client-side connections
+            if let peerId = self.clientRemotePIDs.first(where: { $0.value == remotePID })?.key,
+               let peripheral = self.connectedPeers[peerId] {
+                self.centralManager?.cancelPeripheralConnection(peripheral)
+                return
+            }
+
+            // Check server-side connections - we can't disconnect a central, but we can clean up
+            if let centralId = self.serverRemotePIDs.first(where: { $0.value == remotePID })?.key {
+                self.removeServerPeer(centralId)
+                // Notify delegate of disconnection
+                DispatchQueue.main.async {
+                    self.delegate?.bleDriver(self, didDisconnectFromPeer: remotePID, error: nil)
+                }
+            }
+        }
+    }
+
+    func sendData(_ data: Data, toPeer peerId: String) throws {
+        guard data.count <= BertyBLEConstants.maxDataLength else {
+            throw BertyError.bluetoothError(
+                .bleConnectionFailed,
+                message: "Data too large: \(data.count) bytes (max: \(BertyBLEConstants.maxDataLength))"
+            )
+        }
+
+        guard let characteristic = peerCharacteristics[peerId] else {
+            throw BertyError.bluetoothError(
+                .bleConnectionFailed,
+                message: "No characteristic available for peer: \(peerId)"
+            )
+        }
+
+        guard characteristic.properties.contains(.write) || characteristic.properties.contains(.writeWithoutResponse) else {
+            throw BertyError.bluetoothError(
+                .bleConnectionFailed,
+                message: "Characteristic does not support write for peer: \(peerId)"
+            )
+        }
+
+        guard let peripheral = connectedPeers[peerId] else {
+            throw BertyError.bluetoothError(
+                .bleConnectionFailed,
+                message: "Peer not connected: \(peerId)"
+            )
+        }
+
+        bleQueue.async {
+            peripheral.writeValue(data, for: characteristic, type: .withResponse)
+        }
+    }
+
+    func isBluetoothAvailable() -> Bool {
+        return bluetoothState != .unsupported
+    }
+
+    func isBluetoothEnabled() -> Bool {
+        return bluetoothState == .poweredOn
+    }
+
+    func getCentralManager() -> CBCentralManager? {
+        return centralManager
+    }
+
+    /// Set the local peer ID used in BLE handshake
+    /// Must be called before startAdvertising()
+    func setLocalPID(_ pid: String) {
+        bleQueue.async { [weak self] in
+            guard let self = self else { return }
+
+            if self.isAdvertising {
+                self.logger.info("Warning: setLocalPID called after advertising started - PID may not be used in existing connections")
+            }
+
+            if pid.isEmpty {
+                self.logger.info("Warning: setLocalPID called with empty PID")
+                return
+            }
+
+            self.localPID = pid
+            self.logger.info("Local PID set for BLE handshake")
+        }
+    }
+
+    /// Get the local peer ID
+    func getLocalPID() -> String {
+        return localPID
+    }
+
+    /// Send data to a peer via BLE (server mode - via WRITER notifications)
+    func sendDataToSubscribedCentral(_ data: Data, centralId: String) throws {
+        guard let writerChar = writerCharacteristic else {
+            throw BertyError.bluetoothError(
+                .bleConnectionFailed,
+                message: "WRITER characteristic not available"
+            )
+        }
+
+        guard let central = subscribedCentrals[centralId] else {
+            throw BertyError.bluetoothError(
+                .bleConnectionFailed,
+                message: "Central not subscribed: \(centralId)"
+            )
+        }
+
+        bleQueue.async { [weak self] in
+            guard let self = self else { return }
+            self.sendChunkedNotification(data: data, to: central, via: writerChar)
+        }
+    }
+
+    /// Send data to a peer by their PID (handles both server and client modes)
+    func sendDataToPeer(_ data: Data, remotePID: String) throws {
+        // Check if we're connected as server (they connected to us)
+        if let centralId = serverRemotePIDs.first(where: { $0.value == remotePID })?.key {
+            try sendDataToSubscribedCentral(data, centralId: centralId)
+            return
+        }
+
+        // Check if we're connected as client (we connected to them)
+        if let peripheral = connectedPeers.first(where: { clientRemotePIDs[$0.key] == remotePID })?.value {
+            let peerId = peripheral.identifier.uuidString
+            guard let writerChar = peerWriterCharacteristics[peerId] else {
+                throw BertyError.bluetoothError(
+                    .bleConnectionFailed,
+                    message: "WRITER characteristic not found for peer"
+                )
+            }
+
+            bleQueue.async {
+                self.sendChunkedWrite(data: data, to: peripheral, via: writerChar)
+            }
+            return
+        }
+
+        throw BertyError.bluetoothError(
+            .bleConnectionFailed,
+            message: "Peer not connected: \(remotePID)"
+        )
+    }
+
+    /// Check if peer is connected (either as server or client) with completed handshake
+    func isPeerConnected(_ remotePID: String) -> Bool {
+        // Check server-side connections - find the central ID for this PID
+        if let centralId = serverRemotePIDs.first(where: { $0.value == remotePID })?.key {
+            if serverHandshakeComplete[centralId] == true {
+                return true
+            }
+        }
+        // Check client-side connections - find the peer ID for this PID
+        if let peerId = clientRemotePIDs.first(where: { $0.value == remotePID })?.key {
+            if clientHandshakeComplete[peerId] == true {
+                return true
+            }
+        }
+        return false
+    }
+
+    // MARK: - Peripheral (Advertising) Implementation
+
+    private func setupPeripheralService() {
+        // Skip if service already added
+        if serviceAdded {
+            startPeripheralAdvertising()
+            return
+        }
+
+        // Create the service
+        bertyService = CBMutableService(type: BertyBLEConstants.serviceUUID, primary: true)
+
+        // Create PID characteristic (for handshake - read/write)
+        // Android expects: read returns [4-byte PSM][PID], write receives remote PID + EOD
+        pidCharacteristic = CBMutableCharacteristic(
+            type: BertyBLEConstants.pidCharacteristicUUID,
+            properties: [.read, .write],
+            value: nil,
+            permissions: [.readable, .writeable]
+        )
+
+        // Create WRITER characteristic (for data transfer - write/notify)
+        // Android expects: write receives data, notify sends data
+        writerCharacteristic = CBMutableCharacteristic(
+            type: BertyBLEConstants.writerCharacteristicUUID,
+            properties: [.write, .notify],
+            value: nil,
+            permissions: [.writeable]
+        )
+
+        guard let pidChar = pidCharacteristic,
+              let writerChar = writerCharacteristic,
+              let service = bertyService else {
+            logger.info("Failed to create BLE characteristics or service")
+            return
+        }
+
+        // Add both characteristics to service
+        service.characteristics = [pidChar, writerChar]
+
+        // Add service to peripheral manager
+        peripheralManager?.add(service)
+    }
+
+    private func startPeripheralAdvertising() {
+        let pidSuffix = String(localPID.suffix(4))
+        let devicePrefix = String(UIDevice.current.name.prefix(6))
+        let localName = "Berty-\(devicePrefix)-\(pidSuffix)"
+
+        let advertisementData: [String: Any] = [
+            CBAdvertisementDataServiceUUIDsKey: [BertyBLEConstants.serviceUUID],
+            CBAdvertisementDataLocalNameKey: localName
+        ]
+
+        peripheralManager?.startAdvertising(advertisementData)
+        isAdvertising = true
+        logger.info("Started advertising as: \(localName)")
+    }
+
+    /// Send chunked notifications to a subscribed central (server mode)
+    /// Uses proper queue management instead of blocking sleep
+    private func sendChunkedNotification(data: Data, to central: CBCentral, via characteristic: CBMutableCharacteristic) {
+        // Use the central's actual MTU for optimal throughput
+        let mtu = central.maximumUpdateValueLength - BertyBLEConstants.attHeaderSize
+        let effectiveMtu = max(mtu, 20) // Minimum 20 bytes per BLE spec
+
+        var offset = 0
+
+        while offset < data.count {
+            let endIndex = min(offset + effectiveMtu, data.count)
+            let chunk = data.subdata(in: offset..<endIndex)
+
+            let success = peripheralManager?.updateValue(
+                chunk,
+                for: characteristic,
+                onSubscribedCentrals: [central]
+            ) ?? false
+
+            if !success {
+                // Queue is full - store remaining data and wait for peripheralManagerIsReady
+                let remainingData = data.subdata(in: offset..<data.count)
+                // Prevent unbounded queue growth - drop oldest if at limit
+                if pendingNotifications.count >= maxPendingNotifications {
+                    logger.info("Notification queue at limit, dropping oldest entry")
+                    pendingNotifications.removeFirst()
+                }
+                pendingNotifications.append((data: remainingData, central: central))
+                logger.info("Notification queue full, queued \(remainingData.count) bytes for later")
+                return
+            }
+
+            offset = endIndex
+        }
+    }
+
+    /// Process pending notifications when the queue becomes ready
+    private func processPendingNotifications() {
+        guard !pendingNotifications.isEmpty,
+              let writerChar = writerCharacteristic else { return }
+
+        isProcessingNotifications = true
+
+        while !pendingNotifications.isEmpty {
+            let pending = pendingNotifications.removeFirst()
+            let central = pending.central
+            let data = pending.data
+
+            // Use the central's actual MTU
+            let mtu = central.maximumUpdateValueLength - BertyBLEConstants.attHeaderSize
+            let effectiveMtu = max(mtu, 20)
+            var offset = 0
+
+            while offset < data.count {
+                let endIndex = min(offset + effectiveMtu, data.count)
+                let chunk = data.subdata(in: offset..<endIndex)
+
+                let success = peripheralManager?.updateValue(
+                    chunk,
+                    for: writerChar,
+                    onSubscribedCentrals: [central]
+                ) ?? false
+
+                if !success {
+                    // Still full - put back remaining data and exit
+                    let remainingData = data.subdata(in: offset..<data.count)
+                    pendingNotifications.insert((data: remainingData, central: central), at: 0)
+                    isProcessingNotifications = false
+                    return
+                }
+
+                offset = endIndex
+            }
+        }
+
+        isProcessingNotifications = false
+    }
+
+    /// Send chunked writes to a peripheral (client mode)
+    /// CoreBluetooth internally queues .withResponse writes and processes them in order
+    private func sendChunkedWrite(data: Data, to peripheral: CBPeripheral, via characteristic: CBCharacteristic) {
+        // Get negotiated MTU minus ATT header
+        let mtu = peripheral.maximumWriteValueLength(for: .withResponse)
+        let effectiveMtu = max(mtu, 20) // Minimum 20 bytes per BLE spec
+        var offset = 0
+
+        while offset < data.count {
+            let endIndex = min(offset + effectiveMtu, data.count)
+            let chunk = data.subdata(in: offset..<endIndex)
+
+            // CoreBluetooth queues .withResponse writes internally and processes in order
+            // Errors are reported via didWriteValueFor delegate callback
+            peripheral.writeValue(chunk, for: characteristic, type: .withResponse)
+            offset = endIndex
+        }
+    }
+
+    // MARK: - Central (Scanning) Implementation
+
+    private func startCentralScanning() {
+        let services = [BertyBLEConstants.serviceUUID]
+        let options: [String: Any] = [
+            CBCentralManagerScanOptionAllowDuplicatesKey: false
+        ]
+
+        centralManager?.scanForPeripherals(withServices: services, options: options)
+        isScanning = true
+
+        scheduleScanCycle()
+        logger.info("Started scanning")
+    }
+
+    private func scheduleScanCycle() {
+        scanCycleWork?.cancel()
+
+        let cycleWork = DispatchWorkItem { [weak self] in
+            guard let self = self, self.isScanning else { return }
+
+            // Pause scanning
+            self.centralManager?.stopScan()
+            self.logger.info("Scan cycle: paused")
+
+            // Resume after brief pause to process results
+            self.bleQueue.asyncAfter(deadline: .now() + 1.0) { [weak self] in
+                guard let self = self, self.isScanning else { return }
+                self.centralManager?.scanForPeripherals(
+                    withServices: [BertyBLEConstants.serviceUUID],
+                    options: [CBCentralManagerScanOptionAllowDuplicatesKey: false]
+                )
+                self.logger.info("Scan cycle: resumed")
+                self.scheduleScanCycle()
+            }
+        }
+
+        scanCycleWork = cycleWork
+        bleQueue.asyncAfter(deadline: .now() + scanCycleInterval, execute: cycleWork)
+    }
+
+    private func connectToPeripheral(_ peripheral: CBPeripheral, peerId: String) {
+        let timeoutWork = DispatchWorkItem { [weak self] in
+            self?.handleConnectionTimeout(peerId: peerId)
+        }
+        connectionTimeoutWork[peerId] = timeoutWork
+        bleQueue.asyncAfter(deadline: .now() + BertyBLEConstants.connectionTimeout, execute: timeoutWork)
+
+        peripheral.delegate = self
+        centralManager?.connect(peripheral, options: nil)
+
+        logger.info("Connecting to peer: \(peerId)")
+    }
+
+    private func handleConnectionTimeout(peerId: String) {
+        logger.info("Connection timeout for peer: \(peerId)")
+
+        if let peripheral = connectedPeers[peerId] {
+            centralManager?.cancelPeripheralConnection(peripheral)
+        }
+
+        connectionTimeoutWork.removeValue(forKey: peerId)
+
+        let error = BertyError.bluetoothError(
+            .peerConnectionTimeout,
+            message: "Connection timeout for peer: \(peerId)"
+        )
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.delegate?.bleDriver(self, didFailWithError: error)
+        }
+    }
+
+    // MARK: - Peer Management
+
+    private func addDiscoveredPeer(_ peripheral: CBPeripheral, rssi: NSNumber) {
+        let peerId = peripheral.identifier.uuidString
+
+        let peer = BertyBLEPeer(
+            id: peerId,
+            name: peripheral.name,
+            rssi: rssi.intValue,
+            lastSeen: Date(),
+            isConnected: false,
+            peripheral: peripheral,
+            services: peripheral.services?.map { $0.uuid.uuidString } ?? []
+        )
+
+        discoveredPeers[peerId] = peer
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.delegate?.bleDriver(self, didDiscoverPeer: peer)
+        }
+    }
+
+    private func removePeer(_ peerId: String) {
+        discoveredPeers.removeValue(forKey: peerId)
+        connectedPeers.removeValue(forKey: peerId)
+        peerCharacteristics.removeValue(forKey: peerId)
+
+        connectionTimeoutWork[peerId]?.cancel()
+        connectionTimeoutWork.removeValue(forKey: peerId)
+        handshakeTimeoutWork[peerId]?.cancel()
+        handshakeTimeoutWork.removeValue(forKey: peerId)
+
+        // Clean up client-side state
+        peerWriterCharacteristics.removeValue(forKey: peerId)
+        clientHandshakeComplete.removeValue(forKey: peerId)
+        clientRemotePIDs.removeValue(forKey: peerId)
+        pendingDataCache.removeValue(forKey: peerId)
+        clientHandshakeStates.removeValue(forKey: peerId)
+    }
+
+    /// Clean up server-side state for a central that disconnected
+    private func removeServerPeer(_ centralId: String) {
+        subscribedCentrals.removeValue(forKey: centralId)
+        incomingPIDBuffers.removeValue(forKey: centralId)
+        serverHandshakeComplete.removeValue(forKey: centralId)
+        serverRemotePIDs.removeValue(forKey: centralId)
+        pendingDataCache.removeValue(forKey: centralId)
+
+        pendingNotifications.removeAll { $0.central.identifier.uuidString == centralId }
+    }
+
+    private func disconnectAllPeers() {
+        for (_, peripheral) in connectedPeers {
+            centralManager?.cancelPeripheralConnection(peripheral)
+        }
+
+        // Clean up client-side state
+        connectedPeers.removeAll()
+        peerCharacteristics.removeAll()
+        peerWriterCharacteristics.removeAll()
+        clientHandshakeComplete.removeAll()
+        clientRemotePIDs.removeAll()
+        clientHandshakeStates.removeAll()
+
+        // Clean up server-side state
+        subscribedCentrals.removeAll()
+        incomingPIDBuffers.removeAll()
+        serverHandshakeComplete.removeAll()
+        serverRemotePIDs.removeAll()
+        pendingNotifications.removeAll()
+        isProcessingNotifications = false
+
+        // Clean up shared state
+        pendingDataCache.removeAll()
+
+        for work in connectionTimeoutWork.values {
+            work.cancel()
+        }
+        connectionTimeoutWork.removeAll()
+
+        for work in handshakeTimeoutWork.values {
+            work.cancel()
+        }
+        handshakeTimeoutWork.removeAll()
+    }
+
+    // MARK: - Data Processing
+
+    private func processReceivedData(_ data: Data, fromPeer peerId: String) {
+        // Process and validate received data
+        logger.info(" Received \(data.count) bytes from peer: \(peerId)")
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.delegate?.bleDriver(self, didReceiveData: data, fromPeer: peerId)
+        }
+    }
+
+    // MARK: - Debug Information
+
+    func getDebugInfo() -> [String: Any] {
+        var info: [String: Any] = [:]
+
+        info["bluetoothState"] = String(describing: bluetoothState)
+        info["isAdvertising"] = isAdvertising
+        info["isScanning"] = isScanning
+        info["discoveredPeersCount"] = discoveredPeers.count
+        info["connectedPeersCount"] = connectedPeers.count
+
+        let peersInfo = discoveredPeers.values.map { peer in
+            [
+                "id": peer.id,
+                "name": peer.name ?? "Unknown",
+                "rssi": peer.rssi,
+                "isConnected": peer.isConnected,
+                "lastSeen": peer.lastSeen.timeIntervalSince1970
+            ]
+        }
+        info["peers"] = peersInfo
+
+        return info
+    }
+}
+
+// MARK: - CBCentralManagerDelegate
+extension BertyBLEDriver: CBCentralManagerDelegate {
+    func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        bluetoothState = central.state
+        logger.info("Central manager state updated: \(central.state.rawValue)")
+
+        if central.state != .unknown && central.state != .resetting {
+            bluetoothStateCondition.lock()
+            bluetoothStateReady = true
+            bluetoothStateCondition.broadcast()
+            bluetoothStateCondition.unlock()
+            logger.info("Bluetooth state ready: \(central.state.rawValue)")
+        }
+
+        switch central.state {
+        case .poweredOn:
+            logger.info("Bluetooth is powered on")
+        case .poweredOff:
+            logger.info("Bluetooth is powered off")
+            stopScanning()
+        case .unauthorized:
+            let error = BertyError.bluetoothError(
+                .bluetoothPermissionDenied,
+                message: "Bluetooth permission denied"
+            )
+                DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+                self.delegate?.bleDriver(self, didFailWithError: error)
+            }
+        case .unsupported:
+            let error = BertyError.bluetoothError(
+                .bluetoothUnavailable,
+                message: "Bluetooth is not supported on this device"
+            )
+                DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+                self.delegate?.bleDriver(self, didFailWithError: error)
+            }
+        default:
+            break
+        }
+    }
+
+    func centralManager(_ central: CBCentralManager, willRestoreState dict: [String : Any]) {
+        logger.info("Restoring central manager state")
+
+        if let peripherals = dict[CBCentralManagerRestoredStatePeripheralsKey] as? [CBPeripheral] {
+            for peripheral in peripherals {
+                let peerId = peripheral.identifier.uuidString
+                connectedPeers[peerId] = peripheral
+
+                if peripheral.state == .connected {
+                    peripheral.delegate = self
+                    peripheral.discoverServices([BertyBLEConstants.serviceUUID])
+                }
+            }
+        }
+    }
+
+    func centralManager(_ central: CBCentralManager, didDiscover peripheral: CBPeripheral, advertisementData: [String: Any], rssi RSSI: NSNumber) {
+        let peerId = peripheral.identifier.uuidString
+        logger.info("Discovered peripheral: \(peerId)")
+
+        // Also check service data for Android format (PID suffix in service data bytes)
+        var remotePIDSuffix: String?
+
+        // Try iOS format first: local name "Berty-<device>-<pid_suffix>"
+        if let localName = advertisementData[CBAdvertisementDataLocalNameKey] as? String {
+            let components = localName.split(separator: "-")
+            if components.count >= 3 {
+                remotePIDSuffix = String(components.last ?? "")
+            }
+        }
+
+        // If no PID from local name, try Android format: PID in service data
+        if remotePIDSuffix == nil {
+            if let serviceData = advertisementData[CBAdvertisementDataServiceDataKey] as? [CBUUID: Data],
+               let pidData = serviceData[BertyBLEConstants.serviceUUID],
+               let pidString = String(data: pidData, encoding: .utf8), !pidString.isEmpty {
+                remotePIDSuffix = pidString
+            }
+        }
+
+        if let remoteSuffix = remotePIDSuffix, !localPID.isEmpty {
+            let localSuffix = String(localPID.suffix(4))
+            if localSuffix >= remoteSuffix {
+                // Still add to discovered peers but don't auto-connect
+                addDiscoveredPeer(peripheral, rssi: RSSI)
+                return
+            }
+        }
+
+        addDiscoveredPeer(peripheral, rssi: RSSI)
+
+        // Auto-connect if we're the initiator (lower PID suffix)
+        // But first check if we already have a connection (client or server) with this peer
+        if let remoteSuffix = remotePIDSuffix {
+            // Check if we already have a server-side connection with this peer
+            let hasServerConnection = serverRemotePIDs.values.contains { pid in
+                pid.hasSuffix(remoteSuffix)
+            }
+            if hasServerConnection { return }
+
+            // Check if we already have a client-side connection
+            let hasClientConnection = clientRemotePIDs.values.contains { pid in
+                pid.hasSuffix(remoteSuffix)
+            }
+            if hasClientConnection { return }
+
+            // No existing connection, proceed with auto-connect
+            if discoveredPeers[peerId] != nil && connectedPeers[peerId] == nil {
+                connectToPeripheral(peripheral, peerId: peerId)
+            }
+        }
+    }
+
+    func centralManager(_ central: CBCentralManager, didConnect peripheral: CBPeripheral) {
+        let peerId = peripheral.identifier.uuidString
+
+        connectionTimeoutWork[peerId]?.cancel()
+        connectionTimeoutWork.removeValue(forKey: peerId)
+
+        connectedPeers[peerId] = peripheral
+
+        // Update peer connection status
+        if let peer = discoveredPeers[peerId] {
+            discoveredPeers[peerId] = BertyBLEPeer(
+                id: peer.id,
+                name: peer.name,
+                rssi: peer.rssi,
+                lastSeen: Date(),
+                isConnected: true,
+                peripheral: peer.peripheral,
+                services: peer.services
+            )
+        }
+
+        // Discover services
+        peripheral.discoverServices([BertyBLEConstants.serviceUUID])
+
+        logger.info("Connected to peer: \(peerId)")
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.delegate?.bleDriver(self, didConnectToPeer: peerId)
+        }
+    }
+
+    func centralManager(_ central: CBCentralManager, didFailToConnect peripheral: CBPeripheral, error: Error?) {
+        let peerId = peripheral.identifier.uuidString
+
+        connectionTimeoutWork[peerId]?.cancel()
+        connectionTimeoutWork.removeValue(forKey: peerId)
+
+        removePeer(peerId)
+
+        logger.info("Failed to connect to peer: \(peerId), error: \(error?.localizedDescription ?? "unknown")")
+
+        let bertyError = BertyError.bluetoothError(
+            .bleConnectionFailed,
+            message: "Failed to connect to peer: \(peerId)",
+            underlyingError: error
+        )
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.delegate?.bleDriver(self, didFailWithError: bertyError)
+        }
+    }
+
+    func centralManager(_ central: CBCentralManager, didDisconnectPeripheral peripheral: CBPeripheral, error: Error?) {
+        let peerId = peripheral.identifier.uuidString
+
+        removePeer(peerId)
+
+        logger.info("Disconnected from peer: \(peerId)")
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.delegate?.bleDriver(self, didDisconnectFromPeer: peerId, error: error)
+        }
+    }
+}
+
+// MARK: - CBPeripheralDelegate
+extension BertyBLEDriver: CBPeripheralDelegate {
+    func peripheral(_ peripheral: CBPeripheral, didDiscoverServices error: Error?) {
+        if let error = error {
+            logger.info("Error discovering services: \(error.localizedDescription)")
+            return
+        }
+
+        guard let services = peripheral.services else { return }
+
+        for service in services {
+            if service.uuid == BertyBLEConstants.serviceUUID {
+                // Discover BOTH PID and WRITER characteristics
+                peripheral.discoverCharacteristics(
+                    [BertyBLEConstants.pidCharacteristicUUID, BertyBLEConstants.writerCharacteristicUUID],
+                    for: service
+                )
+            }
+        }
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didDiscoverCharacteristicsFor service: CBService, error: Error?) {
+        if let error = error {
+            logger.info("Error discovering characteristics: \(error.localizedDescription)")
+            return
+        }
+
+        guard let characteristics = service.characteristics else { return }
+
+        let peerId = peripheral.identifier.uuidString
+        var foundPID = false
+        var foundWriter = false
+
+        for characteristic in characteristics {
+            if characteristic.uuid == BertyBLEConstants.pidCharacteristicUUID {
+                peerCharacteristics[peerId] = characteristic
+                foundPID = true
+                logger.info("Found PID characteristic for peer: \(peerId)")
+            } else if characteristic.uuid == BertyBLEConstants.writerCharacteristicUUID {
+                peerWriterCharacteristics[peerId] = characteristic
+                foundWriter = true
+                logger.info("Found WRITER characteristic for peer: \(peerId)")
+
+                // Subscribe to notifications on WRITER characteristic
+                if characteristic.properties.contains(.notify) {
+                    peripheral.setNotifyValue(true, for: characteristic)
+                }
+            }
+        }
+
+        // If we found both characteristics, initiate handshake
+        if foundPID && foundWriter {
+            initiateClientHandshake(with: peripheral)
+        } else if foundPID {
+            // Fallback for older implementations without WRITER
+            logger.info("Only PID characteristic found - legacy mode for peer: \(peerId)")
+            initiateClientHandshake(with: peripheral)
+        }
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didUpdateValueFor characteristic: CBCharacteristic, error: Error?) {
+        if let error = error {
+            logger.info("Error updating characteristic value: \(error.localizedDescription)")
+            return
+        }
+
+        guard let data = characteristic.value else { return }
+        let peerId = peripheral.identifier.uuidString
+
+        if characteristic.uuid == BertyBLEConstants.pidCharacteristicUUID {
+            // This is the response to our PID read - contains [PSM (4 bytes)][PID]
+            handlePIDReadResponse(data: data, fromPeer: peerId, peripheral: peripheral)
+        } else if characteristic.uuid == BertyBLEConstants.writerCharacteristicUUID {
+            // Data received via WRITER notifications
+            handleClientDataReceived(data: data, fromPeer: peerId)
+        }
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didWriteValueFor characteristic: CBCharacteristic, error: Error?) {
+        let peerId = peripheral.identifier.uuidString
+
+        if let error = error {
+            logger.info("Error writing to characteristic: \(error.localizedDescription)")
+
+            let bertyError = BertyError.bluetoothError(
+                .bleConnectionFailed,
+                message: "Write failed for peer: \(peerId)",
+                underlyingError: error
+            )
+
+            // Cancel handshake and disconnect on write failure
+            handshakeTimeoutWork[peerId]?.cancel()
+            handshakeTimeoutWork.removeValue(forKey: peerId)
+            centralManager?.cancelPeripheralConnection(peripheral)
+
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+                self.delegate?.bleDriver(self, didFailWithError: bertyError)
+            }
+            return
+        }
+
+        if characteristic.uuid == BertyBLEConstants.pidCharacteristicUUID {
+            // PID write completed - check if we need to send EOD or read response
+            handlePIDWriteComplete(forPeer: peerId, peripheral: peripheral)
+        }
+    }
+
+    func peripheral(_ peripheral: CBPeripheral, didUpdateNotificationStateFor characteristic: CBCharacteristic, error: Error?) {
+        let peerId = peripheral.identifier.uuidString
+
+        if let error = error {
+            logger.info("Error updating notification state: \(error.localizedDescription)")
+            return
+        }
+
+        if characteristic.uuid == BertyBLEConstants.writerCharacteristicUUID && characteristic.isNotifying {
+            logger.info("Subscribed to WRITER notifications for peer: \(peerId)")
+            // Finalize handshake if PID exchange is complete
+            if clientRemotePIDs[peerId] != nil {
+                finalizeClientHandshake(forPeer: peerId)
+            }
+        }
+    }
+
+    // MARK: - Client-Side Handshake Implementation
+
+    private func initiateClientHandshake(with peripheral: CBPeripheral) {
+        let peerId = peripheral.identifier.uuidString
+
+        guard let pidChar = peerCharacteristics[peerId] else {
+            logger.info("Cannot initiate handshake - PID characteristic not found")
+            return
+        }
+
+        // Step 1: Write local PID to server's PID characteristic
+        guard let pidData = localPID.data(using: .utf8) else {
+            logger.info("Cannot initiate handshake - local PID not set")
+            return
+        }
+
+        let timeoutWork = DispatchWorkItem { [weak self] in
+            guard let self = self else { return }
+            if self.clientHandshakeComplete[peerId] != true {
+                self.logger.info("Handshake timeout for peer: \(peerId)")
+                self.centralManager?.cancelPeripheralConnection(peripheral)
+                self.removePeer(peerId)
+            }
+        }
+        handshakeTimeoutWork[peerId] = timeoutWork
+        bleQueue.asyncAfter(deadline: .now() + handshakeTimeout, execute: timeoutWork)
+
+        clientHandshakeStates[peerId] = .writingPID
+        logger.info("Client handshake step 1: Writing local PID to peer: \(peerId)")
+
+        // Write PID (may be chunked by CoreBluetooth automatically)
+        peripheral.writeValue(pidData, for: pidChar, type: .withResponse)
+    }
+
+    private func handlePIDWriteComplete(forPeer peerId: String, peripheral: CBPeripheral) {
+        guard let pidChar = peerCharacteristics[peerId] else { return }
+
+        let state = clientHandshakeStates[peerId] ?? .idle
+
+        switch state {
+        case .writingPID:
+            // Step 2: Send EOD marker
+            clientHandshakeStates[peerId] = .writingEOD
+            logger.info("Client handshake step 2: Sending EOD marker to peer: \(peerId)")
+            peripheral.writeValue(BertyBLEConstants.eodMarkerData, for: pidChar, type: .withResponse)
+
+        case .writingEOD:
+            // Step 3: Read server's PID response
+            clientHandshakeStates[peerId] = .readingPID
+            logger.info("Client handshake step 3: Reading server PID from peer: \(peerId)")
+            peripheral.readValue(for: pidChar)
+
+        default:
+            break
+        }
+    }
+
+    private func handlePIDReadResponse(data: Data, fromPeer peerId: String, peripheral: CBPeripheral) {
+        // Parse response: [4 bytes PSM (big-endian)][PID string]
+        guard data.count > 4 else {
+            logger.info("Invalid PID response - too short: \(data.count) bytes")
+            return
+        }
+
+        // Extract PSM (first 4 bytes, big-endian)
+        let psmData = data.subdata(in: 0..<4)
+        let psm = psmData.withUnsafeBytes { $0.load(as: Int32.self).bigEndian }
+
+        // Extract remote PID (remaining bytes)
+        let pidData = data.subdata(in: 4..<data.count)
+        guard let remotePID = String(data: pidData, encoding: .utf8) else {
+            logger.info("Invalid PID response - cannot decode PID string")
+            return
+        }
+
+        logger.info("Client received server response: PSM=\(psm), PID=\(remotePID)")
+
+        // Store remote PID
+        clientRemotePIDs[peerId] = remotePID
+
+        // PSM is ignored (iOS doesn't use L2CAP)
+
+        // Step 4: Subscribe to WRITER notifications (already done in didDiscoverCharacteristics)
+        // Check if already subscribed
+        if let writerChar = peerWriterCharacteristics[peerId], writerChar.isNotifying {
+            finalizeClientHandshake(forPeer: peerId)
+        } else {
+            clientHandshakeStates[peerId] = .subscribing
+        }
+    }
+
+    private func handleClientDataReceived(data: Data, fromPeer peerId: String) {
+        // Check if handshake is complete
+        if clientHandshakeComplete[peerId] == true {
+            // Forward data to delegate using remote PID
+            guard let remotePID = clientRemotePIDs[peerId] else { return }
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+                self.delegate?.bleDriver(self, didReceiveData: data, fromPeer: remotePID)
+            }
+        } else {
+            // Cache data until handshake completes with size limit
+            if pendingDataCache[peerId] == nil {
+                pendingDataCache[peerId] = []
+            }
+            let currentSize = pendingDataCache[peerId]?.reduce(0) { $0 + $1.count } ?? 0
+            if currentSize + data.count > maxPendingDataCacheSize {
+                logger.info("Pending data cache overflow for peer \(peerId), dropping")
+                return
+            }
+            pendingDataCache[peerId]?.append(data)
+            logger.info("Cached client data from peer \(peerId) - handshake pending")
+        }
+    }
+
+    private func finalizeClientHandshake(forPeer peerId: String) {
+        handshakeTimeoutWork[peerId]?.cancel()
+        handshakeTimeoutWork.removeValue(forKey: peerId)
+
+        clientHandshakeComplete[peerId] = true
+        clientHandshakeStates[peerId] = .complete
+        logger.info("Client handshake complete for peer: \(peerId)")
+
+        // Flush cached data
+        guard let remotePID = clientRemotePIDs[peerId] else { return }
+
+        if let cachedData = pendingDataCache[peerId] {
+            for data in cachedData {
+                DispatchQueue.main.async { [weak self] in
+                    guard let self = self else { return }
+                    self.delegate?.bleDriver(self, didReceiveData: data, fromPeer: remotePID)
+                }
+            }
+            pendingDataCache.removeValue(forKey: peerId)
+        }
+
+        // Notify delegate that handshake-based connection is established
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+
+            let peripheral = self.connectedPeers[peerId]
+            let serviceUUIDs = peripheral?.services?.map { $0.uuid.uuidString } ?? [BertyBLEConstants.serviceUUID.uuidString]
+
+            // Create a peer object with the remote PID
+            let peer = BertyBLEPeer(
+                id: remotePID,
+                name: peripheral?.name,
+                rssi: 0,
+                lastSeen: Date(),
+                isConnected: true,
+                peripheral: peripheral,
+                services: serviceUUIDs
+            )
+            self.delegate?.bleDriver(self, didDiscoverPeer: peer)
+        }
+    }
+}
+
+// MARK: - CBPeripheralManagerDelegate
+extension BertyBLEDriver: CBPeripheralManagerDelegate {
+    func peripheralManagerDidUpdateState(_ peripheral: CBPeripheralManager) {
+        logger.info("Peripheral manager state updated: \(peripheral.state.rawValue)")
+
+        switch peripheral.state {
+        case .poweredOn:
+            // Signal that peripheral manager is ready
+            peripheralStateCondition.lock()
+            peripheralStateReady = true
+            peripheralStateCondition.broadcast()
+            peripheralStateCondition.unlock()
+        case .poweredOff:
+            peripheralStateCondition.lock()
+            peripheralStateReady = false
+            peripheralStateCondition.unlock()
+            stopAdvertising()
+        default:
+            break
+        }
+    }
+
+    func peripheralManager(_ peripheral: CBPeripheralManager, willRestoreState dict: [String : Any]) {
+        logger.info("Restoring peripheral manager state")
+    }
+
+    func peripheralManager(_ peripheral: CBPeripheralManager, didAdd service: CBService, error: Error?) {
+        if let error = error {
+            logger.info("Error adding service: \(error.localizedDescription)")
+            return
+        }
+
+        serviceAdded = true
+        logger.info("Successfully added service with characteristics")
+        startPeripheralAdvertising()
+    }
+
+    func peripheralManagerDidStartAdvertising(_ peripheral: CBPeripheralManager, error: Error?) {
+        if let error = error {
+            logger.info("Error starting advertising: \(error.localizedDescription)")
+            isAdvertising = false
+        } else {
+            logger.info("Successfully started advertising")
+            isAdvertising = true
+        }
+    }
+
+    func peripheralManagerIsReady(toUpdateSubscribers peripheral: CBPeripheralManager) {
+        // Called when the notification queue has space - resume pending notifications
+        if !pendingNotifications.isEmpty && !isProcessingNotifications {
+            processPendingNotifications()
+        }
+    }
+
+    func peripheralManager(_ peripheral: CBPeripheralManager, didReceiveRead request: CBATTRequest) {
+        // Handle read requests on PID characteristic
+        // Android expects: [4 bytes PSM (big-endian)][PID string bytes]
+        guard request.characteristic.uuid == BertyBLEConstants.pidCharacteristicUUID else {
+            peripheral.respond(to: request, withResult: .requestNotSupported)
+            return
+        }
+
+        var responseData = Data()
+
+        // PSM = 0 (iOS doesn't use L2CAP)
+        let psm: Int32 = 0
+        withUnsafeBytes(of: psm.bigEndian) { responseData.append(contentsOf: $0) }
+
+        // Append local PID
+        if let pidData = localPID.data(using: .utf8) {
+            responseData.append(pidData)
+        }
+
+        // Handle offset for long reads
+        if request.offset < responseData.count {
+            request.value = responseData.subdata(in: request.offset..<responseData.count)
+            peripheral.respond(to: request, withResult: .success)
+        } else {
+            peripheral.respond(to: request, withResult: .invalidOffset)
+        }
+    }
+
+    func peripheralManager(_ peripheral: CBPeripheralManager, didReceiveWrite requests: [CBATTRequest]) {
+        guard let firstRequest = requests.first else { return }
+
+        for request in requests {
+            guard let data = request.value else { continue }
+            let centralId = request.central.identifier.uuidString
+
+            if request.characteristic.uuid == BertyBLEConstants.pidCharacteristicUUID {
+                handlePIDWrite(data: data, fromCentral: centralId)
+            } else if request.characteristic.uuid == BertyBLEConstants.writerCharacteristicUUID {
+                handleWriterData(data: data, fromCentral: centralId)
+            }
+        }
+
+        peripheral.respond(to: firstRequest, withResult: .success)
+    }
+
+    func peripheralManager(_ peripheral: CBPeripheralManager,
+                          central: CBCentral,
+                          didSubscribeTo characteristic: CBCharacteristic) {
+        let centralId = central.identifier.uuidString
+
+        if characteristic.uuid == BertyBLEConstants.writerCharacteristicUUID {
+            subscribedCentrals[centralId] = central
+
+            // If handshake was pending, mark as complete now
+            if serverRemotePIDs[centralId] != nil {
+                finalizeServerHandshake(forCentral: centralId)
+            }
+        }
+    }
+
+    func peripheralManager(_ peripheral: CBPeripheralManager,
+                          central: CBCentral,
+                          didUnsubscribeFrom characteristic: CBCharacteristic) {
+        let centralId = central.identifier.uuidString
+
+        // Notify delegate of disconnection if handshake was complete
+        if let remotePID = serverRemotePIDs[centralId] {
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+                self.delegate?.bleDriver(self, didDisconnectFromPeer: remotePID, error: nil)
+            }
+        }
+
+        // Clean up server-side state
+        removeServerPeer(centralId)
+        logger.info("Central \(centralId) unsubscribed from WRITER notifications")
+    }
+
+    // MARK: - Server-Side Handshake Helpers
+
+    private func handlePIDWrite(data: Data, fromCentral centralId: String) {
+        // Check if this is the EOD marker
+        if data == BertyBLEConstants.eodMarkerData {
+            // EOD received - process accumulated PID
+            if let pidData = incomingPIDBuffers[centralId],
+               let remotePID = String(data: pidData, encoding: .utf8) {
+                serverRemotePIDs[centralId] = remotePID
+
+                // If already subscribed, finalize handshake
+                if subscribedCentrals[centralId] != nil {
+                    finalizeServerHandshake(forCentral: centralId)
+                }
+            }
+            incomingPIDBuffers.removeValue(forKey: centralId)
+        } else {
+            // Accumulate PID data
+            if incomingPIDBuffers[centralId] == nil {
+                incomingPIDBuffers[centralId] = Data()
+            }
+
+            let currentSize = incomingPIDBuffers[centralId]?.count ?? 0
+            if currentSize + data.count > maxPIDBufferSize {
+                logger.info("PID buffer overflow from central: \(centralId), rejecting")
+                incomingPIDBuffers.removeValue(forKey: centralId)
+                return
+            }
+
+            incomingPIDBuffers[centralId]?.append(data)
+        }
+    }
+
+    private func handleWriterData(data: Data, fromCentral centralId: String) {
+        // Check if handshake is complete
+        if serverHandshakeComplete[centralId] == true {
+            // Forward data to delegate
+            guard let remotePID = serverRemotePIDs[centralId] else { return }
+            DispatchQueue.main.async { [weak self] in
+                guard let self = self else { return }
+                self.delegate?.bleDriver(self, didReceiveData: data, fromPeer: remotePID)
+            }
+        } else {
+            // Cache data until handshake completes with size limit
+            if pendingDataCache[centralId] == nil {
+                pendingDataCache[centralId] = []
+            }
+            let currentSize = pendingDataCache[centralId]?.reduce(0) { $0 + $1.count } ?? 0
+            if currentSize + data.count > maxPendingDataCacheSize {
+                logger.info("Pending data cache overflow for central \(centralId), dropping")
+                return
+            }
+            pendingDataCache[centralId]?.append(data)
+        }
+    }
+
+    private func finalizeServerHandshake(forCentral centralId: String) {
+        serverHandshakeComplete[centralId] = true
+        logger.info("Server handshake complete for central: \(centralId)")
+
+        // Flush cached data
+        guard let remotePID = serverRemotePIDs[centralId] else { return }
+
+        if let cachedData = pendingDataCache[centralId] {
+            for data in cachedData {
+                DispatchQueue.main.async { [weak self] in
+                    guard let self = self else { return }
+                    self.delegate?.bleDriver(self, didReceiveData: data, fromPeer: remotePID)
+                }
+            }
+            pendingDataCache.removeValue(forKey: centralId)
+        }
+
+        // Notify delegate of peer connection via server
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.delegate?.bleDriver(self, didConnectToPeer: remotePID)
+        }
+    }
+}
+
+// NOTE: BertyProximityDriverBridge (implementing BertybridgeProximityDriverProtocol)
+// is defined in BertyDriverBridges.swift to avoid duplicate class definitions.

--- a/js/ios/Berty/Sources/Bridge/BertyConfiguration.swift
+++ b/js/ios/Berty/Sources/Bridge/BertyConfiguration.swift
@@ -1,0 +1,164 @@
+import Foundation
+
+// MARK: - Berty Configuration
+
+struct BertyConfiguration {
+
+    // MARK: - Bundle Configuration
+
+    private static var infoDictionary: [String: Any] {
+        return Bundle.main.infoDictionary ?? [:]
+    }
+
+    // MARK: - Keychain Configuration
+
+    static var keychainAccessGroup: String {
+        return infoDictionary["appGroupID"] as? String ?? "group.tech.berty"
+    }
+
+    static let keychainService = "BertyNativeKeystore"
+    static let bertyKeychainService = "tech.berty"
+
+    // MARK: - App Group Configuration
+
+    static var appGroupIdentifier: String {
+        return keychainAccessGroup
+    }
+
+    // MARK: - Background Task Identifiers
+
+    static let backgroundRefreshTaskIdentifier = "tech.berty.background.refresh"
+    static let backgroundProcessingTaskIdentifier = "tech.berty.background.processing"
+
+    // MARK: - BLE Configuration
+
+    // UUIDs normalized to lowercase to match Android implementation
+    static let bleServiceUUID = "00004240-0000-1000-8000-00805f9b34fb"
+    static let blePIDCharacteristicUUID = "00004241-0000-1000-8000-00805f9b34fb"
+    static let bleWriterCharacteristicUUID = "00004242-0000-1000-8000-00805f9b34fb"
+    static let bleCCCDescriptorUUID = "00002902-0000-1000-8000-00805f9b34fb"
+    static let bleEODMarker = "EOD"
+    static let bleMaxDataLength = 512
+    static let bleATTHeaderSize = 3
+
+    // Legacy alias for backward compatibility
+    static let bleCharacteristicUUID = blePIDCharacteristicUUID
+    static let bleConnectionTimeout: TimeInterval = 30.0
+    static let bleScanTimeout: TimeInterval = 10.0
+    static let bleReconnectDelay: TimeInterval = 2.0
+    static let bleScanRestartInterval: TimeInterval = 30.0
+
+    // MARK: - Network Configuration
+
+    static let defaultTimeout: TimeInterval = 30.0
+    static let promiseTimeout: TimeInterval = 30.0
+    static let streamTimeout: TimeInterval = 60.0
+    static let maxRetryAttempts = 3
+
+    // MARK: - Storage Configuration
+
+    static let databaseName = "berty.db"
+    static let logFileName = "berty.log"
+    static let maxLogFileSize: Int64 = 10 * 1024 * 1024 // 10MB
+
+    // MARK: - Directory Configuration
+
+    static var applicationSupportDirectory: URL? {
+        guard let appGroup = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier) else {
+            return FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+        }
+        return appGroup.appendingPathComponent("Application Support")
+    }
+
+    static var documentsDirectory: URL? {
+        guard let appGroup = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier) else {
+            return FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first
+        }
+        return appGroup.appendingPathComponent("Documents")
+    }
+
+    static var cacheDirectory: URL? {
+        guard let appGroup = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier) else {
+            return FileManager.default.urls(for: .cachesDirectory, in: .userDomainMask).first
+        }
+        return appGroup.appendingPathComponent("Caches")
+    }
+
+    static var bertyDataDirectory: URL? {
+        return applicationSupportDirectory?.appendingPathComponent("Berty")
+    }
+
+    // MARK: - Logger Configuration
+
+    static let loggerSubsystem = "tech.berty"
+    static let defaultLogLevel = "info"
+
+    // MARK: - Bridge Configuration
+
+    static let bridgeRestoreIdentifierCentral = "tech.berty.central"
+    static let bridgeRestoreIdentifierPeripheral = "tech.berty.peripheral"
+
+    // MARK: - Development Configuration
+
+    #if DEBUG
+    static let isDevelopment = true
+    static let enableDebugLogging = true
+    static let enableMockData = false
+    #else
+    static let isDevelopment = false
+    static let enableDebugLogging = false
+    static let enableMockData = false
+    #endif
+
+    // MARK: - Feature Flags
+
+    static let enableBackgroundSync = true
+    static let enablePushNotifications = true
+    static let enableBLEProximity = true
+    static let enableOfflineMode = true
+
+    // MARK: - Version Information
+
+    static var appVersion: String {
+        return infoDictionary["CFBundleShortVersionString"] as? String ?? "1.0.0"
+    }
+
+    static var buildNumber: String {
+        return infoDictionary["CFBundleVersion"] as? String ?? "1"
+    }
+
+    static var bundleIdentifier: String {
+        return Bundle.main.bundleIdentifier ?? "tech.berty"
+    }
+}
+
+// MARK: - Configuration Validation
+
+extension BertyConfiguration {
+
+    static func validate() throws {
+        // Ensure required directories exist
+        if let bertyDir = bertyDataDirectory {
+            try FileManager.default.createDirectory(at: bertyDir, withIntermediateDirectories: true, attributes: nil)
+        }
+
+        // Validate keychain access
+        guard !keychainAccessGroup.isEmpty else {
+            throw BertyError.configurationError(.configurationMissing, message: "Keychain access group not configured")
+        }
+
+        // Validate app group
+        guard FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: appGroupIdentifier) != nil else {
+            throw BertyError.configurationError(.configurationInvalid, message: "App group not properly configured")
+        }
+    }
+}
+
+// MARK: - UserDefaults Extension
+
+extension UserDefaults {
+
+    static var berty: UserDefaults? {
+        return UserDefaults(suiteName: BertyConfiguration.appGroupIdentifier)
+    }
+}

--- a/js/ios/Berty/Sources/Bridge/BertyDriverBridges.swift
+++ b/js/ios/Berty/Sources/Bridge/BertyDriverBridges.swift
@@ -1,0 +1,159 @@
+import Foundation
+import Bertybridge
+
+// MARK: - Proximity/BLE Driver Bridge
+// This is the main new functionality - bridges BLE driver to Go's proximity transport
+
+@objc(BertyProximityDriverBridge)
+public class BertyProximityDriverBridge: NSObject, BertybridgeProximityDriverProtocol {
+    private let bleDriver = BertyBLEDriver.shared
+    private let logger = BertyLogger("tech.berty.proximity.bridge")
+    private var transport: (any BertybridgeProximityTransportProtocol)?
+    private var localPeerID: String?
+
+    @objc public func closeConn(withPeer remotePID: String?) {
+        guard let remotePID = remotePID else { return }
+        bleDriver.disconnectByRemotePID(remotePID)
+    }
+
+    @objc public func defaultAddr() -> String {
+        // Must return a valid multiaddr format matching Go's ble.DefaultAddr constant
+        return "/ble/Qmeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
+    }
+
+    @objc public func dialPeer(_ remotePID: String?) -> Bool {
+        // Match Android behavior: dialPeer returns true if the peer is already connected
+        // It does NOT initiate new connections - those happen through discovery
+        guard let remotePID = remotePID else { return false }
+        return bleDriver.isPeerConnected(remotePID)
+    }
+
+    @objc public func protocolCode() -> Int {
+        return 0x0042 // BLE protocol code - matches Android
+    }
+
+    @objc public func protocolName() -> String {
+        return "ble"
+    }
+
+    @objc public func send(toPeer remotePID: String?, payload: Data?) -> Bool {
+        guard let remotePID = remotePID,
+              let payload = payload else { return false }
+
+        do {
+            try bleDriver.sendDataToPeer(payload, remotePID: remotePID)
+            return true
+        } catch {
+            logger.error("Failed to send to peer \(remotePID): \(error)")
+            return false
+        }
+    }
+
+    @objc public func start(_ localPID: String?) {
+        guard let localPID = localPID else {
+            logger.error("Cannot start BLE driver without local PID")
+            return
+        }
+
+        // Get the proximity transport from Go (matching Android behavior)
+        // This MUST be done in start() - Go doesn't call registerTransport()
+        self.transport = BertybridgeGetProximityTransport("ble")
+
+        self.localPeerID = localPID
+        bleDriver.setLocalPID(localPID)
+        bleDriver.delegate = self
+
+        do {
+            try bleDriver.startAdvertising()
+            try bleDriver.startScanning()
+            logger.info("BLE proximity driver started")
+        } catch {
+            logger.error("Failed to start BLE driver: \(error)")
+        }
+    }
+
+    @objc public func stop() {
+        bleDriver.stopAdvertising()
+        bleDriver.stopScanning()
+        bleDriver.delegate = nil
+        logger.info("BLE proximity driver stopped")
+    }
+
+    @objc public func registerTransport(_ transport: BertybridgeProximityTransport?) {
+        self.transport = transport
+    }
+}
+
+// MARK: - BLE Driver Delegate
+
+extension BertyProximityDriverBridge: BertyBLEDriverDelegate {
+    func bleDriver(_ driver: BertyBLEDriver, didDiscoverPeer peer: BertyBLEPeer) {
+        _ = transport?.handleFoundPeer(peer.id)
+    }
+
+    func bleDriver(_ driver: BertyBLEDriver, didConnectToPeer peerId: String) {
+        // Only call handleFoundPeer if peerId is a valid Berty PID format
+        let isValidBertyPID = peerId.hasPrefix("12D3KooW") || peerId.hasPrefix("Qm")
+        if isValidBertyPID {
+            _ = transport?.handleFoundPeer(peerId)
+        }
+    }
+
+    func bleDriver(_ driver: BertyBLEDriver, didDisconnectFromPeer peerId: String, error: Error?) {
+        transport?.handleLostPeer(peerId)
+    }
+
+    func bleDriver(_ driver: BertyBLEDriver, didReceiveData data: Data, fromPeer peerId: String) {
+        transport?.receive(fromPeer: peerId, payload: data)
+    }
+
+    func bleDriver(_ driver: BertyBLEDriver, didFailWithError error: BertyError) {
+        transport?.log(3, message: error.localizedDescription)
+    }
+}
+
+// MARK: - MDNS Locker Driver Bridge
+
+@objc(BertyMDNSLockerDriverBridge)
+public class BertyMDNSLockerDriverBridge: NSObject, BertybridgeNativeMDNSLockerDriverProtocol {
+    private let mdnsLock = NSLock()
+
+    @objc public func lock() {
+        mdnsLock.lock()
+    }
+
+    @objc public func unlock() {
+        mdnsLock.unlock()
+    }
+}
+
+// MARK: - Background Task Implementation
+
+class BertyBackgroundTask: NSObject, BertybridgeLifeCycleBackgroundTaskProtocol {
+    private var taskIdentifier: String = ""
+    private var isCompleted = false
+    private var completion: () -> Void = {}
+
+    convenience init(taskIdentifier: String, completion: @escaping () -> Void) {
+        self.init()
+        self.taskIdentifier = taskIdentifier
+        self.completion = completion
+    }
+
+    @objc func cancel() {
+        if !isCompleted {
+            isCompleted = true
+            completion()
+        }
+    }
+
+    @objc func execute() -> Bool {
+        // Perform background task
+        // For now, just return true to indicate success
+        if !isCompleted {
+            isCompleted = true
+            completion()
+        }
+        return true
+    }
+}

--- a/js/ios/Berty/Sources/Bridge/BertyErrors.swift
+++ b/js/ios/Berty/Sources/Bridge/BertyErrors.swift
@@ -1,0 +1,376 @@
+import Foundation
+
+// MARK: - Berty Error Categories
+enum BertyErrorCategory {
+    case network
+    case bluetooth
+    case keystore
+    case bridge
+    case storage
+    case protocolError
+    case permission
+    case configuration
+    case connectivity
+    case unknown
+}
+
+// MARK: - Berty Error Recovery Strategy
+enum BertyRecoveryStrategy {
+    case retry
+    case reinitialize
+    case reconnect
+    case resetConfiguration
+    case requestPermission
+    case none
+}
+
+// MARK: - Berty Error Codes
+enum BertyErrorCode: String {
+    // Network Errors
+    case networkUnavailable = "NETWORK_UNAVAILABLE"
+    case networkTimeout = "NETWORK_TIMEOUT"
+    case networkConnectionFailed = "NETWORK_CONNECTION_FAILED"
+    case mdnsDiscoveryFailed = "MDNS_DISCOVERY_FAILED"
+
+    // Bluetooth Errors
+    case bluetoothUnavailable = "BLUETOOTH_UNAVAILABLE"
+    case bluetoothPermissionDenied = "BLUETOOTH_PERMISSION_DENIED"
+    case bluetoothPowerOff = "BLUETOOTH_POWER_OFF"
+    case bleAdvertisingFailed = "BLE_ADVERTISING_FAILED"
+    case bleScanningFailed = "BLE_SCANNING_FAILED"
+    case bleConnectionFailed = "BLE_CONNECTION_FAILED"
+
+    // Keystore Errors
+    case keystoreUnavailable = "KEYSTORE_UNAVAILABLE"
+    case keystoreAccessDenied = "KEYSTORE_ACCESS_DENIED"
+    case keystoreKeyNotFound = "KEYSTORE_KEY_NOT_FOUND"
+    case keystoreEncryptionFailed = "KEYSTORE_ENCRYPTION_FAILED"
+    case keystoreDecryptionFailed = "KEYSTORE_DECRYPTION_FAILED"
+
+    // Bridge Errors
+    case bridgeNotInitialized = "BRIDGE_NOT_INITIALIZED"
+    case bridgeAlreadyInitialized = "BRIDGE_ALREADY_INITIALIZED"
+    case bridgeInitializationFailed = "BRIDGE_INITIALIZATION_FAILED"
+    case bridgeConnectionLost = "BRIDGE_CONNECTION_LOST"
+    case bridgeInvalidOperation = "BRIDGE_INVALID_OPERATION"
+    case bridgeProtocolError = "BRIDGE_PROTOCOL_ERROR"
+    case bridgeMethodInvocationFailed = "BRIDGE_METHOD_INVOCATION_FAILED"
+    case bridgeStreamCreationFailed = "BRIDGE_STREAM_CREATION_FAILED"
+    case bridgeStreamTimeout = "BRIDGE_STREAM_TIMEOUT"
+    case bridgePromiseTimeout = "BRIDGE_PROMISE_TIMEOUT"
+    case bridgeDirectoryError = "BRIDGE_DIRECTORY_ERROR"
+
+    // Storage Errors
+    case storageAccessDenied = "STORAGE_ACCESS_DENIED"
+    case storageInsufficientSpace = "STORAGE_INSUFFICIENT_SPACE"
+    case storageCorrupted = "STORAGE_CORRUPTED"
+    case storageWriteError = "STORAGE_WRITE_ERROR"
+    case storageReadError = "STORAGE_READ_ERROR"
+
+    // Protocol Errors
+    case protocolVersionMismatch = "PROTOCOL_VERSION_MISMATCH"
+    case protocolInvalidMessage = "PROTOCOL_INVALID_MESSAGE"
+    case protocolEncryptionFailed = "PROTOCOL_ENCRYPTION_FAILED"
+    case protocolDecryptionFailed = "PROTOCOL_DECRYPTION_FAILED"
+    case protocolGroupNotFound = "PROTOCOL_GROUP_NOT_FOUND"
+    case protocolMemberNotFound = "PROTOCOL_MEMBER_NOT_FOUND"
+
+    // Permission Errors
+    case locationPermissionDenied = "LOCATION_PERMISSION_DENIED"
+    case backgroundPermissionDenied = "BACKGROUND_PERMISSION_DENIED"
+    case notificationPermissionDenied = "NOTIFICATION_PERMISSION_DENIED"
+    case localNetworkPermissionDenied = "LOCAL_NETWORK_PERMISSION_DENIED"
+
+    // Configuration Errors
+    case configurationInvalid = "CONFIGURATION_INVALID"
+    case configurationMissing = "CONFIGURATION_MISSING"
+    case configurationCorrupted = "CONFIGURATION_CORRUPTED"
+
+    // Connectivity Errors
+    case peerDiscoveryFailed = "PEER_DISCOVERY_FAILED"
+    case peerConnectionTimeout = "PEER_CONNECTION_TIMEOUT"
+    case peerAuthenticationFailed = "PEER_AUTHENTICATION_FAILED"
+
+    // Unknown Errors
+    case unknown = "UNKNOWN_ERROR"
+}
+
+// MARK: - Berty Error
+class BertyError: NSError, @unchecked Sendable {
+    let bertyCode: BertyErrorCode
+    let category: BertyErrorCategory
+    let recoveryStrategy: BertyRecoveryStrategy
+    let isRecoverable: Bool
+    let retryCount: Int
+    let maxRetries: Int
+
+    init(
+        code: BertyErrorCode,
+        message: String,
+        category: BertyErrorCategory = .unknown,
+        recoveryStrategy: BertyRecoveryStrategy = .none,
+        isRecoverable: Bool = false,
+        retryCount: Int = 0,
+        maxRetries: Int = 3,
+        underlyingError: Error? = nil
+    ) {
+        self.bertyCode = code
+        self.category = category
+        self.recoveryStrategy = recoveryStrategy
+        self.isRecoverable = isRecoverable
+        self.retryCount = retryCount
+        self.maxRetries = maxRetries
+
+        var userInfo: [String: Any] = [
+            NSLocalizedDescriptionKey: message,
+            "BertyErrorCode": code.rawValue,
+            "BertyCategory": String(describing: category),
+            "RecoveryStrategy": String(describing: recoveryStrategy),
+            "IsRecoverable": isRecoverable,
+            "RetryCount": retryCount,
+            "MaxRetries": maxRetries
+        ]
+
+        if let underlyingError = underlyingError {
+            userInfo[NSUnderlyingErrorKey] = underlyingError
+        }
+
+        super.init(domain: "BertyErrorDomain", code: 0, userInfo: userInfo)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    // MARK: - Error Factory Methods
+
+    static func networkError(_ code: BertyErrorCode, message: String, underlyingError: Error? = nil) -> BertyError {
+        return BertyError(
+            code: code,
+            message: message,
+            category: .network,
+            recoveryStrategy: .reconnect,
+            isRecoverable: true,
+            underlyingError: underlyingError
+        )
+    }
+
+    static func bluetoothError(_ code: BertyErrorCode, message: String, underlyingError: Error? = nil) -> BertyError {
+        let recoverable = code != .bluetoothPermissionDenied && code != .bluetoothUnavailable
+        let strategy: BertyRecoveryStrategy = code == .bluetoothPermissionDenied ? .requestPermission : .retry
+
+        return BertyError(
+            code: code,
+            message: message,
+            category: .bluetooth,
+            recoveryStrategy: strategy,
+            isRecoverable: recoverable,
+            underlyingError: underlyingError
+        )
+    }
+
+    static func keystoreError(_ code: BertyErrorCode, message: String, underlyingError: Error? = nil) -> BertyError {
+        let recoverable = code != .keystoreUnavailable && code != .keystoreAccessDenied
+        let strategy: BertyRecoveryStrategy = code == .keystoreAccessDenied ? .requestPermission : .retry
+
+        return BertyError(
+            code: code,
+            message: message,
+            category: .keystore,
+            recoveryStrategy: strategy,
+            isRecoverable: recoverable,
+            underlyingError: underlyingError
+        )
+    }
+
+    static func bridgeError(_ code: BertyErrorCode, message: String, underlyingError: Error? = nil) -> BertyError {
+        let strategy: BertyRecoveryStrategy = code == .bridgeNotInitialized ? .reinitialize : .retry
+
+        return BertyError(
+            code: code,
+            message: message,
+            category: .bridge,
+            recoveryStrategy: strategy,
+            isRecoverable: true,
+            underlyingError: underlyingError
+        )
+    }
+
+    static func storageError(_ code: BertyErrorCode, message: String, underlyingError: Error? = nil) -> BertyError {
+        let recoverable = code != .storageAccessDenied && code != .storageInsufficientSpace
+
+        return BertyError(
+            code: code,
+            message: message,
+            category: .storage,
+            recoveryStrategy: .retry,
+            isRecoverable: recoverable,
+            underlyingError: underlyingError
+        )
+    }
+
+    static func protocolError(_ code: BertyErrorCode, message: String, underlyingError: Error? = nil) -> BertyError {
+        let recoverable = code != .protocolVersionMismatch
+
+        return BertyError(
+            code: code,
+            message: message,
+            category: .protocolError,
+            recoveryStrategy: .retry,
+            isRecoverable: recoverable,
+            underlyingError: underlyingError
+        )
+    }
+
+    static func permissionError(_ code: BertyErrorCode, message: String, underlyingError: Error? = nil) -> BertyError {
+        return BertyError(
+            code: code,
+            message: message,
+            category: .permission,
+            recoveryStrategy: .requestPermission,
+            isRecoverable: false,
+            underlyingError: underlyingError
+        )
+    }
+
+    static func configurationError(_ code: BertyErrorCode, message: String, underlyingError: Error? = nil) -> BertyError {
+        return BertyError(
+            code: code,
+            message: message,
+            category: .configuration,
+            recoveryStrategy: .resetConfiguration,
+            isRecoverable: true,
+            underlyingError: underlyingError
+        )
+    }
+
+    static func connectivityError(_ code: BertyErrorCode, message: String, underlyingError: Error? = nil) -> BertyError {
+        return BertyError(
+            code: code,
+            message: message,
+            category: .connectivity,
+            recoveryStrategy: .reconnect,
+            isRecoverable: true,
+            underlyingError: underlyingError
+        )
+    }
+
+    // MARK: - Recovery Methods
+
+    func canRetry() -> Bool {
+        return isRecoverable && retryCount < maxRetries
+    }
+
+    func withIncrementedRetry() -> BertyError {
+        return BertyError(
+            code: bertyCode,
+            message: localizedDescription,
+            category: category,
+            recoveryStrategy: recoveryStrategy,
+            isRecoverable: isRecoverable,
+            retryCount: retryCount + 1,
+            maxRetries: maxRetries,
+            underlyingError: userInfo[NSUnderlyingErrorKey] as? Error
+        )
+    }
+
+    // MARK: - User-Friendly Messages
+
+    var userFriendlyMessage: String {
+        switch bertyCode {
+        case .networkUnavailable:
+            return "No internet connection available. Please check your network settings."
+        case .bluetoothUnavailable:
+            return "Bluetooth is not available on this device."
+        case .bluetoothPermissionDenied:
+            return "Bluetooth access is required for offline messaging. Please enable Bluetooth permissions in Settings."
+        case .bluetoothPowerOff:
+            return "Please turn on Bluetooth to enable offline messaging."
+        case .locationPermissionDenied:
+            return "Location access is required for peer discovery. Please enable location permissions in Settings."
+        case .backgroundPermissionDenied:
+            return "Background app refresh is required for message notifications. Please enable it in Settings."
+        case .storageInsufficientSpace:
+            return "Not enough storage space available. Please free up some space and try again."
+        case .bridgeInitializationFailed:
+            return "Failed to initialize secure messaging. Please restart the app."
+        case .protocolVersionMismatch:
+            return "App version is incompatible with current protocol. Please update the app."
+        default:
+            return localizedDescription
+        }
+    }
+}
+
+// MARK: - Error Handler
+class BertyErrorHandler {
+    static let shared = BertyErrorHandler()
+
+    private let logger = BertyLogger("tech.berty.error")
+    private var errorCount: [String: Int] = [:]
+    private let maxRetries = 3
+
+    func handle(_ error: BertyError, recovery: BertyErrorRecoverable? = nil) {
+        logger.error("Handling error: \(error.localizedDescription)")
+        logger.error("Error code: \(error.bertyCode.rawValue)")
+
+        // Track error count
+        let errorKey = error.bertyCode.rawValue
+        errorCount[errorKey] = (errorCount[errorKey] ?? 0) + 1
+
+        // Check if we should attempt recovery
+        if let recovery = recovery,
+           recovery.canRecover(from: error),
+           (errorCount[errorKey] ?? 0) <= maxRetries {
+
+            logger.info("Attempting recovery for error: \(errorKey)")
+            recovery.recover(from: error) { [weak self] success in
+                if success {
+                    self?.logger.info("Recovery successful for error: \(errorKey)")
+                    self?.errorCount[errorKey] = 0
+                } else {
+                    self?.logger.error("Recovery failed for error: \(errorKey)")
+                }
+            }
+        } else if (errorCount[errorKey] ?? 0) > maxRetries {
+            logger.error("Max retries exceeded for error: \(errorKey)")
+        }
+    }
+
+    func reset() {
+        errorCount.removeAll()
+    }
+}
+
+// MARK: - Error Recovery Protocol
+protocol BertyErrorRecoverable {
+    func canRecover(from error: BertyError) -> Bool
+    func recover(from error: BertyError, completion: @escaping (Bool) -> Void)
+}
+
+// MARK: - Error Recovery Manager
+class BertyErrorRecoveryManager {
+    static let shared = BertyErrorRecoveryManager()
+    private var recoveryAttempts: [String: Int] = [:]
+
+    private init() {}
+
+    func shouldAttemptRecovery(for error: BertyError) -> Bool {
+        let key = error.bertyCode.rawValue
+        let attempts = recoveryAttempts[key] ?? 0
+        return error.isRecoverable && attempts < error.maxRetries
+    }
+
+    func recordRecoveryAttempt(for error: BertyError) {
+        let key = error.bertyCode.rawValue
+        recoveryAttempts[key] = (recoveryAttempts[key] ?? 0) + 1
+    }
+
+    func resetRecoveryAttempts(for errorCode: BertyErrorCode) {
+        recoveryAttempts.removeValue(forKey: errorCode.rawValue)
+    }
+
+    func clearAllRecoveryAttempts() {
+        recoveryAttempts.removeAll()
+    }
+}

--- a/js/ios/Berty/Sources/Bridge/BertyLogger.swift
+++ b/js/ios/Berty/Sources/Bridge/BertyLogger.swift
@@ -9,12 +9,12 @@ import os
 import Bertybridge
 
 public class BertyLogger {
-    public enum LogLevel: String {
+    public enum LogLevel: String, Comparable {
         case DEBUG
         case INFO
         case WARN
         case ERROR
-      
+
         var levelString: String {
             return self.rawValue
         }
@@ -44,28 +44,70 @@ public class BertyLogger {
                 return .info
             }
         }
+
+        // For comparison - higher value = more severe
+        var severity: Int {
+            switch self {
+            case .DEBUG: return 0
+            case .INFO: return 1
+            case .WARN: return 2
+            case .ERROR: return 3
+            }
+        }
+
+        public static func < (lhs: LogLevel, rhs: LogLevel) -> Bool {
+            return lhs.severity < rhs.severity
+        }
     }
 
-    private static var bridge: BertybridgeBridge? = nil;
+    // MARK: - Static Configuration
+
+    /// Debug mode - defaults to false (production-safe)
+    private static var debugMode: Bool = false
+
+    /// Minimum log level for production (only warnings and errors)
+    private static let productionMinLevel: LogLevel = .WARN
+
+    private static var bridge: BertybridgeBridge? = nil
+
+    var subsystem: String
+
+    // MARK: - Initialization
+
+    /**
+     * Initialize debug mode based on build configuration.
+     * Call this during app initialization before any Berty code runs.
+     */
+    public static func initializeDebugMode(_ isDebug: Bool) {
+        debugMode = isDebug
+        let log = OSLog(subsystem: "BertyLogger", category: "init")
+        os_log("BertyLogger initialized: debugMode=%{public}@", log: log, type: .info,
+               isDebug ? "true" : "false")
+    }
 
     public static func useBridge(_ bridge: BertybridgeBridge?) {
         BertyLogger.bridge = bridge
     }
 
-    var subsytem: String
-    public init(_ subsytem: String = "logger") {
-        self.subsytem = subsytem
+    public init(_ subsystem: String = "logger") {
+        self.subsystem = subsystem
     }
 
-    public func log(_ level: LogLevel, _ message: String) {
-        if (BertyLogger.bridge == nil) {
-            let log = OSLog(subsystem: self.subsytem, category: self.subsytem)
+    // MARK: - Logging
 
-            os_log("[%{public}s] %{public}s", log: log, type: level.levelNative,
-                level.levelString, message)
+    public func log(_ level: LogLevel, _ message: String) {
+        // In production builds, only log warnings and errors to prevent log flooding
+        if !BertyLogger.debugMode && level < BertyLogger.productionMinLevel {
             return
         }
-      BertyLogger.bridge!.log(level.levelGo, subsystem: self.subsytem, message: message)
+
+        if let bridge = BertyLogger.bridge {
+            bridge.log(level.levelGo, subsystem: self.subsystem, message: message)
+        } else {
+            let log = OSLog(subsystem: self.subsystem, category: self.subsystem)
+            os_log("[%{public}s] %{public}s", log: log, type: level.levelNative,
+                   level.levelString, message)
+        }
     }
 
     public func debug(_ message: String) {

--- a/js/ios/Berty/Sources/Bridge/BertyNetworkDriver.swift
+++ b/js/ios/Berty/Sources/Bridge/BertyNetworkDriver.swift
@@ -1,0 +1,391 @@
+import Foundation
+import Network
+
+// MARK: - Network Interface Protocol
+protocol BertyNetworkDriverProtocol {
+    func getAvailableInterfaces() -> [BertyNetworkInterface]
+    func startNetworkMonitoring()
+    func stopNetworkMonitoring()
+    func isNetworkAvailable() -> Bool
+    func getCurrentConnectionType() -> BertyConnectionType
+    func getMDNSCapability() -> Bool
+}
+
+// MARK: - Network Interface Model
+struct BertyNetworkInterface {
+    let name: String
+    let displayName: String
+    let type: BertyInterfaceType
+    let isActive: Bool
+    let ipv4Address: String?
+    let ipv6Address: String?
+    let mtu: Int
+    let supportsMDNS: Bool
+}
+
+// MARK: - Network Types
+enum BertyInterfaceType {
+    case wifi
+    case cellular
+    case ethernet
+    case loopback
+    case other
+}
+
+enum BertyConnectionType {
+    case none
+    case wifi
+    case cellular
+    case ethernet
+    case unknown
+}
+
+// MARK: - Network Driver
+class BertyNetworkDriver: NSObject, BertyNetworkDriverProtocol {
+    static let shared = BertyNetworkDriver()
+
+    private var networkMonitor: NWPathMonitor?
+    private var monitorQueue: DispatchQueue
+    private var currentPath: NWPath?
+    private var networkStatusCallback: ((BertyConnectionType, Bool) -> Void)?
+
+    private var interfaces: [BertyNetworkInterface] = []
+    private var isMonitoring = false
+
+    override init() {
+        self.monitorQueue = DispatchQueue(label: "BertyNetworkMonitor", qos: .utility)
+        super.init()
+        updateNetworkInterfaces()
+    }
+
+    deinit {
+        stopNetworkMonitoring()
+    }
+
+    // MARK: - Public Interface
+
+    func getAvailableInterfaces() -> [BertyNetworkInterface] {
+        updateNetworkInterfaces()
+        return interfaces
+    }
+
+    func startNetworkMonitoring() {
+        guard !isMonitoring else { return }
+
+        networkMonitor = NWPathMonitor()
+        networkMonitor?.pathUpdateHandler = { [weak self] path in
+            self?.handleNetworkPathUpdate(path)
+        }
+        networkMonitor?.start(queue: monitorQueue)
+        isMonitoring = true
+
+        print("BertyNetworkDriver: Started network monitoring")
+    }
+
+    func stopNetworkMonitoring() {
+        networkMonitor?.cancel()
+        networkMonitor = nil
+        isMonitoring = false
+
+        print("BertyNetworkDriver: Stopped network monitoring")
+    }
+
+    func isNetworkAvailable() -> Bool {
+        return currentPath?.status == .satisfied
+    }
+
+    func getCurrentConnectionType() -> BertyConnectionType {
+        guard let path = currentPath, path.status == .satisfied else {
+            return .none
+        }
+
+        if path.usesInterfaceType(.wifi) {
+            return .wifi
+        } else if path.usesInterfaceType(.cellular) {
+            return .cellular
+        } else if path.usesInterfaceType(.wiredEthernet) {
+            return .ethernet
+        } else {
+            return .unknown
+        }
+    }
+
+    func getMDNSCapability() -> Bool {
+        // MDNS is generally available on iOS except in some restricted network environments
+        let connectionType = getCurrentConnectionType()
+
+        switch connectionType {
+        case .wifi, .ethernet:
+            return true
+        case .cellular:
+            // Cellular networks typically don't support mDNS properly
+            return false
+        case .none, .unknown:
+            return false
+        }
+    }
+
+    // MARK: - Network Path Handling
+
+    private func handleNetworkPathUpdate(_ path: NWPath) {
+        currentPath = path
+        updateNetworkInterfaces()
+
+        let connectionType = getCurrentConnectionType()
+        let isAvailable = path.status == .satisfied
+
+        print("BertyNetworkDriver: Network changed - Type: \(connectionType), Available: \(isAvailable)")
+
+        // Notify callback if set
+        DispatchQueue.main.async { [weak self] in
+            self?.networkStatusCallback?(connectionType, isAvailable)
+        }
+    }
+
+    // MARK: - Interface Discovery
+
+    private func updateNetworkInterfaces() {
+        var newInterfaces: [BertyNetworkInterface] = []
+
+        // Get system network interfaces
+        var ifaddrs: UnsafeMutablePointer<ifaddrs>?
+
+        guard getifaddrs(&ifaddrs) == 0 else {
+            print("BertyNetworkDriver: Failed to get network interfaces")
+            return
+        }
+
+        defer {
+            freeifaddrs(ifaddrs)
+        }
+
+        var currentInterface = ifaddrs
+        while currentInterface != nil {
+            defer {
+                currentInterface = currentInterface?.pointee.ifa_next
+            }
+
+            guard let interface = currentInterface?.pointee else { continue }
+
+            let name = String(cString: interface.ifa_name)
+            let flags = interface.ifa_flags
+
+            // Skip if interface is not up
+            guard (flags & UInt32(IFF_UP)) != 0 else { continue }
+
+            let interfaceType = determineInterfaceType(name: name)
+            let isActive = (flags & UInt32(IFF_RUNNING)) != 0
+
+            var ipv4Address: String?
+            var ipv6Address: String?
+            var mtu = 0
+
+            // Get IP addresses
+            if let addr = interface.ifa_addr {
+                switch addr.pointee.sa_family {
+                case UInt8(AF_INET):
+                    var hostname = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+                    if getnameinfo(addr, socklen_t(addr.pointee.sa_len),
+                                   &hostname, socklen_t(hostname.count),
+                                   nil, 0, NI_NUMERICHOST) == 0 {
+                        ipv4Address = String(cString: hostname)
+                    }
+                case UInt8(AF_INET6):
+                    var hostname = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+                    if getnameinfo(addr, socklen_t(addr.pointee.sa_len),
+                                   &hostname, socklen_t(hostname.count),
+                                   nil, 0, NI_NUMERICHOST) == 0 {
+                        ipv6Address = String(cString: hostname)
+                    }
+                default:
+                    break
+                }
+            }
+
+            // Get MTU (simplified - would need additional system calls for accurate MTU)
+            mtu = getMTUForInterface(name: name)
+
+            let networkInterface = BertyNetworkInterface(
+                name: name,
+                displayName: getDisplayName(for: name),
+                type: interfaceType,
+                isActive: isActive,
+                ipv4Address: ipv4Address,
+                ipv6Address: ipv6Address,
+                mtu: mtu,
+                supportsMDNS: supportsMDNS(interfaceType: interfaceType, name: name)
+            )
+
+            newInterfaces.append(networkInterface)
+        }
+
+        interfaces = newInterfaces
+    }
+
+    private func determineInterfaceType(name: String) -> BertyInterfaceType {
+        switch name {
+        case let n where n.hasPrefix("en"):
+            // en0 is typically WiFi, en1+ can be ethernet
+            return name == "en0" ? .wifi : .ethernet
+        case let n where n.hasPrefix("pdp_ip"):
+            return .cellular
+        case let n where n.hasPrefix("lo"):
+            return .loopback
+        case let n where n.hasPrefix("utun") || n.hasPrefix("ipsec"):
+            return .other // VPN interfaces
+        default:
+            return .other
+        }
+    }
+
+    private func getDisplayName(for interfaceName: String) -> String {
+        switch interfaceName {
+        case "en0":
+            return "Wi-Fi"
+        case "lo0":
+            return "Loopback"
+        case let name where name.hasPrefix("pdp_ip"):
+            return "Cellular"
+        case let name where name.hasPrefix("en"):
+            return "Ethernet"
+        case let name where name.hasPrefix("utun"):
+            return "VPN"
+        default:
+            return interfaceName.capitalized
+        }
+    }
+
+    private func getMTUForInterface(name: String) -> Int {
+        // Simplified MTU detection - in a full implementation,
+        // you'd use ioctl with SIOCGIFMTU to get actual MTU
+        switch name {
+        case let n where n.hasPrefix("en"):
+            return 1500 // Standard Ethernet MTU
+        case let n where n.hasPrefix("lo"):
+            return 16384 // Loopback typically has larger MTU
+        case let n where n.hasPrefix("pdp_ip"):
+            return 1280 // Conservative cellular MTU
+        default:
+            return 1500
+        }
+    }
+
+    private func supportsMDNS(interfaceType: BertyInterfaceType, name: String) -> Bool {
+        switch interfaceType {
+        case .wifi, .ethernet:
+            return true
+        case .cellular:
+            return false // Cellular networks typically don't support mDNS
+        case .loopback:
+            return true
+        case .other:
+            return name.hasPrefix("utun") ? false : true // VPN might not support mDNS
+        }
+    }
+
+    // MARK: - Network Quality Assessment
+
+    func getNetworkQuality() -> BertyNetworkQuality {
+        guard let path = currentPath, path.status == .satisfied else {
+            return .none
+        }
+
+        // Basic quality assessment based on interface type
+        if path.usesInterfaceType(.wifi) {
+            return .good
+        } else if path.usesInterfaceType(.wiredEthernet) {
+            return .excellent
+        } else if path.usesInterfaceType(.cellular) {
+            return .fair // Could be enhanced with signal strength detection
+        } else {
+            return .poor
+        }
+    }
+
+    // MARK: - Callback Registration
+
+    func setNetworkStatusCallback(_ callback: @escaping (BertyConnectionType, Bool) -> Void) {
+        networkStatusCallback = callback
+    }
+
+    // MARK: - P2P Network Support
+
+    func canSupportP2PConnections() -> Bool {
+        let connectionType = getCurrentConnectionType()
+
+        switch connectionType {
+        case .wifi:
+            return true // WiFi typically allows P2P
+        case .ethernet:
+            return true // Ethernet allows P2P
+        case .cellular:
+            return false // Cellular networks typically use NAT
+        case .none, .unknown:
+            return false
+        }
+    }
+
+    func getLocalNetworkAddresses() -> [String] {
+        return interfaces.compactMap { interface in
+            guard interface.isActive && interface.type != .loopback else { return nil }
+            return interface.ipv4Address
+        }.compactMap { $0 }
+    }
+
+    // MARK: - Debug Information
+
+    func getNetworkDebugInfo() -> [String: Any] {
+        var info: [String: Any] = [:]
+
+        info["isMonitoring"] = isMonitoring
+        info["isNetworkAvailable"] = isNetworkAvailable()
+        info["connectionType"] = String(describing: getCurrentConnectionType())
+        info["networkQuality"] = String(describing: getNetworkQuality())
+        info["mdnsCapable"] = getMDNSCapability()
+        info["p2pCapable"] = canSupportP2PConnections()
+
+        let interfaceInfo = interfaces.map { interface in
+            [
+                "name": interface.name,
+                "displayName": interface.displayName,
+                "type": String(describing: interface.type),
+                "isActive": interface.isActive,
+                "ipv4": interface.ipv4Address ?? "none",
+                "ipv6": interface.ipv6Address ?? "none",
+                "mtu": interface.mtu,
+                "supportsMDNS": interface.supportsMDNS
+            ]
+        }
+        info["interfaces"] = interfaceInfo
+
+        return info
+    }
+}
+
+// MARK: - Network Quality Enum
+enum BertyNetworkQuality {
+    case none
+    case poor
+    case fair
+    case good
+    case excellent
+}
+
+// MARK: - Berty Native Net Driver Bridge
+// This class implements the BertybridgeNativeNetDriver protocol from the framework
+@objc class BertyNativeNetDriverBridge: NSObject {
+    private let driver = BertyNetworkDriver.shared
+
+    @objc func updateAddr(_ addrs: [String]) {
+        // Implementation would update network addresses for the bridge
+        print("BertyNativeNetDriverBridge: updateAddr called with \(addrs)")
+    }
+
+    @objc func getInterfaceAddrs() -> [String] {
+        return driver.getLocalNetworkAddresses()
+    }
+
+    @objc func isConnected() -> Bool {
+        return driver.isNetworkAvailable()
+    }
+}

--- a/js/ios/Berty/Sources/Bridge/BertyProximityManager.swift
+++ b/js/ios/Berty/Sources/Bridge/BertyProximityManager.swift
@@ -1,0 +1,856 @@
+import Foundation
+import CoreBluetooth
+import Network
+import UIKit
+
+// MARK: - Connection Quality Enum
+enum BertyConnectionQuality {
+    case excellent
+    case good
+    case fair
+    case poor
+    case terrible
+}
+
+// MARK: - Proximity Manager Protocol
+protocol BertyProximityManagerProtocol {
+    func startDiscovery()
+    func stopDiscovery()
+    func startAdvertising()
+    func stopAdvertising()
+    func connectToPeer(_ peer: BertyProximityPeer) throws
+    func disconnectFromPeer(_ peerId: String)
+    func sendDataToPeer(_ data: Data, peerId: String) throws
+    func getDiscoveredPeers() -> [BertyProximityPeer]
+    func getConnectedPeers() -> [BertyProximityPeer]
+}
+
+// MARK: - Proximity Peer Model
+struct BertyProximityPeer {
+    let id: String
+    let name: String?
+    let deviceType: BertyDeviceType
+    let transport: BertyTransportType
+    let rssi: Int?
+    let lastSeen: Date
+    let isConnected: Bool
+    let connectionQuality: BertyConnectionQuality
+    let capabilities: Set<BertyPeerCapability>
+    let metadata: [String: Any]
+
+    init(
+        id: String,
+        name: String? = nil,
+        deviceType: BertyDeviceType = .unknown,
+        transport: BertyTransportType,
+        rssi: Int? = nil,
+        lastSeen: Date = Date(),
+        isConnected: Bool = false,
+        connectionQuality: BertyConnectionQuality = .poor,
+        capabilities: Set<BertyPeerCapability> = [],
+        metadata: [String: Any] = [:]
+    ) {
+        self.id = id
+        self.name = name
+        self.deviceType = deviceType
+        self.transport = transport
+        self.rssi = rssi
+        self.lastSeen = lastSeen
+        self.isConnected = isConnected
+        self.connectionQuality = connectionQuality
+        self.capabilities = capabilities
+        self.metadata = metadata
+    }
+}
+
+// MARK: - Supporting Types
+enum BertyDeviceType {
+    case phone
+    case tablet
+    case desktop
+    case unknown
+}
+
+enum BertyTransportType {
+    case bluetooth
+    case wifi
+    case cellular
+    case multicast
+    case relay
+}
+
+enum BertyPeerCapability {
+    case messaging
+    case fileTransfer
+    case voiceCall
+    case videoCall
+    case groupChat
+    case encryption
+    case relay
+}
+
+// MARK: - Proximity Manager Delegate
+protocol BertyProximityManagerDelegate: AnyObject {
+    func proximityManager(_ manager: BertyProximityManager, didDiscoverPeer peer: BertyProximityPeer)
+    func proximityManager(_ manager: BertyProximityManager, didLosePeer peerId: String)
+    func proximityManager(_ manager: BertyProximityManager, didConnectToPeer peer: BertyProximityPeer)
+    func proximityManager(_ manager: BertyProximityManager, didDisconnectFromPeer peerId: String, error: Error?)
+    func proximityManager(_ manager: BertyProximityManager, didReceiveData data: Data, fromPeer peerId: String)
+    func proximityManager(_ manager: BertyProximityManager, didFailWithError error: BertyError)
+}
+
+// MARK: - Proximity Manager
+class BertyProximityManager: NSObject, BertyProximityManagerProtocol {
+    static let shared = BertyProximityManager()
+
+    weak var delegate: BertyProximityManagerDelegate?
+
+    private let logger = BertyLogger("tech.berty.proximity")
+
+    // Transport drivers
+    private let bleDriver = BertyBLEDriver.shared
+    private let networkDriver = BertyNetworkDriver.shared
+
+    // State management
+    private var isDiscovering = false
+    private var isAdvertising = false
+
+    private let peersLock = NSLock()
+    private var _discoveredPeers: [String: BertyProximityPeer] = [:]
+    private var _connectedPeers: [String: BertyProximityPeer] = [:]
+
+    private var discoveredPeers: [String: BertyProximityPeer] {
+        get {
+            peersLock.lock()
+            defer { peersLock.unlock() }
+            return _discoveredPeers
+        }
+        set {
+            peersLock.lock()
+            defer { peersLock.unlock() }
+            _discoveredPeers = newValue
+        }
+    }
+
+    private var connectedPeers: [String: BertyProximityPeer] {
+        get {
+            peersLock.lock()
+            defer { peersLock.unlock() }
+            return _connectedPeers
+        }
+        set {
+            peersLock.lock()
+            defer { peersLock.unlock() }
+            _connectedPeers = newValue
+        }
+    }
+
+    // Discovery configuration
+    private var discoveryConfig = BertyDiscoveryConfig()
+    private let discoveryQueue = DispatchQueue(label: "BertyProximityDiscovery", qos: .userInitiated)
+
+    // Peer management - use DispatchWorkItem instead of Timer to avoid RunLoop requirements
+    private var peerTimeoutWork: [String: DispatchWorkItem] = [:]
+    private let peerTimeoutInterval: TimeInterval = 30.0
+
+    // Multicast discovery
+    private var multicastBrowser: NWBrowser?
+    private var multicastListener: NWListener?
+
+    override init() {
+        super.init()
+        setupTransportDrivers()
+    }
+
+    deinit {
+        stopDiscovery()
+        stopAdvertising()
+    }
+
+    // MARK: - Setup
+
+    private func setupTransportDrivers() {
+        // Setup BLE driver delegate
+        bleDriver.delegate = self
+
+        // Setup network status monitoring
+        networkDriver.setNetworkStatusCallback { [weak self] connectionType, isAvailable in
+            self?.handleNetworkStatusChange(connectionType: connectionType, isAvailable: isAvailable)
+        }
+    }
+
+    // MARK: - Discovery Management
+
+    func startDiscovery() {
+        guard !isDiscovering else { return }
+
+        logger.info(" Starting peer discovery")
+        isDiscovering = true
+
+        // Start BLE discovery
+        startBLEDiscovery()
+
+        // Start multicast discovery if on WiFi
+        if networkDriver.getCurrentConnectionType() == .wifi {
+            startMulticastDiscovery()
+        }
+
+        // Start peer timeout monitoring
+        startPeerTimeoutMonitoring()
+    }
+
+    func stopDiscovery() {
+        guard isDiscovering else { return }
+
+        logger.info(" Stopping peer discovery")
+        isDiscovering = false
+
+        // Stop all discovery mechanisms
+        stopBLEDiscovery()
+        stopMulticastDiscovery()
+        stopPeerTimeoutMonitoring()
+
+        // Clear discovered peers
+        discoveredPeers.removeAll()
+    }
+
+    func startAdvertising() {
+        guard !isAdvertising else { return }
+
+        logger.info(" Starting advertising")
+        isAdvertising = true
+
+        // Start BLE advertising
+        startBLEAdvertising()
+
+        // Start multicast advertising if on WiFi
+        if networkDriver.getCurrentConnectionType() == .wifi {
+            if #available(iOS 16.0, *) {
+                startMulticastAdvertising()
+            }
+        }
+    }
+
+    func stopAdvertising() {
+        guard isAdvertising else { return }
+
+        logger.info(" Stopping advertising")
+        isAdvertising = false
+
+        // Stop all advertising mechanisms
+        stopBLEAdvertising()
+        stopMulticastAdvertising()
+    }
+
+    // MARK: - BLE Discovery/Advertising
+
+    private func startBLEDiscovery() {
+        do {
+            try bleDriver.startScanning()
+            logger.info(" Started BLE discovery")
+        } catch {
+            logger.info(" Failed to start BLE discovery: \(error)")
+            delegate?.proximityManager(self, didFailWithError: BertyError.bluetoothError(
+                .bleScanningFailed,
+                message: "Failed to start BLE discovery",
+                underlyingError: error
+            ))
+        }
+    }
+
+    private func stopBLEDiscovery() {
+        bleDriver.stopScanning()
+        logger.info(" Stopped BLE discovery")
+    }
+
+    private func startBLEAdvertising() {
+        do {
+            try bleDriver.startAdvertising()
+            logger.info(" Started BLE advertising")
+        } catch {
+            logger.info(" Failed to start BLE advertising: \(error)")
+            delegate?.proximityManager(self, didFailWithError: BertyError.bluetoothError(
+                .bleAdvertisingFailed,
+                message: "Failed to start BLE advertising",
+                underlyingError: error
+            ))
+        }
+    }
+
+    private func stopBLEAdvertising() {
+        bleDriver.stopAdvertising()
+        logger.info(" Stopped BLE advertising")
+    }
+
+    // MARK: - Multicast Discovery/Advertising
+
+    @available(iOS 13.0, *)
+    private func startMulticastDiscovery() {
+        let parameters = NWParameters()
+        parameters.includePeerToPeer = true
+
+        let browserDescriptor = NWBrowser.Descriptor.bonjour(type: "_berty._tcp", domain: nil)
+        multicastBrowser = NWBrowser(for: browserDescriptor, using: parameters)
+
+        multicastBrowser?.stateUpdateHandler = { [weak self] state in
+            self?.handleMulticastBrowserStateChange(state)
+        }
+
+        multicastBrowser?.browseResultsChangedHandler = { [weak self] results, changes in
+            self?.handleMulticastBrowseResults(results, changes: changes)
+        }
+
+        multicastBrowser?.start(queue: discoveryQueue)
+        logger.info(" Started multicast discovery")
+    }
+
+    private func stopMulticastDiscovery() {
+        multicastBrowser?.cancel()
+        multicastBrowser = nil
+        logger.info(" Stopped multicast discovery")
+    }
+
+    @available(iOS 16.0, *)
+    private func startMulticastAdvertising() {
+        let parameters = NWParameters.tcp
+        parameters.includePeerToPeer = true
+
+        let service = NWListener.Service(name: "Berty-\(UIDevice.current.name)", type: "_berty._tcp")
+
+        do {
+            multicastListener = try NWListener(service: service, using: parameters)
+
+            multicastListener?.stateUpdateHandler = { [weak self] state in
+                self?.handleMulticastListenerStateChange(state)
+            }
+
+            multicastListener?.newConnectionHandler = { [weak self] connection in
+                self?.handleMulticastNewConnection(connection)
+            }
+
+            multicastListener?.start(queue: discoveryQueue)
+            logger.info(" Started multicast advertising")
+        } catch {
+            logger.info(" Failed to start multicast advertising: \(error)")
+        }
+    }
+
+    private func stopMulticastAdvertising() {
+        multicastListener?.cancel()
+        multicastListener = nil
+        logger.info(" Stopped multicast advertising")
+    }
+
+    // MARK: - Multicast Handlers
+
+    @available(iOS 13.0, *)
+    private func handleMulticastBrowserStateChange(_ state: NWBrowser.State) {
+        switch state {
+        case .ready:
+            logger.info(" Multicast browser ready")
+        case .failed(let error):
+            logger.info(" Multicast browser failed: \(error)")
+        case .cancelled:
+            logger.info(" Multicast browser cancelled")
+        default:
+            break
+        }
+    }
+
+    @available(iOS 13.0, *)
+    private func handleMulticastBrowseResults(_ results: Set<NWBrowser.Result>, changes: Set<NWBrowser.Result.Change>) {
+        for change in changes {
+            switch change {
+            case .added(let result):
+                handleMulticastPeerAdded(result)
+            case .removed(let result):
+                handleMulticastPeerRemoved(result)
+            case .changed(_, let new, _):
+                handleMulticastPeerChanged(new)
+            case .identical:
+                break
+            @unknown default:
+                break
+            }
+        }
+    }
+
+    @available(iOS 13.0, *)
+    private func handleMulticastPeerAdded(_ result: NWBrowser.Result) {
+        let peerId = result.endpoint.debugDescription
+        let name = extractNameFromBonjourResult(result)
+
+        let peer = BertyProximityPeer(
+            id: peerId,
+            name: name,
+            deviceType: .unknown,
+            transport: .multicast,
+            isConnected: false,
+            capabilities: [.messaging, .groupChat]
+        )
+
+        addDiscoveredPeer(peer)
+    }
+
+    @available(iOS 13.0, *)
+    private func handleMulticastPeerRemoved(_ result: NWBrowser.Result) {
+        let peerId = result.endpoint.debugDescription
+        removeDiscoveredPeer(peerId)
+    }
+
+    @available(iOS 13.0, *)
+    private func handleMulticastPeerChanged(_ result: NWBrowser.Result) {
+        let peerId = result.endpoint.debugDescription
+        updatePeerLastSeen(peerId)
+    }
+
+    @available(iOS 13.0, *)
+    private func handleMulticastListenerStateChange(_ state: NWListener.State) {
+        switch state {
+        case .ready:
+            logger.info(" Multicast listener ready")
+        case .failed(let error):
+            logger.info(" Multicast listener failed: \(error)")
+        case .cancelled:
+            logger.info(" Multicast listener cancelled")
+        default:
+            break
+        }
+    }
+
+    @available(iOS 13.0, *)
+    private func handleMulticastNewConnection(_ connection: NWConnection) {
+        logger.info(" New multicast connection: \(connection)")
+
+        // Handle incoming multicast connection
+        connection.stateUpdateHandler = { [weak self] state in
+            switch state {
+            case .ready:
+                self?.logger.info(" Multicast connection ready")
+            case .failed(let error):
+                self?.logger.info(" Multicast connection failed: \(error)")
+            default:
+                break
+            }
+        }
+
+        connection.start(queue: discoveryQueue)
+    }
+
+    private func extractNameFromBonjourResult(_ result: NWBrowser.Result) -> String? {
+        if case .service(let name, _, _, _) = result.endpoint {
+            return name
+        }
+        return nil
+    }
+
+    // MARK: - Peer Management
+
+    private func addDiscoveredPeer(_ peer: BertyProximityPeer) {
+        discoveredPeers[peer.id] = peer
+        setupPeerTimeout(peerId: peer.id)
+
+        logger.info(" Discovered peer: \(peer.id) (\(peer.transport))")
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.delegate?.proximityManager(self, didDiscoverPeer: peer)
+        }
+    }
+
+    private func removeDiscoveredPeer(_ peerId: String) {
+        discoveredPeers.removeValue(forKey: peerId)
+        clearPeerTimeout(peerId: peerId)
+
+        logger.info(" Lost peer: \(peerId)")
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.delegate?.proximityManager(self, didLosePeer: peerId)
+        }
+    }
+
+    private func updatePeerLastSeen(_ peerId: String) {
+        guard var peer = discoveredPeers[peerId] else { return }
+
+        peer = BertyProximityPeer(
+            id: peer.id,
+            name: peer.name,
+            deviceType: peer.deviceType,
+            transport: peer.transport,
+            rssi: peer.rssi,
+            lastSeen: Date(),
+            isConnected: peer.isConnected,
+            connectionQuality: peer.connectionQuality,
+            capabilities: peer.capabilities,
+            metadata: peer.metadata
+        )
+
+        discoveredPeers[peerId] = peer
+        resetPeerTimeout(peerId: peerId)
+    }
+
+    // MARK: - Peer Timeout Management
+
+    private func startPeerTimeoutMonitoring() {
+        // Monitoring is handled per-peer in setupPeerTimeout
+    }
+
+    private func stopPeerTimeoutMonitoring() {
+        for work in peerTimeoutWork.values {
+            work.cancel()
+        }
+        peerTimeoutWork.removeAll()
+    }
+
+    private func setupPeerTimeout(peerId: String) {
+        clearPeerTimeout(peerId: peerId)
+
+        // Use DispatchWorkItem instead of Timer - works without active RunLoop
+        let work = DispatchWorkItem { [weak self] in
+            self?.handlePeerTimeout(peerId: peerId)
+        }
+        peerTimeoutWork[peerId] = work
+        discoveryQueue.asyncAfter(deadline: .now() + peerTimeoutInterval, execute: work)
+    }
+
+    private func clearPeerTimeout(peerId: String) {
+        peerTimeoutWork[peerId]?.cancel()
+        peerTimeoutWork.removeValue(forKey: peerId)
+    }
+
+    private func resetPeerTimeout(peerId: String) {
+        setupPeerTimeout(peerId: peerId)
+    }
+
+    private func handlePeerTimeout(peerId: String) {
+        logger.info(" Peer timeout: \(peerId)")
+        removeDiscoveredPeer(peerId)
+    }
+
+    // MARK: - Connection Management
+
+    func connectToPeer(_ peer: BertyProximityPeer) throws {
+        guard !peer.isConnected else {
+            throw BertyError.connectivityError(
+                .peerConnectionTimeout,
+                message: "Peer is already connected: \(peer.id)"
+            )
+        }
+
+        switch peer.transport {
+        case .bluetooth:
+            try connectViaBluetooth(peer)
+        case .multicast, .wifi:
+            try connectViaNetwork(peer)
+        default:
+            throw BertyError.connectivityError(
+                .peerDiscoveryFailed,
+                message: "Unsupported transport type: \(peer.transport)"
+            )
+        }
+    }
+
+    private func connectViaBluetooth(_ peer: BertyProximityPeer) throws {
+        try bleDriver.connectToPeer(peer.id)
+    }
+
+    private func connectViaNetwork(_ peer: BertyProximityPeer) throws {
+        // Implement network-based connection
+        logger.info(" Connecting via network to peer: \(peer.id)")
+
+        // This would establish a direct network connection
+        // For now, we'll simulate success
+        let connectedPeer = BertyProximityPeer(
+            id: peer.id,
+            name: peer.name,
+            deviceType: peer.deviceType,
+            transport: peer.transport,
+            rssi: peer.rssi,
+            lastSeen: peer.lastSeen,
+            isConnected: true,
+            connectionQuality: .good,
+            capabilities: peer.capabilities,
+            metadata: peer.metadata
+        )
+
+        connectedPeers[peer.id] = connectedPeer
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.delegate?.proximityManager(self, didConnectToPeer: connectedPeer)
+        }
+    }
+
+    func disconnectFromPeer(_ peerId: String) {
+        guard let peer = connectedPeers[peerId] else { return }
+
+        switch peer.transport {
+        case .bluetooth:
+            bleDriver.disconnectFromPeer(peerId)
+        case .multicast, .wifi:
+            disconnectFromNetworkPeer(peerId)
+        default:
+            break
+        }
+
+        connectedPeers.removeValue(forKey: peerId)
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.delegate?.proximityManager(self, didDisconnectFromPeer: peerId, error: nil)
+        }
+    }
+
+    private func disconnectFromNetworkPeer(_ peerId: String) {
+        logger.info(" Disconnecting from network peer: \(peerId)")
+        // Implement network disconnection logic
+    }
+
+    // MARK: - Data Transfer
+
+    func sendDataToPeer(_ data: Data, peerId: String) throws {
+        guard let peer = connectedPeers[peerId] else {
+            throw BertyError.connectivityError(
+                .peerConnectionTimeout,
+                message: "Peer not connected: \(peerId)"
+            )
+        }
+
+        switch peer.transport {
+        case .bluetooth:
+            try bleDriver.sendData(data, toPeer: peerId)
+        case .multicast, .wifi:
+            try sendDataViaNetwork(data, toPeer: peerId)
+        default:
+            throw BertyError.connectivityError(
+                .peerDiscoveryFailed,
+                message: "Unsupported transport for data transfer: \(peer.transport)"
+            )
+        }
+    }
+
+    private func sendDataViaNetwork(_ data: Data, toPeer peerId: String) throws {
+        logger.info(" Sending \(data.count) bytes via network to peer: \(peerId)")
+        // Implement network data sending
+    }
+
+    // MARK: - Public Getters
+
+    func getDiscoveredPeers() -> [BertyProximityPeer] {
+        return Array(discoveredPeers.values)
+    }
+
+    func getConnectedPeers() -> [BertyProximityPeer] {
+        return Array(connectedPeers.values)
+    }
+
+    // MARK: - Network Status Handling
+
+    private func handleNetworkStatusChange(connectionType: BertyConnectionType, isAvailable: Bool) {
+        logger.info(" Network status changed - Type: \(connectionType), Available: \(isAvailable)")
+
+        if connectionType == .wifi && isAvailable && isDiscovering {
+            // Start multicast discovery when WiFi becomes available
+            startMulticastDiscovery()
+        } else if connectionType != .wifi {
+            // Stop multicast discovery when not on WiFi
+            stopMulticastDiscovery()
+        }
+
+        if connectionType == .wifi && isAvailable && isAdvertising {
+            // Start multicast advertising when WiFi becomes available
+            if #available(iOS 16.0, *) {
+                startMulticastAdvertising()
+            }
+        } else if connectionType != .wifi {
+            // Stop multicast advertising when not on WiFi
+            stopMulticastAdvertising()
+        }
+    }
+
+    // MARK: - Configuration
+
+    func updateDiscoveryConfig(_ config: BertyDiscoveryConfig) {
+        discoveryConfig = config
+
+        // Apply new configuration
+        if isDiscovering {
+            stopDiscovery()
+            startDiscovery()
+        }
+    }
+
+    // MARK: - Debug Information
+
+    func getDebugInfo() -> [String: Any] {
+        var info: [String: Any] = [:]
+
+        info["isDiscovering"] = isDiscovering
+        info["isAdvertising"] = isAdvertising
+        info["discoveredPeersCount"] = discoveredPeers.count
+        info["connectedPeersCount"] = connectedPeers.count
+        info["peerTimeoutsActive"] = peerTimeoutWork.count
+
+        let discoveredPeersInfo = discoveredPeers.values.map { peer in
+            [
+                "id": peer.id,
+                "name": peer.name ?? "unknown",
+                "transport": String(describing: peer.transport),
+                "isConnected": peer.isConnected,
+                "lastSeen": peer.lastSeen.timeIntervalSince1970,
+                "rssi": peer.rssi ?? 0
+            ]
+        }
+        info["discoveredPeers"] = discoveredPeersInfo
+
+        let connectedPeersInfo = connectedPeers.values.map { peer in
+            [
+                "id": peer.id,
+                "name": peer.name ?? "unknown",
+                "transport": String(describing: peer.transport),
+                "connectionQuality": String(describing: peer.connectionQuality)
+            ]
+        }
+        info["connectedPeers"] = connectedPeersInfo
+
+        info["networkType"] = String(describing: networkDriver.getCurrentConnectionType())
+        info["bleEnabled"] = bleDriver.isBluetoothEnabled()
+
+        return info
+    }
+}
+
+// MARK: - Discovery Configuration
+struct BertyDiscoveryConfig {
+    let enableBluetooth: Bool
+    let enableMulticast: Bool
+    let enableRelay: Bool
+    let discoveryInterval: TimeInterval
+    let advertisingInterval: TimeInterval
+    let peerTimeout: TimeInterval
+
+    init(
+        enableBluetooth: Bool = true,
+        enableMulticast: Bool = true,
+        enableRelay: Bool = false,
+        discoveryInterval: TimeInterval = 10.0,
+        advertisingInterval: TimeInterval = 5.0,
+        peerTimeout: TimeInterval = 30.0
+    ) {
+        self.enableBluetooth = enableBluetooth
+        self.enableMulticast = enableMulticast
+        self.enableRelay = enableRelay
+        self.discoveryInterval = discoveryInterval
+        self.advertisingInterval = advertisingInterval
+        self.peerTimeout = peerTimeout
+    }
+}
+
+// MARK: - BLE Driver Delegate
+extension BertyProximityManager: BertyBLEDriverDelegate {
+    func bleDriver(_ driver: BertyBLEDriver, didDiscoverPeer peer: BertyBLEPeer) {
+        let proximityPeer = BertyProximityPeer(
+            id: peer.id,
+            name: peer.name,
+            deviceType: .phone, // Assume phone for BLE devices
+            transport: .bluetooth,
+            rssi: peer.rssi,
+            lastSeen: peer.lastSeen,
+            isConnected: peer.isConnected,
+            connectionQuality: assessConnectionQuality(rssi: peer.rssi),
+            capabilities: [.messaging, .encryption]
+        )
+
+        addDiscoveredPeer(proximityPeer)
+    }
+
+    func bleDriver(_ driver: BertyBLEDriver, didConnectToPeer peerId: String) {
+        guard var peer = discoveredPeers[peerId] else { return }
+
+        peer = BertyProximityPeer(
+            id: peer.id,
+            name: peer.name,
+            deviceType: peer.deviceType,
+            transport: peer.transport,
+            rssi: peer.rssi,
+            lastSeen: peer.lastSeen,
+            isConnected: true,
+            connectionQuality: peer.connectionQuality,
+            capabilities: peer.capabilities,
+            metadata: peer.metadata
+        )
+
+        connectedPeers[peerId] = peer
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.delegate?.proximityManager(self, didConnectToPeer: peer)
+        }
+    }
+
+    func bleDriver(_ driver: BertyBLEDriver, didDisconnectFromPeer peerId: String, error: Error?) {
+        connectedPeers.removeValue(forKey: peerId)
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.delegate?.proximityManager(self, didDisconnectFromPeer: peerId, error: error)
+        }
+    }
+
+    func bleDriver(_ driver: BertyBLEDriver, didReceiveData data: Data, fromPeer peerId: String) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.delegate?.proximityManager(self, didReceiveData: data, fromPeer: peerId)
+        }
+    }
+
+    func bleDriver(_ driver: BertyBLEDriver, didFailWithError error: BertyError) {
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            self.delegate?.proximityManager(self, didFailWithError: error)
+        }
+    }
+
+    private func assessConnectionQuality(rssi: Int) -> BertyConnectionQuality {
+        switch rssi {
+        case -30...0:
+            return .excellent
+        case -60...(-31):
+            return .good
+        case -80...(-61):
+            return .fair
+        default:
+            return .poor
+        }
+    }
+}
+
+// MARK: - Berty Native Proximity Driver Bridge
+@objc class BertyNativeProximityDriverBridge: NSObject {
+    private let manager = BertyProximityManager.shared
+
+    @objc func startDiscovery() {
+        manager.startDiscovery()
+    }
+
+    @objc func stopDiscovery() {
+        manager.stopDiscovery()
+    }
+
+    @objc func startAdvertising() {
+        manager.startAdvertising()
+    }
+
+    @objc func stopAdvertising() {
+        manager.stopAdvertising()
+    }
+
+    @objc func getPeerCount() -> Int {
+        return manager.getDiscoveredPeers().count
+    }
+
+    @objc func getConnectedPeerCount() -> Int {
+        return manager.getConnectedPeers().count
+    }
+}

--- a/js/ios/Berty/Sources/Bridge/BertyQueueManager.swift
+++ b/js/ios/Berty/Sources/Bridge/BertyQueueManager.swift
@@ -1,0 +1,236 @@
+import Foundation
+
+// MARK: - Queue Manager
+
+class BertyQueueManager {
+    static let shared = BertyQueueManager()
+
+    // Dedicated queues for different operations
+    let bridgeQueue = DispatchQueue(label: "tech.berty.bridge", qos: .userInitiated)
+    let streamQueue = DispatchQueue(label: "tech.berty.stream", qos: .userInitiated)
+    let promiseQueue = DispatchQueue(label: "tech.berty.promise", qos: .userInitiated)
+    let eventQueue = DispatchQueue(label: "tech.berty.event", qos: .utility)
+    let backgroundQueue = DispatchQueue(label: "tech.berty.background", qos: .background)
+    let keystoreQueue = DispatchQueue(label: "tech.berty.keystore", qos: .userInitiated)
+    let bleQueue = DispatchQueue(label: "tech.berty.ble", qos: .userInitiated)
+
+    // Serial queues for critical sections
+    let stateQueue = DispatchQueue(label: "tech.berty.state")
+    let memoryQueue = DispatchQueue(label: "tech.berty.memory")
+
+    // Concurrent queue for read operations
+    let readQueue = DispatchQueue(label: "tech.berty.read", attributes: .concurrent)
+
+    // High priority queue for time-sensitive operations
+    let priorityQueue = DispatchQueue(label: "tech.berty.priority", qos: .userInteractive)
+
+    private init() {}
+
+    // MARK: - Queue Operations
+
+    func executeOnBridge<T>(_ block: @escaping () throws -> T, completion: @escaping (Result<T, Error>) -> Void) {
+        bridgeQueue.async {
+            do {
+                let result = try block()
+                DispatchQueue.main.async {
+                    completion(.success(result))
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    completion(.failure(error))
+                }
+            }
+        }
+    }
+
+    func executeOnStream<T>(_ block: @escaping () throws -> T, completion: @escaping (Result<T, Error>) -> Void) {
+        streamQueue.async {
+            do {
+                let result = try block()
+                DispatchQueue.main.async {
+                    completion(.success(result))
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    completion(.failure(error))
+                }
+            }
+        }
+    }
+
+    func executeOnPriority<T>(_ block: @escaping () throws -> T, completion: @escaping (Result<T, Error>) -> Void) {
+        priorityQueue.async {
+            do {
+                let result = try block()
+                DispatchQueue.main.async {
+                    completion(.success(result))
+                }
+            } catch {
+                DispatchQueue.main.async {
+                    completion(.failure(error))
+                }
+            }
+        }
+    }
+
+    // MARK: - Synchronous Operations
+
+    func synchronouslyOnState<T>(_ block: () throws -> T) rethrows -> T {
+        return try stateQueue.sync {
+            try block()
+        }
+    }
+
+    func synchronouslyOnMemory<T>(_ block: () throws -> T) rethrows -> T {
+        return try memoryQueue.sync {
+            try block()
+        }
+    }
+
+    // MARK: - Barrier Operations
+
+    func barrierOnRead(_ block: @escaping () -> Void) {
+        readQueue.async(flags: .barrier) {
+            block()
+        }
+    }
+
+    // MARK: - Delayed Operations
+
+    func executeAfterDelay(on queue: DispatchQueue? = nil, delay: TimeInterval, block: @escaping () -> Void) {
+        let targetQueue = queue ?? DispatchQueue.main
+        targetQueue.asyncAfter(deadline: .now() + delay) {
+            block()
+        }
+    }
+}
+
+// MARK: - Thread-Safe Collections
+
+class ThreadSafeArray<Element> {
+    private var array: [Element] = []
+    private let queue = DispatchQueue(label: "tech.berty.array", attributes: .concurrent)
+
+    var count: Int {
+        queue.sync { array.count }
+    }
+
+    func append(_ element: Element) {
+        queue.async(flags: .barrier) {
+            self.array.append(element)
+        }
+    }
+
+    func remove(at index: Int) -> Element? {
+        queue.sync(flags: .barrier) {
+            guard index < array.count else { return nil }
+            return array.remove(at: index)
+        }
+    }
+
+    func removeAll(where predicate: @escaping (Element) -> Bool) {
+        queue.async(flags: .barrier) {
+            self.array.removeAll(where: predicate)
+        }
+    }
+
+    func first(where predicate: (Element) -> Bool) -> Element? {
+        queue.sync {
+            array.first(where: predicate)
+        }
+    }
+
+    func forEach(_ body: (Element) -> Void) {
+        queue.sync {
+            array.forEach(body)
+        }
+    }
+
+    func map<T>(_ transform: (Element) -> T) -> [T] {
+        queue.sync {
+            array.map(transform)
+        }
+    }
+
+    subscript(index: Int) -> Element? {
+        get {
+            queue.sync {
+                guard index < array.count else { return nil }
+                return array[index]
+            }
+        }
+        set {
+            queue.async(flags: .barrier) {
+                guard index < self.array.count, let newValue = newValue else { return }
+                self.array[index] = newValue
+            }
+        }
+    }
+}
+
+class ThreadSafeDictionary<Key: Hashable, Value> {
+    private var dictionary: [Key: Value] = [:]
+    private let queue = DispatchQueue(label: "tech.berty.dictionary", attributes: .concurrent)
+
+    var count: Int {
+        queue.sync { dictionary.count }
+    }
+
+    var keys: [Key] {
+        queue.sync { Array(dictionary.keys) }
+    }
+
+    var values: [Value] {
+        queue.sync { Array(dictionary.values) }
+    }
+
+    func set(_ value: Value?, for key: Key) {
+        queue.async(flags: .barrier) {
+            self.dictionary[key] = value
+        }
+    }
+
+    func get(_ key: Key) -> Value? {
+        queue.sync { dictionary[key] }
+    }
+
+    func removeValue(for key: Key) -> Value? {
+        queue.sync(flags: .barrier) {
+            dictionary.removeValue(forKey: key)
+        }
+    }
+
+    func removeAll() {
+        queue.async(flags: .barrier) {
+            self.dictionary.removeAll()
+        }
+    }
+
+    subscript(key: Key) -> Value? {
+        get { get(key) }
+        set { set(newValue, for: key) }
+    }
+}
+
+// MARK: - Atomic Properties
+
+@propertyWrapper
+class Atomic<Value> {
+    private var value: Value
+    private let queue = DispatchQueue(label: "tech.berty.atomic", attributes: .concurrent)
+
+    init(wrappedValue value: Value) {
+        self.value = value
+    }
+
+    var wrappedValue: Value {
+        get { queue.sync { value } }
+        set { queue.async(flags: .barrier) { self.value = newValue } }
+    }
+
+    func mutate(_ mutation: @escaping (inout Value) -> Void) {
+        queue.async(flags: .barrier) {
+            mutation(&self.value)
+        }
+    }
+}

--- a/js/ios/Berty/Sources/Bridge/ConnectivityDriver.swift
+++ b/js/ios/Berty/Sources/Bridge/ConnectivityDriver.swift
@@ -5,135 +5,297 @@
 //  Created by u on 01/02/2023.
 //
 
-import SystemConfiguration
-import CoreBluetooth
-import CoreTelephony
 import Foundation
-import Bertybridge
+import UIKit
 import Network
+import SystemConfiguration
+import CoreTelephony
+import CoreBluetooth
+import Bertybridge
 
-class ConnectivityDriver: NSObject, BertybridgeIConnectivityDriverProtocol, CBCentralManagerDelegate {
-    let logger: BertyLogger = BertyLogger("tech.berty.ConnectivityDriver")
-    let queue = DispatchQueue.global(qos: .background)
-    let pathMonitor = NWPathMonitor()
-    var centralManager: CBCentralManager!
+// Bridges iOS network and Bluetooth state to Go's netmanager.
+//
+// Network reachability comes from NWPathMonitor, with an SCNetworkReachability
+// fallback for iOS < 12. Bluetooth state is observed through the CBCentralManager
+// owned by BertyBLEDriver when one is available, so we avoid spinning up a second
+// central manager (and its extra power alert). If the BLE driver has not created a
+// manager yet, we fall back to our own and keep a strong reference so it is not
+// deallocated.
+//
+// The connectivity constants (state/net/cellular) are exported by the Bertybridge
+// framework from Go's netmanager/connectivity.go — never redefine them locally.
+class ConnectivityDriver: NSObject, BertybridgeIConnectivityDriverProtocol {
+    let logger = BertyLogger("tech.berty.connectivity")
 
-    var state: BertybridgeConnectivityInfo
-    var handlers: [BertybridgeIConnectivityHandlerProtocol] = []
+    private var pathMonitor: NWPathMonitor?
+    private let monitorQueue = DispatchQueue(label: "tech.berty.connectivity.monitor")
+
+    // Prefer the BLE driver's shared manager; only create (and strongly retain) our
+    // own when the BLE driver has not initialized one yet.
+    private weak var sharedCentralManager: CBCentralManager?
+    private var ownedCentralManager: CBCentralManager?
+
+    private let networkInfo = CTTelephonyNetworkInfo()
+
+    private var isMonitoring = false
+    private var currentPath: NWPath?
+    private var bluetoothState: CBManagerState = .unknown
+
+    // Thread-safe handler storage. Go callbacks run on a dedicated serial queue
+    // (not DispatchQueue.global(), which causes stack-alignment issues in the Go
+    // runtime) when the app is backgrounded.
+    private let handlerQueue = DispatchQueue(label: "tech.berty.connectivity.handlers", attributes: .concurrent)
+    private let goCallbackQueue = DispatchQueue(label: "tech.berty.connectivity.go-callbacks")
+    private var handlers: [BertybridgeIConnectivityHandlerProtocol] = []
 
     override init() {
-        self.logger.debug("Init")
-      
-        self.state = BertybridgeConnectivityInfo()!
-
         super.init()
-      
-        self.centralManager = CBCentralManager(delegate: self, queue: nil)
-
-        self.pathMonitor.pathUpdateHandler = { [weak self] path in
-            self!.logger.debug("Network state changed")
-          
-            self!.updateNetworkState(path)
-
-            for handler in self!.handlers {
-                handler.handleConnectivityUpdate(self!.state)
-            }
-        }
-        self.pathMonitor.start(queue: self.queue)
+        self.startMonitoring()
     }
 
-    func updateNetworkState(_ info: NWPath) {
-        self.state.setState(info.status == .satisfied ? BertybridgeConnectivityStateOn : BertybridgeConnectivityStateOff)
-        self.state.setMetering(BertybridgeConnectivityStateUnknown)
-        self.state.setNetType(BertybridgeConnectivityNetUnknown)
-        self.state.setCellularType(BertybridgeConnectivityCellularUnknown)
+    // MARK: - Monitoring lifecycle
 
-        if info.status != .satisfied {
-            return
+    func startMonitoring() {
+        guard !self.isMonitoring else { return }
+        self.isMonitoring = true
+
+        if #available(iOS 12.0, *) {
+            self.setupPathMonitor()
         }
+        self.setupBluetoothMonitoring()
 
-        if #available(iOS 13.0, *) {
-            self.state.setMetering(info.isConstrained ? BertybridgeConnectivityStateOn : BertybridgeConnectivityStateOff)
-        }
-
-        if let interface = self.pathMonitor.currentPath.availableInterfaces.first {
-            switch interface.type {
-                case .wifi:
-                    self.state.setNetType(BertybridgeConnectivityNetWifi)
-                case .cellular:
-                    self.state.setNetType(BertybridgeConnectivityNetCellular)
-                    self.state.setCellularType(ConnectivityDriver.getCellularType())
-                case .wiredEthernet:
-                    self.state.setNetType(BertybridgeConnectivityNetEthernet)
-                default:
-                    self.state.setNetType(BertybridgeConnectivityNetUnknown)
-            }
-        }
-    }
-  
-    static func getCellularType() -> Int {
-        let networkInfo = CTTelephonyNetworkInfo()
-
-        guard let carrierType = networkInfo.serviceCurrentRadioAccessTechnology?.first?.value else {
-            return BertybridgeConnectivityCellularNone
-        }
-
-        switch carrierType {
-            case CTRadioAccessTechnologyGPRS,
-                 CTRadioAccessTechnologyEdge,
-                 CTRadioAccessTechnologyCDMA1x:
-                return BertybridgeConnectivityCellular2G
-            case CTRadioAccessTechnologyWCDMA,
-                 CTRadioAccessTechnologyHSDPA,
-                 CTRadioAccessTechnologyHSUPA,
-                 CTRadioAccessTechnologyCDMAEVDORev0,
-                 CTRadioAccessTechnologyCDMAEVDORevA,
-                 CTRadioAccessTechnologyCDMAEVDORevB,
-                 CTRadioAccessTechnologyeHRPD:
-                return BertybridgeConnectivityCellular3G
-            case CTRadioAccessTechnologyLTE:
-                return BertybridgeConnectivityCellular4G
-            default:
-                if #available(iOS 14.1, *) {
-                    if carrierType == CTRadioAccessTechnologyNRNSA
-                    || carrierType == CTRadioAccessTechnologyNR {
-                        return BertybridgeConnectivityCellular5G
-                    }
-                }
-
-                return BertybridgeConnectivityCellularUnknown
-        }
+        self.logger.info("Started connectivity monitoring")
     }
 
-    func centralManagerDidUpdateState(_ central: CBCentralManager) {
-        self.logger.debug("Bluetooth state changed")
+    func stopMonitoring() {
+        guard self.isMonitoring else { return }
+        self.isMonitoring = false
 
-        switch central.state {
-            case .poweredOn:
-                self.state.setBluetooth(BertybridgeConnectivityStateOn)
-            case .poweredOff,
-                 .unsupported,
-                 .unauthorized,
-                 .resetting:
-                self.state.setBluetooth(BertybridgeConnectivityStateOff)
-            case .unknown:
-                self.state.setBluetooth(BertybridgeConnectivityStateUnknown)
-            @unknown default:
-                self.state.setBluetooth(BertybridgeConnectivityStateUnknown)
+        if #available(iOS 12.0, *) {
+            self.pathMonitor?.cancel()
+            self.pathMonitor = nil
         }
+        self.sharedCentralManager = nil
+        self.ownedCentralManager = nil
 
-        for handler in self.handlers {
-            handler.handleConnectivityUpdate(self.state)
-        }
+        self.logger.info("Stopped connectivity monitoring")
     }
+
+    // MARK: - BertybridgeIConnectivityDriverProtocol
 
     public func getCurrentState() -> BertybridgeConnectivityInfo? {
-        return self.state
+        return self.buildCurrentState()
     }
 
     public func register(_ handler: BertybridgeIConnectivityHandlerProtocol?) {
-        if (handler != nil) {
-            self.handlers.append(handler!)
+        guard let handler = handler else { return }
+
+        self.handlerQueue.async(flags: .barrier) { [weak self] in
+            self?.handlers.append(handler)
         }
+
+        // Notify the new handler of the current state immediately.
+        handler.handleConnectivityUpdate(self.buildCurrentState())
+    }
+
+    // MARK: - State
+
+    private func buildCurrentState() -> BertybridgeConnectivityInfo {
+        let info = BertybridgeConnectivityInfo()!
+
+        if #available(iOS 12.0, *), let path = self.currentPath {
+            info.setState(path.status == .satisfied ? BertybridgeConnectivityStateOn : BertybridgeConnectivityStateOff)
+
+            if #available(iOS 13.0, *) {
+                info.setMetering(path.isConstrained ? BertybridgeConnectivityStateOn : BertybridgeConnectivityStateOff)
+            } else {
+                info.setMetering(BertybridgeConnectivityStateUnknown)
+            }
+
+            if path.usesInterfaceType(.wifi) {
+                info.setNetType(BertybridgeConnectivityNetWifi)
+            } else if path.usesInterfaceType(.cellular) {
+                info.setNetType(BertybridgeConnectivityNetCellular)
+                info.setCellularType(self.getCellularGeneration())
+            } else if path.usesInterfaceType(.wiredEthernet) {
+                info.setNetType(BertybridgeConnectivityNetEthernet)
+            } else {
+                info.setNetType(BertybridgeConnectivityNetUnknown)
+            }
+        } else {
+            // Fallback for iOS < 12
+            info.setState(self.isConnectedLegacy() ? BertybridgeConnectivityStateOn : BertybridgeConnectivityStateOff)
+            info.setMetering(BertybridgeConnectivityStateUnknown)
+            info.setNetType(self.getNetworkTypeLegacy())
+            info.setCellularType(BertybridgeConnectivityCellularUnknown)
+        }
+
+        // Read Bluetooth state directly from the live manager for the freshest value:
+        // when observing the shared manager we do not receive delegate callbacks.
+        let state = self.ownedCentralManager?.state ?? self.sharedCentralManager?.state ?? self.bluetoothState
+        switch state {
+        case .poweredOn:
+            info.setBluetooth(BertybridgeConnectivityStateOn)
+        case .poweredOff:
+            info.setBluetooth(BertybridgeConnectivityStateOff)
+        default:
+            info.setBluetooth(BertybridgeConnectivityStateUnknown)
+        }
+
+        return info
+    }
+
+    private func notifyHandlers() {
+        // Read applicationState on the main thread before entering handlerQueue, to
+        // avoid a sync hop to main from within the queue (deadlock risk).
+        DispatchQueue.main.async { [weak self] in
+            guard let self = self else { return }
+            let isBackground = UIApplication.shared.applicationState == .background
+
+            self.handlerQueue.async { [weak self] in
+                guard let self = self else { return }
+                let state = self.buildCurrentState()
+                let handlers = self.handlers
+
+                if isBackground {
+                    // Background: hand off to Go on the dedicated serial queue.
+                    self.goCallbackQueue.async {
+                        handlers.forEach { $0.handleConnectivityUpdate(state) }
+                    }
+                } else {
+                    DispatchQueue.main.async {
+                        handlers.forEach { $0.handleConnectivityUpdate(state) }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Network monitoring
+
+    @available(iOS 12.0, *)
+    private func setupPathMonitor() {
+        let monitor = NWPathMonitor()
+        monitor.pathUpdateHandler = { [weak self] path in
+            self?.handlePathUpdate(path)
+        }
+        monitor.start(queue: self.monitorQueue)
+        self.pathMonitor = monitor
+    }
+
+    @available(iOS 12.0, *)
+    private func handlePathUpdate(_ path: NWPath) {
+        self.logger.info("Network path updated: status=\(path.status), wifi=\(path.usesInterfaceType(.wifi)), cellular=\(path.usesInterfaceType(.cellular))")
+        self.currentPath = path
+        self.notifyHandlers()
+    }
+
+    // MARK: - Bluetooth monitoring
+
+    private func setupBluetoothMonitoring() {
+        guard self.sharedCentralManager == nil, self.ownedCentralManager == nil else { return }
+
+        if let shared = BertyBLEDriver.shared.getCentralManager() {
+            // Observe the BLE driver's manager; it owns the delegate.
+            self.sharedCentralManager = shared
+            self.bluetoothState = shared.state
+            self.logger.info("Using shared CBCentralManager from BertyBLEDriver (state: \(shared.state.rawValue))")
+        } else {
+            // The BLE driver has not created a manager yet: create our own, keep a
+            // strong reference so it is not deallocated, and suppress the system
+            // power alert since we only observe state.
+            self.ownedCentralManager = CBCentralManager(delegate: self, queue: nil, options: [CBCentralManagerOptionShowPowerAlertKey: false])
+            self.logger.info("Created own CBCentralManager (BLE driver not initialized)")
+        }
+    }
+
+    // MARK: - Cellular
+
+    private func getCellularGeneration() -> Int {
+        let technology: String?
+        if #available(iOS 12.0, *) {
+            technology = self.networkInfo.serviceCurrentRadioAccessTechnology?.values.first
+        } else {
+            technology = self.networkInfo.currentRadioAccessTechnology
+        }
+        guard let technology = technology else {
+            return BertybridgeConnectivityCellularNone
+        }
+        return self.mapRadioAccessTechnology(technology)
+    }
+
+    private func mapRadioAccessTechnology(_ technology: String) -> Int {
+        switch technology {
+        case CTRadioAccessTechnologyGPRS,
+             CTRadioAccessTechnologyEdge,
+             CTRadioAccessTechnologyCDMA1x:
+            return BertybridgeConnectivityCellular2G
+
+        case CTRadioAccessTechnologyWCDMA,
+             CTRadioAccessTechnologyHSDPA,
+             CTRadioAccessTechnologyHSUPA,
+             CTRadioAccessTechnologyCDMAEVDORev0,
+             CTRadioAccessTechnologyCDMAEVDORevA,
+             CTRadioAccessTechnologyCDMAEVDORevB,
+             CTRadioAccessTechnologyeHRPD:
+            return BertybridgeConnectivityCellular3G
+
+        case CTRadioAccessTechnologyLTE:
+            return BertybridgeConnectivityCellular4G
+
+        default:
+            if #available(iOS 14.1, *),
+               technology == CTRadioAccessTechnologyNRNSA || technology == CTRadioAccessTechnologyNR {
+                return BertybridgeConnectivityCellular5G
+            }
+            return BertybridgeConnectivityCellularUnknown
+        }
+    }
+
+    // MARK: - Legacy support (iOS < 12)
+
+    private func isConnectedLegacy() -> Bool {
+        guard let flags = self.legacyReachabilityFlags() else { return false }
+        return flags.contains(.reachable) && !flags.contains(.connectionRequired)
+    }
+
+    private func getNetworkTypeLegacy() -> Int {
+        guard let flags = self.legacyReachabilityFlags() else {
+            return BertybridgeConnectivityNetUnknown
+        }
+        if flags.contains(.isWWAN) {
+            return BertybridgeConnectivityNetCellular
+        } else if flags.contains(.reachable) {
+            return BertybridgeConnectivityNetWifi
+        }
+        return BertybridgeConnectivityNetUnknown
+    }
+
+    private func legacyReachabilityFlags() -> SCNetworkReachabilityFlags? {
+        var zeroAddress = sockaddr_in()
+        zeroAddress.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        zeroAddress.sin_family = sa_family_t(AF_INET)
+
+        let reachability = withUnsafePointer(to: &zeroAddress) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { zeroSockAddress in
+                SCNetworkReachabilityCreateWithAddress(nil, zeroSockAddress)
+            }
+        }
+        guard let reachability = reachability else { return nil }
+
+        var flags = SCNetworkReachabilityFlags()
+        guard SCNetworkReachabilityGetFlags(reachability, &flags) else { return nil }
+        return flags
+    }
+}
+
+// MARK: - CBCentralManagerDelegate
+
+extension ConnectivityDriver: CBCentralManagerDelegate {
+    func centralManagerDidUpdateState(_ central: CBCentralManager) {
+        // Only fires for a manager we own; the shared manager's delegate is BertyBLEDriver.
+        self.logger.info("Bluetooth state changed: \(central.state.rawValue)")
+        self.bluetoothState = central.state
+        self.notifyHandlers()
     }
 }


### PR DESCRIPTION
# Port BLE fixes and improvements

## Motivation

We run a Berty fork at CoHunt. The bluetooth data exchange is extremely important to our users in circumstances with no cell service. This PR is meant to enhance and bridge communication between iOS and Android users.  Feedback is welcome!

## Summary

Adds a **native iOS CoreBluetooth BLE proximity transport** for Berty (iOS previously had no native BLE driver), ports the same reliability/safety model into the existing **Android BLE driver**, and **improves the iOS connectivity driver**.

~4,600 lines across iOS (`js/ios`), expo (`berty-bridge-expo/ios`), and Android (`js/android`). No Go changes — the iOS transport binds to the existing gomobile `Bertybridge` proximity protocols and is wire-compatible with the Android BLE driver.

## What's included

### iOS — native BLE proximity transport (new)
- **`BertyBLEDriver.swift`** — CoreBluetooth engine acting as both GATT central and peripheral; custom PID handshake, chunked data over a WRITER characteristic, per-peer connection/handshake timeouts, lazy Bluetooth init, CoreBluetooth state restoration. Wire-compatible with Android (service `0x4240`, PID char `0x4241`, WRITER char `0x4242`, `EOD` marker, `[PSM][PID]` framing; iOS pins PSM=0 as it has no L2CAP).
- **`BertyDriverBridges.swift`** — Go wiring: `BertyProximityDriverBridge` (`BertybridgeProximityDriverProtocol`, `protocolName "ble"`, `protocolCode 0x0042`, `defaultAddr "/ble/Qmeeee…"`); pulls the transport via `BertybridgeGetProximityTransport("ble")` and forwards driver callbacks into the Go transport. Also an MDNS-locker bridge and a background-task shim.
- **`BertyProximityManager.swift`** — higher-level BLE + Bonjour/Wi-Fi coordinator (see Known limitations).
- **Supporting infra:** `BertyConfiguration` (constants incl. the interop-critical BLE UUIDs), `BertyQueueManager` (named queues + thread-safe collections), `BertyErrors` (error taxonomy + recovery), `BertyNetworkDriver` (interface/reachability introspection), `ActivityBackgroundState`, and `BertyLogger` updates (typo fix, `Comparable` levels, production log gating).

### iOS — connectivity driver improvements
- Reworked `ConnectivityDriver` to share `BertyBLEDriver`'s `CBCentralManager` when available (else owns one — strong ref, power-alert suppressed), with a thread-safe handler list, background-safe Go callbacks, fresh Bluetooth-state reads, and an iOS<12 reachability fallback. Applied to both `js/ios` and `berty-bridge-expo` (expo owns its own manager, since it has no BLE driver).

### Android — BLE reliability hardening
- Real timeouts replacing unbounded/mis-unit waits (notably a `GattServer` write that effectively waited ~2.78h due to a SECONDS/MS unit bug; several unbounded `await()` calls now bounded and tear down stale connections).
- Concurrency hardening (`volatile` + dedicated locks in `BleInterface`, `AtomicLong` in `BleQueue`, `ConcurrentHashMap` in `Scanner`), stoppable L2CAP accept/read threads with bounded `join()` + socket-leak fixes, null-safety guards, and a 64KB inbound-buffer cap (OOM protection).

## Wire compatibility
BLE service/characteristic UUIDs, the `EOD` marker, and `[PSM][PID]` framing match the Android driver so iOS↔Android proximity works. `protocolCode 0x0042` / `protocolName "ble"` / `defaultAddr` must stay in sync with the Go and Android sides.

## Known limitations / open questions for reviewers
- **Logging is gated to ≥WARN unless `initializeDebugMode(true)` is called at startup**, which isn't wired in yet (affects both the new iOS and Android loggers) — INFO/DEBUG is currently suppressed in all builds. Needs a startup call.
- **`BertyBLEDriver` reads some mutable dictionaries off its serial `bleQueue` without locking** in a few public methods — potential data races to tighten.
- **`BertyProximityManager` and `BertyNetworkDriver` appear auxiliary** — not on the live Go transport path; the proximity manager's multicast connect/send paths and the net driver's `updateAddr` are stubs. Confirm whether to wire them in or trim.
- BLE initiator tie-break uses a 4-char PID-suffix comparison (collision-prone at scale).
- Android: operations now return `false`/`disconnect()` on timeout (a slow-but-alive peer >30s gets torn down); the 64KB single-accumulation cap silently drops larger windows.

