### PR TITLE
fix(bledriver): guard against short strings in idFromPid

### DIFF
--- a/berty-bridge-expo/android/src/main/java/tech/berty/bertybridgeexpo/gobridge/bledriver/BleDriver.java
+++ b/berty-bridge-expo/android/src/main/java/tech/berty/bertybridgeexpo/gobridge/bledriver/BleDriver.java
@@ -353,7 +353,13 @@ public class BleDriver {
     }
 
     public static String idFromPid(String pid) {
+        if (pid == null) {
+            return "";
+        }
         int pidLen = pid.length();
+        if (pidLen < 4) {
+            return pid;
+        }
         return pid.substring(pidLen - 4, pidLen);
     }
 


### PR DESCRIPTION
Small defensive check in `idFromPid` to avoid an index out of bounds exception if `pid` is null or shorter than 4 chars.
