### PR TITLE
fix(ci): resolve bertymessenger test data race and Android release disk exhaustion

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -27,6 +27,18 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Free disk space
+        if: inputs.app-json-artifact != ''
+        run: |
+          echo "Disk space before cleanup:"
+          df -h /
+          # Remove large preinstalled toolchains unused by the Android build.
+          # Keep /usr/local/lib/android (SDK/NDK) — the build needs it.
+          sudo rm -rf /usr/share/dotnet /opt/ghc /usr/local/.ghcup /usr/local/share/boost /usr/share/swift
+          sudo docker image prune --all --force || true
+          echo "Disk space after cleanup:"
+          df -h /
+
       - name: Download patched app.json
         if: inputs.app-json-artifact != ''
         uses: actions/download-artifact@v4

--- a/go/pkg/bertymessenger/service_test.go
+++ b/go/pkg/bertymessenger/service_test.go
@@ -1372,10 +1372,10 @@ func TestAccountUpdate(t *testing.T) {
 	time.Sleep(4 * time.Second)
 
 	user := nodes[0]
-	userPK := user.account.GetPublicKey()
+	userPK := user.GetAccount().GetPublicKey()
 	friends := nodes[1:]
 	for _, friend := range friends {
-		_, err := user.client.ContactRequest(ctx, &messengertypes.ContactRequest_Request{Link: friend.account.GetLink()})
+		_, err := user.client.ContactRequest(ctx, &messengertypes.ContactRequest_Request{Link: friend.GetAccount().GetLink()})
 		require.NoError(t, err)
 		time.Sleep(1 * time.Second)
 		_, err = friend.client.ContactAccept(ctx, &messengertypes.ContactAccept_Request{PublicKey: userPK})
@@ -1399,7 +1399,7 @@ func TestAccountUpdate(t *testing.T) {
 
 	logger.Info("checking friends")
 	for _, friend := range friends {
-		logger.Info("checking node", zap.String("name", friend.account.GetDisplayName()))
+		logger.Info("checking node", zap.String("name", friend.GetAccount().GetDisplayName()))
 		userInFriend := friend.GetContact(t, userPK)
 		require.Equal(t, testName, userInFriend.GetDisplayName())
 	}
@@ -1469,9 +1469,8 @@ func TestFlappyAccountUpdateGroup(t *testing.T) {
 
 	logger.Info("checking friends")
 	for _, friend := range friends {
-		logger.Info("checking node", zap.String("name", friend.account.GetDisplayName()))
-		userInFriend, ok := friend.members[conv.GetAccountMemberPublicKey()]
-		require.True(t, ok)
+		logger.Info("checking node", zap.String("name", friend.GetAccount().GetDisplayName()))
+		userInFriend := friend.GetMember(t, conv.GetAccountMemberPublicKey())
 		require.Equal(t, testName, userInFriend.GetDisplayName())
 	}
 

--- a/go/pkg/bertymessenger/service_test.go
+++ b/go/pkg/bertymessenger/service_test.go
@@ -1506,7 +1506,7 @@ func TestSendBlob(t *testing.T) {
 
 	inte := (*messengertypes.Interaction)(nil)
 
-	for _, i := range friend.interactions {
+	for _, i := range friend.GetAllInteractions() {
 		if i.GetType() == messengertypes.AppMessage_TypeUserMessage {
 			inte = i
 			break
@@ -1543,7 +1543,7 @@ func TestSendMedia(t *testing.T) {
 
 	inte := (*messengertypes.Interaction)(nil)
 
-	for _, i := range friend.interactions {
+	for _, i := range friend.GetAllInteractions() {
 		if i.GetType() == messengertypes.AppMessage_TypeUserMessage {
 			inte = i
 			break

--- a/go/pkg/bertymessenger/testing.go
+++ b/go/pkg/bertymessenger/testing.go
@@ -509,6 +509,16 @@ func (a *TestingAccount) GetAllConversations() map[string]*messengertypes.Conver
 	return newMap
 }
 
+func (a *TestingAccount) GetAllInteractions() map[string]*messengertypes.Interaction {
+	a.processMutex.Lock()
+	defer a.processMutex.Unlock()
+	newMap := make(map[string]*messengertypes.Interaction)
+	for k, v := range a.interactions {
+		newMap[k] = v
+	}
+	return newMap
+}
+
 func (a *TestingAccount) TryNextEvent(t testing.TB, timeout time.Duration) *messengertypes.StreamEvent {
 	t.Helper()
 	a.openStream(t)


### PR DESCRIPTION
## Summary

Fixes two unrelated CI failures observed on `master`.

### 1. `test(bertymessenger)`: data race in account update tests

The `Stable tests (macOS)` job failed under the `-race` flag (passes without it). `TestAccountUpdate` and `TestFlappyAccountUpdateGroup` read the `TestingAccount.account`/`members` fields directly while the background goroutine spawned by `ProcessWholeStream` writes them under `processMutex`, causing a detected data race.

Fix: route those reads through the existing mutex-protected `GetAccount()` / `GetMember()` accessors.

Verified locally with the race detector:
- `TestAccountUpdate` — 5/5 PASS, no data race
- `TestFlappyAccountUpdateGroup` (`TEST_STABILITY=flappy`) — 3/3 PASS, no data race

### 2. `ci(android)`: free runner disk space before the release AAB build

The release (master) Android build runs a full multi-ABI `eas build --local` that compiles all native C++ modules (`react-native-worklets`, `expo-modules-core`) for x86, x86_64, armeabi-v7a and arm64-v8a. This exhausts the ~14 GB `ubuntu-latest` disk, failing with `No space left on device` during the clang link step (surfacing as `Bus error (core dumped)`).

PR builds only run a single-ABI compile check, so they never hit this — which is why it failed on `master` but not in PRs.

Fix: free unused preinstalled toolchains (.NET, GHC, Boost, Swift) and prune Docker images before the build, gated to the real-build path. The Android SDK/NDK are kept intact.