### PR TITLE
fix(bridge-expo/api): exclude @types/node from tsc build to unblock Release CI

### DIFF
--- a/berty-bridge-expo/mobile/src/api/tsconfig.json
+++ b/berty-bridge-expo/mobile/src/api/tsconfig.json
@@ -11,6 +11,7 @@
     "allowJs": true,
     "isolatedModules": true,
     "moduleResolution": "node",
+    "types": [],
   },
   "files": [
     "index.js",


### PR DESCRIPTION
## Problem

The **Release** workflow on `master` is failing at the `post-semantic-release` job's *Publish npm package: @berty/api (DryRun)* step:

```
node_modules/@types/node/ffi.d.ts(94,21): error TS1139: Type parameter declaration expected.
...
npm error command sh -c tsc && cp ./*.d.ts ./dist
panic: run npm install: exit status 2
```

## Root cause

`@berty/api`'s `prepublish` runs `tsc`, which auto-includes the transitive `@types/node` (pulled in by `protobufjs@6`). That dependency floats and bumped to **v26.1.0**, whose `ffi.d.ts` uses TypeScript syntax the pinned **TS 4.6** cannot parse.

`skipLibCheck` (already set) doesn't help — it suppresses type-*checking* of `.d.ts` files, not *parsing* them, and these are parse (`TS1xxx`) errors.

## Fix

Add `"types": []` to `berty-bridge-expo/mobile/src/api/tsconfig.json` so tsc no longer loads `@types/node`'s global declarations. This protobuf-only package doesn't need them.

## Verification

Reproduced the exact CI failure locally with a fresh `@types/node@26.1.0` install, applied the fix, and confirmed `npm run prepublish` now exits 0 and produces identical `dist/` output (`index.d.ts`, `index.js`, `root.pb.d.ts`, `root.pb.js`).