### PR TITLE
fix(bridge-expo): derive iOS App Group per build variant

### DIFF
--- a/berty-bridge-expo/mobile/app.config.ts
+++ b/berty-bridge-expo/mobile/app.config.ts
@@ -77,7 +77,7 @@ export default ({ config }: ConfigContext): ExpoConfig => {
 									bundleIdentifier: `${bundleIdentifier}.NotificationService`,
 									entitlements: {
 										"com.apple.security.application-groups": [
-											"group.tech.berty",
+											getAppGroupID(bundleIdentifier),
 										],
 										"com.apple.developer.associated-domains": [
 											"applinks:berty.tech",
@@ -137,6 +137,20 @@ export default ({ config }: ConfigContext): ExpoConfig => {
 		},
 		owner: "bertytechnologies",
 	};
+};
+
+// Derive the iOS App Group container id from the build variant so that
+// side-by-side installs don't share storage. Must stay in sync with the
+// bridge plugin's getAppGroupID (berty-bridge-expo/plugin/src/appGroup.ts).
+const APP_GROUP_PREFIX = "group.tech.berty";
+export const getAppGroupID = (id?: string): string => {
+	if (!id || id === BUNDLE_IDENTIFIER) {
+		return APP_GROUP_PREFIX;
+	}
+	if (id.startsWith(`${BUNDLE_IDENTIFIER}.`)) {
+		return `${APP_GROUP_PREFIX}${id.slice(BUNDLE_IDENTIFIER.length)}`;
+	}
+	return `${APP_GROUP_PREFIX}.${id}`;
 };
 
 // Dynamically configure the app based on the environment.

--- a/berty-bridge-expo/plugin/src/appGroup.ts
+++ b/berty-bridge-expo/plugin/src/appGroup.ts
@@ -1,0 +1,28 @@
+// The App Group container is where the Go bridge stores its "shared" root
+// directory on iOS (see RootDir.swift). Every build variant that is installed
+// side-by-side on a device MUST use its own container, otherwise a debug build
+// sees the production account list but not its data (ErrBertyAccountDataNotFound)
+// because the app-private "Documents" root is not shared while the App Group is.
+//
+// This mirrors the historical native scheme (group.tech.berty for release,
+// group.tech.berty.dev for debug, ...) by deriving the suffix from the bundle
+// identifier variant (tech.berty.ios, tech.berty.ios.debug, tech.berty.ios.staff).
+
+export const APP_GROUP_PREFIX = "group.tech.berty";
+export const PRODUCTION_BUNDLE_IDENTIFIER = "tech.berty.ios";
+
+export const getAppGroupID = (bundleIdentifier?: string): string => {
+	if (!bundleIdentifier || bundleIdentifier === PRODUCTION_BUNDLE_IDENTIFIER) {
+		return APP_GROUP_PREFIX;
+	}
+
+	// Variant bundle ids extend the production one (e.g. "tech.berty.ios.debug"),
+	// so reuse that ".debug"/".staff" suffix to keep the container name readable.
+	if (bundleIdentifier.startsWith(`${PRODUCTION_BUNDLE_IDENTIFIER}.`)) {
+		const suffix = bundleIdentifier.slice(PRODUCTION_BUNDLE_IDENTIFIER.length);
+		return `${APP_GROUP_PREFIX}${suffix}`;
+	}
+
+	// Fallback for unexpected bundle ids: keep uniqueness by appending the whole id.
+	return `${APP_GROUP_PREFIX}.${bundleIdentifier}`;
+};

--- a/berty-bridge-expo/plugin/src/withIosEntitlements.ts
+++ b/berty-bridge-expo/plugin/src/withIosEntitlements.ts
@@ -1,5 +1,7 @@
 import { ConfigPlugin, withEntitlementsPlist } from "@expo/config-plugins";
 
+import { getAppGroupID } from "./appGroup";
+
 const withIosEntitlements: ConfigPlugin = (config) => {
 	return withEntitlementsPlist(config, (config) => {
 		if (config.ios?.bundleIdentifier === "tech.berty.ios") {
@@ -12,7 +14,7 @@ const withIosEntitlements: ConfigPlugin = (config) => {
 			"applinks:berty.tech",
 		];
 		config.modResults["com.apple.security.application-groups"] = [
-			"group.tech.berty",
+			getAppGroupID(config.ios?.bundleIdentifier),
 		];
 		config.modResults["keychain-access-groups"] = [
 			"$(AppIdentifierPrefix)tech.berty.ios",

--- a/berty-bridge-expo/plugin/src/withIosPlist.ts
+++ b/berty-bridge-expo/plugin/src/withIosPlist.ts
@@ -1,5 +1,7 @@
 import { ConfigPlugin, withInfoPlist } from "@expo/config-plugins";
 
+import { getAppGroupID } from "./appGroup";
+
 const withIosPlist: ConfigPlugin = (config) => {
 	return withInfoPlist(config, (config) => {
 		if (!config.ios) {
@@ -9,7 +11,9 @@ const withIosPlist: ConfigPlugin = (config) => {
 			config.ios.infoPlist = {};
 		}
 
-		config.ios.infoPlist["appGroupID"] = "group.tech.berty";
+		config.ios.infoPlist["appGroupID"] = getAppGroupID(
+			config.ios?.bundleIdentifier
+		);
 
 		// background
 

--- a/berty-bridge-expo/plugin/src/withIosPush.ts
+++ b/berty-bridge-expo/plugin/src/withIosPush.ts
@@ -7,6 +7,8 @@ import * as fs from "fs";
 import * as path from "path";
 import { execSync } from "child_process";
 
+import { APP_GROUP_PREFIX, getAppGroupID } from "./appGroup";
+
 const TARGET_NAME = "NotificationService";
 const SOURCE_FILES = [
 	"Common.swift",
@@ -94,6 +96,25 @@ const withCopyFiles: ConfigPlugin = (config) => {
 					`${iosPath}/${TARGET_NAME}/${FRAMEWORKS[i]}`,
 					{ recursive: true }
 				);
+			}
+
+			// The NotificationService copies default (production) files that hardcode
+			// the production App Group. Rewrite them so the extension shares the same
+			// per-variant container as the main app, otherwise push decryption and the
+			// keychain-backed keystore read from the wrong (production) group.
+			const appGroupID = getAppGroupID(config.ios?.bundleIdentifier);
+			if (appGroupID !== APP_GROUP_PREFIX) {
+				for (const file of [ENTITLEMENTS_FILE, ...EXT_FILES]) {
+					const targetFile = `${iosPath}/${TARGET_NAME}/${file}`;
+					const contents = fs.readFileSync(targetFile, "utf8");
+					fs.writeFileSync(
+						targetFile,
+						contents.replaceAll(
+							`<string>${APP_GROUP_PREFIX}</string>`,
+							`<string>${appGroupID}</string>`
+						)
+					);
+				}
 			}
 
 			return config;


### PR DESCRIPTION
## Problem

The iOS App Group was hardcoded to `group.tech.berty` for **every** build variant.

The Go bridge keeps two roots on iOS: `appRootDir` = the app-sandbox `Documents/berty` (per-install), and `sharedRootDir` = the iOS **App Group** container (shared by group id). `ListAccounts`/account selection read `sharedRootDir`, but the open-time existence check (`accountExists`) reads `appRootDir`.

When two variants are installed side-by-side (e.g. production `tech.berty.ios` and debug `tech.berty.ios.debug`), they shared the App Group container. The debug build then saw production's account list via `ListAccounts` but not its data via the existence check, failing with:

```
ErrBertyAccountOpenAccount(#5006): ErrBertyAccountDataNotFound(#5007)
```

and hanging on the opening loader.

## Fix

Derive the App Group from the bundle-identifier variant instead of hardcoding it:

| Bundle identifier | App Group |
|---|---|
| `tech.berty.ios` (production) | `group.tech.berty` |
| `tech.berty.ios.debug` (development) | `group.tech.berty.debug` |
| `tech.berty.ios.staff` (preview) | `group.tech.berty.staff` |

- New `plugin/src/appGroup.ts` — `getAppGroupID(bundleIdentifier)` helper.
- Wired into `withIosEntitlements.ts` (app-groups entitlement) and `withIosPlist.ts` (`appGroupID` Info.plist key — also used as the keychain access group for the keystore).
- `withIosPush.ts` rewrites the copied NotificationService `ProdNS.entitlements` + `NotificationService-Info.plist` for non-prod variants so the extension shares the **same** per-variant container (needed for push decryption and the keychain-backed keystore).
- `mobile/app.config.ts` derives the NSE App Group the same way for EAS builds (small inline copy of the helper — Expo evaluates `app.config.ts` in isolation via sucrase and can't reliably import the plugin's `.ts` source or its gitignored `build/` output).

This mirrors the original app's historical scheme (`group.tech.berty.dev` / `group.tech.berty.entreprise`).

Android is unaffected (per-package `getNoBackupFilesDir`, no App Groups; variant packages already differ).

## Tested

Tested on iOS with two different app variants. They didn't share their DB anymore.